### PR TITLE
Harden restart scripts against cmd injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ test_*.py
 *_test.py
 *.log
 dialogue_migration.log
+# 保留專案的測試套件
+!tests/
+!tests/test_*.py
 
 # 忽略備份檔案（保留結構）
 data/backups/**/*.db

--- a/addons/update/restart.py
+++ b/addons/update/restart.py
@@ -221,8 +221,9 @@ class SimpleRestartManager:
             # 獲取當前進程 PID
             current_pid = os.getpid()
             
-            safe_current_dir = current_dir.replace('"', '""')
-            safe_python_exe = python_exe.replace('"', '""')
+            # Escape characters that trigger cmd expansion
+            safe_current_dir = current_dir.replace('%', '%%').replace('"', '""')
+            safe_python_exe = python_exe.replace('%', '%%').replace('"', '""')
 
             # 創建強力關閉原始 CMD 的重啟批次檔
             batch_content = f"""@echo off
@@ -244,7 +245,9 @@ exit
             
             # 使用 cmd.exe /c start 命令執行批次檔，不等待完成直接分離
             cmd_exe = os.environ.get('COMSPEC', 'cmd.exe')
-            cmd_args = [cmd_exe, '/c', 'start', 'PigPig Bot Restart', '/B', batch_file]
+            batch_file_arg = batch_file.replace('%', '%%').replace('"', '""')
+            quoted_batch_file = f'"{batch_file_arg}"'
+            cmd_args = [cmd_exe, '/c', 'start', '""', '/B', quoted_batch_file]
             
             self.logger.info(f"執行重啟命令: {' '.join(cmd_args)}")
             

--- a/addons/update/restart.py
+++ b/addons/update/restart.py
@@ -221,12 +221,15 @@ class SimpleRestartManager:
             # 獲取當前進程 PID
             current_pid = os.getpid()
             
+            safe_current_dir = current_dir.replace('"', '""')
+            safe_python_exe = python_exe.replace('"', '""')
+
             # 創建強力關閉原始 CMD 的重啟批次檔
             batch_content = f"""@echo off
 chcp 65001 >nul 2>&1
 timeout /t 3 /nobreak >nul
-cd /d "{current_dir}"
-"{python_exe}" main.py
+cd /d "{safe_current_dir}"
+"{safe_python_exe}" main.py
 rem 重啟完成後，嘗試關閉原始 CMD 視窗
 taskkill /F /PID {current_pid} >nul 2>&1
 exit
@@ -239,15 +242,16 @@ exit
             
             self.logger.info(f"重啟批次檔已創建: {batch_file}")
             
-            # 使用 start 命令執行批次檔，不等待完成直接分離
-            cmd = f'start "PigPig Bot Restart" /B "{batch_file}"'
+            # 使用 cmd.exe /c start 命令執行批次檔，不等待完成直接分離
+            cmd_exe = os.environ.get('COMSPEC', 'cmd.exe')
+            cmd_args = [cmd_exe, '/c', 'start', 'PigPig Bot Restart', '/B', batch_file]
             
-            self.logger.info(f"執行重啟命令: {cmd}")
+            self.logger.info(f"執行重啟命令: {' '.join(cmd_args)}")
             
             # 使用 Popen 進行真正的進程分離
             process = subprocess.Popen(
-                cmd,
-                shell=True,
+                cmd_args,
+                shell=False,
                 cwd=current_dir,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
@@ -283,14 +287,18 @@ exit
     
     def _unix_simple_restart(self, python_exe: str, current_dir: str) -> bool:
         """Unix/Linux 簡單重啟方法"""
+        import shlex
         try:
             self.logger.info("使用 Unix/Linux 簡單重啟方法")
             
+            safe_current_dir = shlex.quote(current_dir)
+            safe_python_exe = shlex.quote(python_exe)
+
             # 創建簡單的重啟腳本
             script_content = f"""#!/bin/bash
 sleep 3
-cd "{current_dir}"
-"{python_exe}" main.py
+cd {safe_current_dir}
+{safe_python_exe} main.py
 """
             
             script_file = os.path.join(current_dir, "temp_restart.sh")

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -1,0 +1,118 @@
+import os
+import shlex
+import subprocess
+import sys
+import types
+import importlib.util
+from pathlib import Path
+
+# Stub external modules that require production environment variables
+project_root = Path(__file__).resolve().parent.parent
+fake_addons = types.ModuleType("addons")
+fake_addons.__path__ = [str(project_root / "addons")]
+
+
+class _DummyLogger:
+    def info(self, *args, **kwargs):
+        return None
+
+    def warning(self, *args, **kwargs):
+        return None
+
+    def error(self, *args, **kwargs):
+        return None
+
+
+fake_logging = types.ModuleType("addons.logging")
+fake_logging.get_logger = lambda **kwargs: _DummyLogger()
+
+fake_settings = types.ModuleType("addons.settings")
+fake_settings.base_config = {}
+
+fake_addons.logging = fake_logging
+fake_addons.settings = fake_settings
+
+sys.modules["addons"] = fake_addons
+sys.modules["addons.logging"] = fake_logging
+sys.modules["addons.settings"] = fake_settings
+
+fake_function = types.ModuleType("function")
+fake_function.func = types.SimpleNamespace(report_error=lambda *args, **kwargs: None)
+sys.modules["function"] = fake_function
+
+fake_update = types.ModuleType("addons.update")
+fake_update.__path__ = [str(project_root / "addons" / "update")]
+sys.modules["addons.update"] = fake_update
+
+restart_path = project_root / "addons" / "update" / "restart.py"
+spec = importlib.util.spec_from_file_location("addons.update.restart", restart_path)
+restart_module = importlib.util.module_from_spec(spec)
+sys.modules["addons.update.restart"] = restart_module
+spec.loader.exec_module(restart_module)
+SimpleRestartManager = restart_module.SimpleRestartManager
+
+
+def test_windows_simple_restart_escapes_paths(monkeypatch, tmp_path):
+    manager = SimpleRestartManager(bot=None)
+
+    current_dir = tmp_path / "dir%with&chars"
+    current_dir.mkdir()
+    python_exe = current_dir / "py%thon&exe.exe"
+
+    popen_calls = {}
+
+    class DummyProcess:
+        def __init__(self) -> None:
+            self.pid = 12345
+
+    def fake_popen(args, **kwargs):
+        popen_calls["args"] = args
+        popen_calls["kwargs"] = kwargs
+        return DummyProcess()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    monkeypatch.setenv("COMSPEC", "cmd.exe")
+
+    assert manager._windows_simple_restart(str(python_exe), str(current_dir))
+
+    batch_file = current_dir / "temp_restart.bat"
+    content = batch_file.read_text(encoding="utf-8")
+    assert str(current_dir).replace("%", "%%") in content
+    assert str(python_exe).replace("%", "%%") in content
+
+    args = popen_calls["args"]
+    assert args[:5] == ["cmd.exe", "/c", "start", '""', "/B"]
+    batch_arg = args[-1]
+    assert batch_arg.startswith('"') and batch_arg.endswith('"')
+    assert "%%" in batch_arg
+    assert popen_calls["kwargs"]["shell"] is False
+
+
+def test_unix_simple_restart_quotes_paths(monkeypatch, tmp_path):
+    manager = SimpleRestartManager(bot=None)
+
+    current_dir = tmp_path / "dir with spaces and'quotes"
+    current_dir.mkdir()
+    python_exe = current_dir / "py thon'exe"
+
+    popen_calls = {}
+
+    class DummyProcess:
+        pid = 6789
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls["cmd"] = cmd
+        popen_calls["kwargs"] = kwargs
+        return DummyProcess()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    assert manager._unix_simple_restart(str(python_exe), str(current_dir))
+
+    script_file = current_dir / "temp_restart.sh"
+    content = script_file.read_text(encoding="utf-8")
+    assert shlex.quote(str(current_dir)) in content
+    assert shlex.quote(str(python_exe)) in content
+
+    assert popen_calls["cmd"] == ["nohup", str(script_file)]
+    assert popen_calls["kwargs"]["start_new_session"] is True


### PR DESCRIPTION
The restart manager still allowed cmd metacharacter expansion when restart scripts were generated/launched, and promised restart tests were missing.

- **Windows restart**: Escape `%` and quotes in script paths and use a quoted `cmd.exe /c start "" /B "<batch>"` invocation to prevent cmd parsing of metacharacters (e.g., `&`, `%`).
- **Unix restart**: Coverage added to ensure `shlex.quote` usage remains intact for script paths.
- **Tests/ignore**: Added `tests/test_restart.py` with stubs to isolate environment-dependent modules and updated `.gitignore` to keep the test suite versioned.

Example (Windows launch args):
```python
cmd_args = ["cmd.exe", "/c", "start", '""', "/B", f'"{batch_file_arg}"']
```