### PR TITLE
Restore overlapped memory fetch with safe cancellation

### DIFF
--- a/llm/context_manager.py
+++ b/llm/context_manager.py
@@ -58,14 +58,23 @@ class ContextManager:
                 )
                 return None
 
-        # 1) Fetch short-term messages AND episodic context in parallel to minimize latency
+        episodic_task = (
+            asyncio.create_task(_fetch_episodic()) if self.episodic_provider is not None else None
+        )
+
         try:
-            short_term_msgs, episodic_str = await asyncio.gather(
-                _fetch_short_term(),
-                _fetch_episodic(),
-            )
+            short_term_msgs = await _fetch_short_term()
         except Exception as e:
-            # Report and return safe fallback per design
+            if episodic_task:
+                episodic_task.cancel()
+                try:
+                    await episodic_task
+                except asyncio.CancelledError:
+                    pass
+                except Exception:
+                    # best-effort cancellation; errors already reported downstream
+                    pass
+
             asyncio.create_task(
                 func.report_error(e, "ContextManager.get_context: short_term_provider.get failed")
             )
@@ -82,9 +91,23 @@ class ContextManager:
             _LOGGER.error("extract_user_ids failed", exception=e)
             user_ids = []
 
-        # 3) Fetch procedural memory
+        procedural_task = asyncio.create_task(self.procedural_provider.get(user_ids))
+        episodic_str: Optional[str] = None
+
+        if episodic_task:
+            try:
+                episodic_str = await episodic_task
+            except asyncio.CancelledError:
+                episodic_str = None
+            except Exception as e:
+                asyncio.create_task(
+                    func.report_error(e, "ContextManager.get_context: episodic_provider.get failed")
+                )
+                _LOGGER.error("episodic_provider.get failed", exception=e)
+                episodic_str = None
+
         try:
-            procedural_memory = await self.procedural_provider.get(user_ids)
+            procedural_memory = await procedural_task
         except Exception as e:
             asyncio.create_task(
                 func.report_error(e, "ContextManager.get_context: procedural_provider.get failed")

--- a/llm/context_manager.py
+++ b/llm/context_manager.py
@@ -44,9 +44,26 @@ class ContextManager:
         The short_term_msgs are returned in oldest->newest order as produced by
         ShortTermMemoryProvider.
         """
-        # 1) Fetch short-term messages
+        async def _fetch_short_term() -> List[BaseMessage]:
+            return await self.short_term_provider.get(message)
+
+        async def _fetch_episodic() -> Optional[str]:
+            if self.episodic_provider is None:
+                return None
+            try:
+                return await self.episodic_provider.get(message)
+            except Exception as e:
+                asyncio.create_task(
+                    func.report_error(e, "ContextManager.get_context: episodic_provider.get failed")
+                )
+                return None
+
+        # 1) Fetch short-term messages AND episodic context in parallel to minimize latency
         try:
-            short_term_msgs = await self.short_term_provider.get(message)
+            short_term_msgs, episodic_str = await asyncio.gather(
+                _fetch_short_term(),
+                _fetch_episodic(),
+            )
         except Exception as e:
             # Report and return safe fallback per design
             asyncio.create_task(
@@ -65,32 +82,15 @@ class ContextManager:
             _LOGGER.error("extract_user_ids failed", exception=e)
             user_ids = []
 
-        # 3) Fetch procedural memory AND episodic context in parallel to minimize latency
-        async def _fetch_procedural() -> ProceduralMemory:
-            try:
-                return await self.procedural_provider.get(user_ids)
-            except Exception as e:
-                asyncio.create_task(
-                    func.report_error(e, "ContextManager.get_context: procedural_provider.get failed")
-                )
-                _LOGGER.error("procedural_provider.get failed", exception=e)
-                return ProceduralMemory(user_info={})
-
-        async def _fetch_episodic() -> Optional[str]:
-            if self.episodic_provider is None:
-                return None
-            try:
-                return await self.episodic_provider.get(message)
-            except Exception as e:
-                asyncio.create_task(
-                    func.report_error(e, "ContextManager.get_context: episodic_provider.get failed")
-                )
-                return None
-
-        procedural_memory, episodic_str = await asyncio.gather(
-            _fetch_procedural(),
-            _fetch_episodic(),
-        )
+        # 3) Fetch procedural memory
+        try:
+            procedural_memory = await self.procedural_provider.get(user_ids)
+        except Exception as e:
+            asyncio.create_task(
+                func.report_error(e, "ContextManager.get_context: procedural_provider.get failed")
+            )
+            _LOGGER.error("procedural_provider.get failed", exception=e)
+            procedural_memory = ProceduralMemory(user_info={})
 
         # 4) Format procedural memory into string (no STM serialization here)
         try:


### PR DESCRIPTION
`ContextManager.get_context` lost overlap between episodic and procedural fetches, increasing latency when procedural was slower, and episodic work could continue after short-term failures.

- **Concurrency**: Launch episodic fetch as a background task, await short-term first for `user_ids`, then await procedural and episodic in parallel to regain overlap.
- **Cancellation & resilience**: Cancel and await the episodic task on short-term failure; retain error reporting for episodic/procedural tasks without leaking work.

Example:
```python
episodic_task = asyncio.create_task(_fetch_episodic())
short_term = await _fetch_short_term()  # fail-fast, cancels episodic if needed
procedural_task = asyncio.create_task(self.procedural_provider.get(user_ids))
episodic = await episodic_task
procedural = await procedural_task
```