### PR TITLE
[Config] Add configurable TTL for procedural memory cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ The bot's default files are in the [./base_configs](./base_configs) folder. You 
 
 ### Step 3: Configure Long-term Memory System
 If you do not want to enable the long-term memory system, set `enabled` to `false` in `base_configs/memory.yaml`.
+To tune cache behavior, adjust `procedural_cache_ttl` (seconds) in `base_configs/memory.yaml`; larger values reduce DB reads, smaller values refresh user data more aggressively.
 If you use a cloud vector database (like Qdrant), set the `VECTOR_STORE_API_KEY` in the `.env` file.
 And ensure that the vector database URL and other parameters are correctly set in `base_configs/memory.yaml`.
 For local installation or cloud setup methods, refer to [Qdrant official documentation](https://qdrant.tech/documentation/).

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -123,6 +123,7 @@ CONFIG_ROOT="/path/to/your/config"
 
 ### 步驟 3：設定長期記憶系統
 如果您不希望啟用長期記憶系統，請在 `base_configs/memory.yaml` 中將 `enabled` 設為 `false`。
+若要調整快取行為，可在 `base_configs/memory.yaml` 中設定 `procedural_cache_ttl`（秒）；數值越大越省資料庫查詢，越小則能更快同步使用者資料。
 如果您使用雲端向量資料庫（如 Qdrant），請在 `.env` 檔案中設定 `VECTOR_STORE_API_KEY`。
 並且確保在 `base_configs/memory.yaml` 中正確設定向量資料庫的 URL 和其他參數。
 本地安裝方式或是雲端設定方法可以參考[Qdrant 官方文件](https://qdrant.tech/documentation/).

--- a/addons/settings.py
+++ b/addons/settings.py
@@ -291,6 +291,9 @@ class MemoryConfig:
         # Toggle to enable/disable memory subsystem
         self.enabled: bool = bool(data.get("enabled", True))
 
+        # Procedural memory cache TTL in seconds
+        self.procedural_cache_ttl: float = float(data.get("procedural_cache_ttl", 300.0))
+
         # Storage / vector store configuration
         self.procedural_data_path: str = data.get("procedural_data_path", "data/memory/procedural.db")
         self.episodic_data_path: str = data.get("episodic_data_path", "data/memory/episodic.db")

--- a/base_configs/memory.yaml
+++ b/base_configs/memory.yaml
@@ -2,6 +2,7 @@
 # enabled: whether to enable the memory / episodic memory subsystem.
 # If false, all memory-related components will not be instantiated or initialized.
 enabled: true
+procedural_cache_ttl: 300.0 # TTL (seconds) for the procedural memory in-process cache
 procedural_data_path: data/memory/procedural.db # Path to procedural data file
 episodic_data_path: data/memory/episodic.db # Path to episodic memory file
 vector_store_type: qdrant # options: qdrant, faiss, sqlite, in_memory

--- a/docs/addons/settings.md
+++ b/docs/addons/settings.md
@@ -235,6 +235,7 @@ Manages the memory subsystem configuration for persistent conversation storage.
 #### Properties
 
 - **`enabled`** (bool): Whether memory system is enabled (default: true)
+- **`procedural_cache_ttl`** (float): In-process procedural cache TTL in seconds (default: 300.0)
 - **`procedural_data_path`** (str): Path to procedural memory database
 - **`episodic_data_path`** (str): Path to episodic memory database
 - **`vector_store_type`** (str): Vector store provider (default: "qdrant")
@@ -254,6 +255,7 @@ Manages the memory subsystem configuration for persistent conversation storage.
 
 ```yaml
 enabled: true
+procedural_cache_ttl: 300.0
 procedural_data_path: "data/memory/procedural.db"
 episodic_data_path: "data/memory/episodic.db"
 vector_store_type: "qdrant"

--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -5,9 +5,7 @@ from typing import Dict, List, Optional, Tuple
 from llm.memory.schema import ProceduralMemory, UserInfo
 from cogs.memory.users.manager import SQLiteUserManager
 from function import func
-
-# Cache TTL in seconds. Procedural memory is low-frequency data; 300s is sufficient.
-_CACHE_TTL_SECONDS: float = 300.0
+from addons.settings import memory_config
 
 
 class ProceduralMemoryProvider:
@@ -60,7 +58,7 @@ class ProceduralMemoryProvider:
                 await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
                 fetched = {}
 
-            expire_at = time.monotonic() + _CACHE_TTL_SECONDS
+            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
             async with self._lock:
                 for uid, info in fetched.items():
                     self._cache[uid] = (info, expire_at)

--- a/tests/test_procedural_memory.py
+++ b/tests/test_procedural_memory.py
@@ -1,0 +1,54 @@
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parent.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+# Provide required env vars so addons.tokens validation does not exit during import
+os.environ.setdefault("TOKEN", "test-token")
+os.environ.setdefault("CLIENT_ID", "123")
+os.environ.setdefault("CLIENT_SECRET_ID", "secret")
+os.environ.setdefault("SERCET_KEY", "secret-key")
+os.environ.setdefault("BUG_REPORT_CHANNEL_ID", "1")
+os.environ.setdefault("BOT_OWNER_ID", "1")
+
+from addons.settings import memory_config
+from llm.memory.procedural import ProceduralMemoryProvider
+from llm.memory.schema import UserInfo
+
+
+class StubUserManager:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def get_multiple_users(self, user_ids):
+        self.calls += 1
+        return {uid: UserInfo(user_background=f"user-{uid}") for uid in user_ids}
+
+
+def test_procedural_cache_respects_configured_ttl(monkeypatch):
+    # Use a short TTL to exercise expiration quickly
+    monkeypatch.setattr(memory_config, "procedural_cache_ttl", 0.05)
+    manager = StubUserManager()
+    provider = ProceduralMemoryProvider(manager)
+
+    async def run_checks():
+        first = await provider.get(["1"])
+        assert "1" in first.user_info
+        assert manager.calls == 1
+
+        # Within TTL: should hit cache and not increase call count
+        second = await provider.get(["1"])
+        assert "1" in second.user_info
+        assert manager.calls == 1
+
+        # After TTL expiration: should fetch again
+        await asyncio.sleep(0.06)
+        third = await provider.get(["1"])
+        assert "1" in third.user_info
+        assert manager.calls == 2
+
+    asyncio.run(run_checks())


### PR DESCRIPTION
**What:**
The procedural memory cache TTL was hardcoded to `300.0` seconds in `llm/memory/procedural.py`, making it unconfigurable for end-users who might want a longer or shorter TTL for procedural caching.

**Where:**
- `llm/memory/procedural.py:5`
- `addons/settings.py:294`

**Why:**
Allowing users to customize the procedural cache TTL provides better performance tuning options. For deployments with high API rates, raising the TTL could lower database pressure, whereas environments requiring immediate reactivity might want to lower it. This change has high alignment with the config structure and zero risk to existing interfaces.

**What was done:**
1. Modified `addons/settings.py` to expose `procedural_cache_ttl` with a default of 300.0.
2. Modified `llm/memory/procedural.py` to import `memory_config` and substitute the hardcoded constant with `memory_config.procedural_cache_ttl`.

---
*PR created automatically by Jules for task [7250409116425194558](https://jules.google.com/task/7250409116425194558) started by @starpig1129*