### PR TITLE
Fix UTC-safe timestamps in context and short-term memory

### DIFF
--- a/llm/context_manager.py
+++ b/llm/context_manager.py
@@ -102,15 +102,20 @@ class ContextManager:
         try:
             if getattr(message, "created_at", None) is not None:
                 timestamp = message.created_at.timestamp()
+                human_time = message.created_at.strftime('%Y-%m-%d %H:%M:%S UTC')
             else:
-                timestamp = datetime.utcnow().timestamp()
+                now = datetime.utcnow()
+                timestamp = now.timestamp()
+                human_time = now.strftime('%Y-%m-%d %H:%M:%S UTC')
         except Exception:
-            timestamp = datetime.utcnow().timestamp()
+            now = datetime.utcnow()
+            timestamp = now.timestamp()
+            human_time = now.strftime('%Y-%m-%d %H:%M:%S UTC')
 
         procedural_str = ""
         try:
             procedural_str = self._format_context_for_prompt(
-                procedural_memory, channel_name, timestamp, episodic_str=episodic_str
+                procedural_memory, channel_name, timestamp, episodic_str=episodic_str, human_time=human_time
             )
         except Exception as e:
             asyncio.create_task(
@@ -165,6 +170,7 @@ class ContextManager:
         channel_name: str,
         timestamp: float,
         episodic_str: Optional[str] = None,
+        human_time: Optional[str] = None,
     ) -> str:
         """Format procedural memory and current state into a single string.
  
@@ -191,7 +197,11 @@ class ContextManager:
             _LOGGER.error("Formatting procedural memory failed", exception=e)
 
         try:
-            parts.append(f"Channel: #{channel_name}\nTimestamp: {timestamp}")
+            # Provide both Unix timestamp and human-readable time for better LLM comprehension
+            if human_time:
+                parts.append(f"Channel: #{channel_name}\nTimestamp: {timestamp}\nCurrent Time: {human_time}")
+            else:
+                parts.append(f"Channel: #{channel_name}\nTimestamp: {timestamp}")
         except Exception as e:
             asyncio.create_task(
                 func.report_error(e, "ContextManager._format_context_for_prompt/channel_ts")

--- a/llm/context_manager.py
+++ b/llm/context_manager.py
@@ -8,7 +8,7 @@ This module implements the new ContextManager per docs/llm/context_manager.md:
 import asyncio
 
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, List, Optional, Tuple
 
 import discord
@@ -101,14 +101,19 @@ class ContextManager:
         # Use message.created_at when available; fallback to current UTC timestamp (float seconds)
         try:
             if getattr(message, "created_at", None) is not None:
-                timestamp = message.created_at.timestamp()
-                human_time = message.created_at.strftime('%Y-%m-%d %H:%M:%S UTC')
+                created_at = message.created_at
+                if getattr(created_at, "tzinfo", None) is None:
+                    created_at = created_at.replace(tzinfo=timezone.utc)
+                else:
+                    created_at = created_at.astimezone(timezone.utc)
+                timestamp = created_at.timestamp()
+                human_time = created_at.strftime('%Y-%m-%d %H:%M:%S UTC')
             else:
-                now = datetime.utcnow()
+                now = datetime.now(timezone.utc)
                 timestamp = now.timestamp()
                 human_time = now.strftime('%Y-%m-%d %H:%M:%S UTC')
         except Exception:
-            now = datetime.utcnow()
+            now = datetime.now(timezone.utc)
             timestamp = now.timestamp()
             human_time = now.strftime('%Y-%m-%d %H:%M:%S UTC')
 

--- a/llm/memory/short_term.py
+++ b/llm/memory/short_term.py
@@ -1,5 +1,6 @@
 from typing import List, Any
 import re
+from datetime import datetime
 
 import discord
 from langchain_core.messages import BaseMessage, HumanMessage, AIMessage
@@ -54,7 +55,12 @@ class ShortTermMemoryProvider:
                 # Include reference info if it's a reply
                 if msg.reference:
                     content_suffix.append(f"reply_to: {msg.reference.message_id}")
-                content_suffix.append(f"timestamp: {msg.created_at.timestamp()}")
+
+                # Provide both Unix timestamp and human-readable time
+                ts = msg.created_at.timestamp()
+                human_time = msg.created_at.strftime('%Y-%m-%d %H:%M:%S UTC')
+                content_suffix.append(f"timestamp: {ts} ({human_time})")
+
                 if msg.content:
                     cleaned_content = re.sub(rf'<@!?{self.bot.user.id}>', '', msg.content).strip()
                     content_parts.append({"type": "text", "text": f"[{content_prefix}] <som> {cleaned_content} <eom> [{' | '.join(content_suffix)}]"})

--- a/llm/memory/short_term.py
+++ b/llm/memory/short_term.py
@@ -1,6 +1,5 @@
 from typing import List, Any
 import re
-from datetime import datetime
 
 import discord
 from langchain_core.messages import BaseMessage, HumanMessage, AIMessage


### PR DESCRIPTION
LLM context was emitting naive timestamps labeled as UTC, risking incorrect temporal grounding on non-UTC hosts.

- Context manager: normalize `message.created_at` to UTC (attach tzinfo or convert) and use timezone-aware fallback via `datetime.now(timezone.utc)` before formatting both Unix and human-readable times.
- Short-term memory: drop unused `datetime` import; message suffix remains unchanged.

Example:
```python
# before: naive datetime could be treated as local time
created_at = message.created_at  # tzinfo may be None
timestamp = created_at.timestamp()

# after: enforce UTC awareness
created_at = (created_at.replace(tzinfo=timezone.utc)
              if created_at.tzinfo is None else created_at.astimezone(timezone.utc))
timestamp = created_at.timestamp()
human_time = created_at.strftime("%Y-%m-%d %H:%M:%S UTC")
```