### PR TITLE
Harden user-memory clearing and align translations/docs

### DIFF
--- a/cogs/memory/db/procedural_storage.py
+++ b/cogs/memory/db/procedural_storage.py
@@ -154,6 +154,20 @@ class ProceduralStorage:
             await func.report_error(e, f"update_user_data failed (user: {discord_id})")
             return False
 
+    async def delete_user_data(self, discord_id: str) -> bool:
+        try:
+            with self.db.get_connection() as conn:
+                cursor = conn.execute("DELETE FROM users WHERE discord_id = ?", (discord_id,))
+                conn.commit()
+                deleted = cursor.rowcount > 0
+
+                if deleted and discord_id in self._user_cache:
+                    del self._user_cache[discord_id]
+                return deleted
+        except Exception as e:
+            await func.report_error(e, f"delete_user_data failed (user: {discord_id})")
+            return False
+
     async def update_user_activity(self, discord_id: str, discord_name: str) -> bool:
         try:
             with self.db.get_connection() as conn:

--- a/cogs/memory/interfaces/storage_interface.py
+++ b/cogs/memory/interfaces/storage_interface.py
@@ -14,6 +14,10 @@ class ProceduralStorageInterface(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    async def delete_user_data(self, discord_id: str) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
     async def update_user_data(
         self,
         discord_id: str,

--- a/cogs/memory/users/manager.py
+++ b/cogs/memory/users/manager.py
@@ -96,6 +96,19 @@ class SQLiteUserManager:
             await func.report_error(e, f"Failed to update user data (user: {user_id})")
             return False
 
+    async def delete_user_data(self, user_id: str) -> bool:
+        """Delegate deletion to storage and invalidate cache."""
+        try:
+            if hasattr(self.storage, "delete_user_data"):
+                success = await getattr(self.storage, "delete_user_data")(user_id)
+                if success and user_id in self._user_cache:
+                    del self._user_cache[user_id]
+                return success
+            return False
+        except Exception as e:
+            await func.report_error(e, f"Failed to delete user data (user: {user_id})")
+            return False
+
     async def update_user_activity(self, user_id: str, display_name: str = "") -> bool:
         """Delegate activity update to storage and invalidate cache."""
         try:

--- a/cogs/memory/users/manager.py
+++ b/cogs/memory/users/manager.py
@@ -99,12 +99,10 @@ class SQLiteUserManager:
     async def delete_user_data(self, user_id: str) -> bool:
         """Delegate deletion to storage and invalidate cache."""
         try:
-            if hasattr(self.storage, "delete_user_data"):
-                success = await getattr(self.storage, "delete_user_data")(user_id)
-                if success and user_id in self._user_cache:
-                    del self._user_cache[user_id]
-                return success
-            return False
+            success = await self.storage.delete_user_data(user_id)
+            if success and user_id in self._user_cache:
+                del self._user_cache[user_id]
+            return success
         except Exception as e:
             await func.report_error(e, f"Failed to delete user data (user: {user_id})")
             return False

--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -62,6 +62,8 @@ FALLBACK_TRANSLATIONS = {
     "data_not_found": "I currently have no specific memory about you.",
     "data_updated": "Got it! I've remembered it!\nMy updated memory:\n{data}",
     "data_created": "Got it! I've remembered it!\nMy new memory:\n{data}",
+    "clear_success": "I have forgotten everything about you.",
+    "clear_failed": "Failed to clear your memory or you had no memory stored.",
     "sqlite_not_available": "Personal memory system not initialized",
     "invalid_action": "Invalid action. Please use 'save' or 'show'.",
     "database_error": "Database operation error: {error}",
@@ -569,6 +571,30 @@ class UserDataCog(commands.Cog):
         await interaction.followup.send(result, ephemeral=True)
 
     @memory_group.command(
+        name="clear",
+        description="Clear all your personal memory"
+    )
+    async def memory_clear(self, interaction: discord.Interaction) -> None:
+        """Handles /memory clear command to clear user preferences.
+
+        Args:
+            interaction: Discord interaction object.
+        """
+        if not self.lang_manager:
+            self.lang_manager = LanguageManager.get_instance(self.bot)
+
+        await interaction.response.defer(thinking=True, ephemeral=True)
+
+        result = await self.manage_user_data(
+            context=interaction,
+            user=interaction.user,
+            user_data='',
+            action='clear'
+        )
+
+        await interaction.followup.send(result, ephemeral=True)
+
+    @memory_group.command(
         name="show",
         description="View everything I currently remember about you"
     )
@@ -630,7 +656,8 @@ class UserDataCog(commands.Cog):
         if message_to_edit:
             status_key_map = {
                 'read': 'searching',
-                'save': 'updating'
+                'save': 'updating',
+                'clear': 'updating'
             }
             message_key = status_key_map.get(action, 'processing')
             
@@ -657,11 +684,72 @@ class UserDataCog(commands.Cog):
                 user_data,
                 context
             )
+        elif action == 'clear':
+            return await self._clear_user_data(user_id, context)
         else:
             return self._translate(
                 guild_id,
                 "commands", "userdata", "responses", "invalid_action",
                 fallback_key="invalid_action"
+            )
+
+    async def _clear_user_data(self, user_id: str, context: Union[discord.Interaction, discord.Message]) -> str:
+        """Core logic for clearing user data.
+
+        Args:
+            user_id: Target user ID to clear data for.
+            context: Discord context for guild ID.
+
+        Returns:
+            Success or error message string.
+        """
+        guild_id = self._get_guild_id_from_context(context)
+
+        try:
+            if not self.user_manager:
+                return self._translate(
+                    guild_id,
+                    "commands", "userdata", "errors", "sqlite_not_available",
+                    fallback_key="sqlite_not_available"
+                )
+
+            success = await self.user_manager.delete_user_data(user_id)
+            if success:
+                # Invalidate ProceduralMemoryProvider cache
+                try:
+                    orchestrator = getattr(self.bot, "orchestrator", None)
+                    if orchestrator:
+                        provider = getattr(
+                            getattr(orchestrator, "context_manager", None),
+                            "procedural_provider",
+                            None,
+                        )
+                        if provider and hasattr(provider, "invalidate"):
+                            await provider.invalidate(str(user_id))
+                except Exception:
+                    pass
+
+                return self._translate(
+                    guild_id,
+                    "commands", "userdata", "responses", "clear_success",
+                    fallback_key="clear_success"
+                )
+            else:
+                return self._translate(
+                    guild_id,
+                    "commands", "userdata", "responses", "clear_failed",
+                    fallback_key="clear_failed"
+                )
+
+        except Exception as e:
+            self.logger.error(f"Failed to clear user data for {user_id}: {e}")
+            await func.report_error(e, f"Clear user data failed (user: {user_id})")
+
+            return self._translate(
+                guild_id,
+                "commands", "userdata", "errors", "database_error",
+                fallback_key="database_error",
+                error=str(e)
             )
 
     async def manage_user_data_message(

--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -65,7 +65,7 @@ FALLBACK_TRANSLATIONS = {
     "clear_success": "I have forgotten everything about you.",
     "clear_failed": "Failed to clear your memory or you had no memory stored.",
     "sqlite_not_available": "Personal memory system not initialized",
-    "invalid_action": "Invalid action. Please use 'save' or 'show'.",
+    "invalid_action": "Invalid action. Please use 'read', 'save', or 'clear'.",
     "database_error": "Database operation error: {error}",
     "ai_processing_failed": "AI processing error for your memory: {error}",
     "update_failed": "Failed to update your memory: {error}",
@@ -632,7 +632,7 @@ class UserDataCog(commands.Cog):
             context: Interaction or message context.
             user: Target user object.
             user_data: Optional data to save (only used for 'save' action).
-            action: Either 'read' or 'save'.
+            action: Either 'read', 'save', or 'clear'.
             message_to_edit: Optional message object to edit during processing.
             
         Returns:
@@ -886,4 +886,3 @@ async def setup(bot: commands.Bot) -> None:
     user_manager = getattr(bot, 'user_manager', None)
     cog = UserDataCog(bot, user_manager=user_manager)
     await bot.add_cog(cog)
-

--- a/llm/tools/user_data.py
+++ b/llm/tools/user_data.py
@@ -193,6 +193,60 @@ class UserMemoryTools:
                 return f"An unexpected error occurred while reading memory: {e}"
 
         @tool
+        async def clear_user_memory(user_id: int) -> str:
+            """Clears all personal memory and preferences stored for a specific user.
+
+            Use this tool when the user **explicitly asks** you to forget everything
+            about them or clear their memory/preferences.
+
+            Args:
+                user_id: The Discord user's ID.
+
+            Returns:
+                A string confirming that the memory was successfully cleared,
+                or an error message if the operation failed.
+            """
+            cog = get_cog()
+            if not cog:
+                return "Error: Personal memory system (UserDataCog) is not loaded."
+
+            try:
+                logger.info("Clearing personal memory", extra={"user_id": user_id})
+
+                effective_id = None
+                try:
+                    effective_id = int(user_id)
+                except Exception:
+                    msg = getattr(runtime, "message", None)
+                    if msg and getattr(msg, "author", None):
+                        logger.warning(
+                            "clear_user_memory: LLM provided invalid user_id; defaulting to message author",
+                            extra={"provided_user_id": user_id, "author_id": getattr(msg.author, "id", None)}
+                        )
+                        effective_id = msg.author.id
+                    else:
+                        logger.warning(
+                            "clear_user_memory: invalid user_id and no message context; using raw value",
+                            extra={"user_id": user_id}
+                        )
+                        effective_id = user_id
+
+                # Using manage_user_data with action 'clear' requires an Interaction or Message context
+                context = cast(
+                    Union[discord.Interaction, discord.Message],
+                    getattr(runtime, "message", None)
+                )
+
+                result_msg = await cog._clear_user_data(str(effective_id), context)
+                return result_msg
+
+            except Exception as e:
+                await func.report_error(
+                    e, f"Failed to clear personal memory for user_id={user_id}"
+                )
+                return f"An unexpected error occurred while clearing memory: {e}"
+
+        @tool
         async def save_user_memory(user_id: int, memory_to_save: str) -> str:
             """Saves or updates a personal memory or preference for a specific user.
     
@@ -319,4 +373,4 @@ class UserMemoryTools:
                 )
                 return f"An unexpected error occurred while saving memory: {e}"
 
-        return [read_user_memory, save_user_memory]
+        return [read_user_memory, save_user_memory, clear_user_memory]

--- a/llm/tools/user_data.py
+++ b/llm/tools/user_data.py
@@ -211,31 +211,40 @@ class UserMemoryTools:
                 return "Error: Personal memory system (UserDataCog) is not loaded."
 
             try:
-                logger.info("Clearing personal memory", extra={"user_id": user_id})
+                logger.info("Clearing personal memory", extra={"requested_user_id": user_id})
 
-                effective_id = None
-                try:
-                    effective_id = int(user_id)
-                except Exception:
-                    msg = getattr(runtime, "message", None)
-                    if msg and getattr(msg, "author", None):
-                        logger.warning(
-                            "clear_user_memory: LLM provided invalid user_id; defaulting to message author",
-                            extra={"provided_user_id": user_id, "author_id": getattr(msg.author, "id", None)}
-                        )
-                        effective_id = msg.author.id
-                    else:
-                        logger.warning(
-                            "clear_user_memory: invalid user_id and no message context; using raw value",
-                            extra={"user_id": user_id}
-                        )
-                        effective_id = user_id
-
-                # Using manage_user_data with action 'clear' requires an Interaction or Message context
+                # Always clear for the requesting user when context is available.
                 context = cast(
-                    Union[discord.Interaction, discord.Message],
-                    getattr(runtime, "message", None)
+                    Optional[Union[discord.Interaction, discord.Message]],
+                    getattr(runtime, "message", None) or getattr(runtime, "interaction", None)
                 )
+                requester_id = None
+
+                if isinstance(context, discord.Message) and getattr(context, "author", None):
+                    requester_id = getattr(context.author, "id", None)
+                elif isinstance(context, discord.Interaction) and getattr(context, "user", None):
+                    requester_id = getattr(context.user, "id", None)
+
+                if requester_id:
+                    if str(requester_id) != str(user_id):
+                        logger.warning(
+                            "clear_user_memory: overriding provided user_id with requesting user",
+                            extra={"provided_user_id": user_id, "requester_id": requester_id}
+                        )
+                    effective_id = requester_id
+                else:
+                    try:
+                        effective_id = int(user_id)
+                    except Exception:
+                        logger.error(
+                            "clear_user_memory: unable to determine requesting user",
+                            extra={"provided_user_id": user_id}
+                        )
+                        return "Error: Unable to identify the requesting user to clear memory."
+
+                if not context:
+                    logger.error("clear_user_memory: no interaction or message context available")
+                    return "Error: Cannot clear memory without a message or interaction context."
 
                 result_msg = await cog._clear_user_data(str(effective_id), context)
                 return result_msg

--- a/translations/en_US/commands/userdata.json
+++ b/translations/en_US/commands/userdata.json
@@ -3,13 +3,14 @@
         "name": "userdata",
         "description": "Manage user data",
         "options": {
-            "action": "Choose action (read/save)",
+            "action": "Choose action (read/save/clear)",
             "user": "Target user",
             "user_data": "User data to save"
         },
         "choices": {
             "read": "Read",
-            "save": "Save"
+            "save": "Save",
+            "clear": "Clear"
         },
         "responses": {
             "searching": "Searching user data...",
@@ -18,7 +19,9 @@
             "data_not_found": "User <@{user_id}> data not found.",
             "data_updated": "Updated user <@{user_id}> data: {data}",
             "data_created": "Created data for user <@{user_id}>: {data}",
-            "invalid_action": "Invalid action. Please use 'read' or 'save'.",
+            "clear_success": "Cleared personal data for <@{user_id}>.",
+            "clear_failed": "Failed to clear data for <@{user_id}> or no data existed.",
+            "invalid_action": "Invalid action. Please use 'read', 'save', or 'clear'.",
             "no_data_provided": "You didn't tell me what to remember."
         },
         "errors": {

--- a/translations/ja_JP/commands/userdata.json
+++ b/translations/ja_JP/commands/userdata.json
@@ -3,13 +3,14 @@
         "name": "userdata",
         "description": "ユーザーデータを管理",
         "options": {
-            "action": "アクションを選択（読み取り/保存）",
+            "action": "アクションを選択（読み取り/保存/クリア）",
             "user": "対象ユーザー",
             "user_data": "保存するユーザーデータ"
         },
         "choices": {
             "read": "読み取り",
-            "save": "保存"
+            "save": "保存",
+            "clear": "クリア"
         },
         "responses": {
             "searching": "ユーザーデータを検索中...",
@@ -18,7 +19,9 @@
             "data_not_found": "ユーザー <@{user_id}> のデータが見つかりません。",
             "data_updated": "ユーザー <@{user_id}> のデータを更新：{data}",
             "data_created": "ユーザー <@{user_id}> のデータを作成：{data}",
-            "invalid_action": "無効なアクション。'読み取り'または'保存'を使用してください。",
+            "clear_success": "ユーザー <@{user_id}> のデータを消去しました。",
+            "clear_failed": "ユーザー <@{user_id}> のデータを消去できませんでした、またはデータがありませんでした。",
+            "invalid_action": "無効なアクションです。「読み取り」「保存」または「クリア」を使用してください。",
             "no_data_provided": "覚える内容を教えてください。"
         },
         "errors": {

--- a/translations/zh_CN/commands/userdata.json
+++ b/translations/zh_CN/commands/userdata.json
@@ -3,13 +3,14 @@
         "name": "userdata",
         "description": "管理用户数据",
         "options": {
-            "action": "选择动作（读取/保存）",
+            "action": "选择动作（读取/保存/清除）",
             "user": "目标用户",
             "user_data": "要保存的用户数据"
         },
         "choices": {
             "read": "读取",
-            "save": "保存"
+            "save": "保存",
+            "clear": "清除"
         },
         "responses": {
             "searching": "查询用户资料中...",
@@ -18,7 +19,9 @@
             "data_not_found": "找不到用户 <@{user_id}> 的资料。",
             "data_updated": "已更新用户 <@{user_id}> 的资料：{data}",
             "data_created": "已为用户 <@{user_id}> 创建资料：{data}",
-            "invalid_action": "无效的操作。请使用 '读取' 或 '保存'。",
+            "clear_success": "已清除用户 <@{user_id}> 的个人资料。",
+            "clear_failed": "清除用户 <@{user_id}> 的资料失败，或没有资料可以清除。",
+            "invalid_action": "无效的操作。请使用“读取”、“保存”或“清除”。",
             "no_data_provided": "你没有告诉我需要记住什么。"
         },
         "errors": {

--- a/translations/zh_TW/commands/userdata.json
+++ b/translations/zh_TW/commands/userdata.json
@@ -3,13 +3,14 @@
         "name": "userdata",
         "description": "管理用戶數據",
         "options": {
-            "action": "選擇動作（讀取/保存）",
+            "action": "選擇動作（讀取/保存/清除）",
             "user": "目標用戶",
             "user_data": "要保存的用戶數據"
         },
         "choices": {
             "read": "讀取",
-            "save": "保存"
+            "save": "保存",
+            "clear": "清除"
         },
         "responses": {
             "searching": "查詢用戶資料中...",
@@ -18,7 +19,9 @@
             "data_not_found": "找不到用戶 <@{user_id}> 的資料。",
             "data_updated": "已更新用戶 <@{user_id}> 的資料：{data}",
             "data_created": "已為用戶 <@{user_id}> 創建資料：{data}",
-            "invalid_action": "無效的操作。請使用 '讀取' 或 '保存'。",
+            "clear_success": "已清除用戶 <@{user_id}> 的個人資料。",
+            "clear_failed": "清除用戶 <@{user_id}> 的資料失敗，或沒有資料可以清除。",
+            "invalid_action": "無效的操作。請使用「讀取」、「保存」或「清除」。",
             "no_data_provided": "你沒有告訴我需要記住什麼。"
         },
         "errors": {


### PR DESCRIPTION
The clear-user-memory feature should exist for privacy, but the tool could clear other users’ data and UI strings/docs/translations were incomplete.

- **Safety**: `clear_user_memory` now derives the target from the requesting message/interaction and aborts if no context is available.
- **Manager API**: Call storage’s `delete_user_data` directly, trusting the interface contract.
- **UX/Docs**: Add `clear` to docstrings and fallback invalid-action messaging.
- **Translations**: Add `clear` action text and `clear_success` / `clear_failed` responses across all locales.

Example:
```python
# Tool now binds to requesting user
context = runtime.message or runtime.interaction
requester_id = context.user.id or context.author.id
return await cog._clear_user_data(str(requester_id), context)
```