### PR TITLE
[Perf] Bound TTL cache size in ProceduralMemoryProvider to prevent memory leak

### DIFF
--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -15,9 +15,10 @@ class ProceduralMemoryProvider:
     and caches results per user_id to avoid redundant DB calls within the TTL window.
     """
 
-    def __init__(self, user_manager: SQLiteUserManager) -> None:
+    def __init__(self, user_manager: SQLiteUserManager, max_cache_size: int = 1000) -> None:
         """Initializes the provider with a user manager instance."""
         self.user_manager = user_manager
+        self.max_cache_size = max_cache_size
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
         self._cache: Dict[str, Tuple[UserInfo, float]] = {}
         self._lock = asyncio.Lock()
@@ -63,6 +64,14 @@ class ProceduralMemoryProvider:
                 for uid, info in fetched.items():
                     self._cache[uid] = (info, expire_at)
                     result[uid] = info
+
+                if len(self._cache) > self.max_cache_size:
+                    now_insert = time.monotonic()
+                    self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+
+                    while len(self._cache) > self.max_cache_size:
+                        oldest_key = next(iter(self._cache))
+                        self._cache.pop(oldest_key)
 
         return ProceduralMemory(user_info=result)
 

--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -16,7 +16,18 @@ class ProceduralMemoryProvider:
     """
 
     def __init__(self, user_manager: SQLiteUserManager, max_cache_size: int = 1000) -> None:
-        """Initializes the provider with a user manager instance."""
+        """Initializes the provider with a user manager instance and cache size limit.
+
+        Args:
+            user_manager: Manager used to fetch user information from storage.
+            max_cache_size: Maximum number of user entries to retain in the cache
+                before pruning. Must be a non-negative integer.
+
+        Raises:
+            ValueError: If max_cache_size is negative.
+        """
+        if max_cache_size < 0:
+            raise ValueError("max_cache_size must be >= 0")
         self.user_manager = user_manager
         self.max_cache_size = max_cache_size
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)

--- a/tests/test_procedural_memory.py
+++ b/tests/test_procedural_memory.py
@@ -3,6 +3,8 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
 project_root = Path(__file__).resolve().parent.parent
 if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
@@ -97,8 +99,5 @@ def test_max_cache_size_prunes_expired_entries_first(monkeypatch):
 def test_max_cache_size_negative_raises():
     """Passing a negative max_cache_size should raise ValueError."""
     manager = StubUserManager()
-    try:
+    with pytest.raises(ValueError, match=r"max_cache_size"):
         ProceduralMemoryProvider(manager, max_cache_size=-1)
-        assert False, "Expected ValueError"
-    except ValueError as exc:
-        assert "max_cache_size" in str(exc).lower() or ">= 0" in str(exc)

--- a/tests/test_procedural_memory.py
+++ b/tests/test_procedural_memory.py
@@ -52,3 +52,53 @@ def test_procedural_cache_respects_configured_ttl(monkeypatch):
         assert manager.calls == 2
 
     asyncio.run(run_checks())
+
+
+def test_max_cache_size_evicts_oldest_entries(monkeypatch):
+    """Cache should not exceed max_cache_size; oldest entries are evicted first."""
+    monkeypatch.setattr(memory_config, "procedural_cache_ttl", 60)
+    manager = StubUserManager()
+    max_size = 3
+    provider = ProceduralMemoryProvider(manager, max_cache_size=max_size)
+
+    async def run_checks():
+        # Fill the cache beyond its limit
+        for i in range(max_size + 2):
+            await provider.get([str(i)])
+
+        assert len(provider._cache) <= max_size
+
+    asyncio.run(run_checks())
+
+
+def test_max_cache_size_prunes_expired_entries_first(monkeypatch):
+    """Expired entries should be pruned before evicting live entries."""
+    monkeypatch.setattr(memory_config, "procedural_cache_ttl", 0.05)
+    manager = StubUserManager()
+    provider = ProceduralMemoryProvider(manager, max_cache_size=3)
+
+    async def run_checks():
+        # Populate the cache with entries that will expire
+        for i in range(3):
+            await provider.get([str(i)])
+
+        # Wait for those entries to expire
+        await asyncio.sleep(0.1)
+
+        # Fetch new entries; expired entries should be pruned first
+        for i in range(10, 14):
+            await provider.get([str(i)])
+
+        assert len(provider._cache) <= 3
+
+    asyncio.run(run_checks())
+
+
+def test_max_cache_size_negative_raises():
+    """Passing a negative max_cache_size should raise ValueError."""
+    manager = StubUserManager()
+    try:
+        ProceduralMemoryProvider(manager, max_cache_size=-1)
+        assert False, "Expected ValueError"
+    except ValueError as exc:
+        assert "max_cache_size" in str(exc).lower() or ">= 0" in str(exc)


### PR DESCRIPTION
**What:** The `ProceduralMemoryProvider` uses an unbounded dictionary (`self._cache`) for its TTL cache.
**Where:** `llm/memory/procedural.py`, line ~18 and ~64
**Why:** Because it lacked size bounds, the cache could grow indefinitely as new users interact with the bot, leading to a memory leak because expired entries are only lazily removed upon a cache hit, not periodically.
**What was done:** Added `max_cache_size=1000` to the `__init__` signature, and logic in `get()` that lazily removes expired items when the cache limit is exceeded, popping the oldest remaining items (via `next(iter(self._cache))`) until the cache conforms to the limit.

---
*PR created automatically by Jules for task [10134076084171857810](https://jules.google.com/task/10134076084171857810) started by @starpig1129*