### PR TITLE
Make admin slash-command responses ephemeral

### DIFF
--- a/cogs/channel_manager.py
+++ b/cogs/channel_manager.py
@@ -127,7 +127,7 @@ class ChannelManager(commands.Cog):
         else:
             response = f"已將 **整個伺服器** 的回應模式設定為：{mode.name}"
 
-        await interaction.response.send_message(response)
+        await interaction.response.send_message(response, ephemeral=True)
 
     @app_commands.command(name="set_channel_mode", description="為特定頻道設定特殊模式 (例如：故事模式)")
     @app_commands.describe(channel="要設定的頻道", mode="要為此頻道設定的模式")
@@ -155,7 +155,7 @@ class ChannelManager(commands.Cog):
             message = f"已將頻道 {channel.mention} 的模式設定為：**{mode.name}**。"
 
         self.save_config(guild_id, config)
-        await interaction.response.send_message(message)
+        await interaction.response.send_message(message, ephemeral=True)
 
     @app_commands.command(name="add_channel", description="新增頻道到白名單或黑名單")
     @app_commands.choices(list_type=[
@@ -200,7 +200,7 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"已將頻道 <#{channel_id}> 新增到 {list_type_name}"
             
-            await interaction.response.send_message(success_message)
+            await interaction.response.send_message(success_message, ephemeral=True)
         else:
             if self.lang_manager:
                 exists_message = self.lang_manager.translate(
@@ -215,7 +215,7 @@ class ChannelManager(commands.Cog):
             else:
                 exists_message = f"頻道 <#{channel_id}> 已存在於 {list_type_name}"
             
-            await interaction.response.send_message(exists_message)
+            await interaction.response.send_message(exists_message, ephemeral=True)
 
     @app_commands.command(name="remove_channel", description="移除頻道從白名單或黑名單")
     @app_commands.choices(list_type=[
@@ -260,7 +260,7 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"已將頻道 <#{channel_id}> 移除從 {list_type_name}"
             
-            await interaction.response.send_message(success_message)
+            await interaction.response.send_message(success_message, ephemeral=True)
         else:
             if self.lang_manager:
                 not_found_message = self.lang_manager.translate(
@@ -275,7 +275,7 @@ class ChannelManager(commands.Cog):
             else:
                 not_found_message = f"頻道 <#{channel_id}> 不存在於 {list_type_name}"
             
-            await interaction.response.send_message(not_found_message)
+            await interaction.response.send_message(not_found_message, ephemeral=True)
 
     @app_commands.command(name="auto_response", description="設定頻道自動回覆")
     async def auto_response_command(self, interaction: discord.Interaction, channel: discord.TextChannel, enabled: bool):
@@ -304,7 +304,7 @@ class ChannelManager(commands.Cog):
             # 備用訊息
             success_message = f"已將頻道 <#{channel_id}> 自動回覆設定為：{enabled}"
         
-        await interaction.response.send_message(success_message)
+        await interaction.response.send_message(success_message, ephemeral=True)
 
     def is_allowed_channel(self, channel: discord.TextChannel, guild_id: str) -> Tuple[bool, bool, Optional[str]]:
         """

--- a/cogs/language_manager.py
+++ b/cogs/language_manager.py
@@ -392,25 +392,28 @@ class LanguageManager(commands.Cog):
                 "errors",
                 "permission_denied"
             )
-            await interaction.response.send_message(error_message)
+            await interaction.response.send_message(error_message, ephemeral=True)
             return
         
         guild_id = str(interaction.guild_id)
         
         if language not in self.supported_languages:
             await interaction.response.send_message(
-                self.translate(guild_id, "commands", "set_language", "responses", "unsupported")
+                self.translate(guild_id, "commands", "set_language", "responses", "unsupported"),
+                ephemeral=True
             )
             return
 
         if self.save_server_lang(guild_id, language):
             lang_name = self.supported_languages[language]
             await interaction.response.send_message(
-                self.translate(guild_id, "commands", "set_language", "responses", "success", language=lang_name)
+                self.translate(guild_id, "commands", "set_language", "responses", "success", language=lang_name),
+                ephemeral=True
             )
         else:
             await interaction.response.send_message(
-                self.translate(guild_id, "commands", "set_language", "responses", "error")
+                self.translate(guild_id, "commands", "set_language", "responses", "error"),
+                ephemeral=True
             )
 
     @app_commands.command(
@@ -431,7 +434,8 @@ class LanguageManager(commands.Cog):
                 "responses",
                 "current",
                 language=lang_name
-            )
+            ),
+            ephemeral=True
         )
 
     @staticmethod


### PR DESCRIPTION
Several configuration/admin slash commands were replying publicly, cluttering channels with permission errors and config confirmations.

- **ChannelManager**: Added `ephemeral=True` to server/channel mode, allow/deny list, and auto-response confirmation/error replies so only the invoker sees them.
- **LanguageManager**: Made language set/view success and permission/error responses ephemeral to keep admin chatter out of public channels.

Example:
```python
await interaction.response.send_message(success_message, ephemeral=True)
```