### PR TITLE
[UX] Fix latency timeout in /play command by eager deferral

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -104,6 +104,8 @@ class YTMusic(commands.Cog):
             await interaction.response.send_message(embed=embed, ephemeral=True)
             return
             
+        await interaction.response.defer(ephemeral=True, thinking=True)
+
         # 連接至語音頻道
         channel = interaction.user.voice.channel
         if interaction.guild.voice_client is None:
@@ -113,7 +115,7 @@ class YTMusic(commands.Cog):
                 await func.report_error(e, "music.py/play/channel.connect")
                 title = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "voice_connect_failed")
                 embed = discord.Embed(title=f"❌ | {title}", color=discord.Color.red())
-                await interaction.response.send_message(embed=embed, ephemeral=True)
+                await interaction.followup.send(embed=embed, ephemeral=True)
                 return
 
         # 如果沒有提供查詢，刷新UI
@@ -132,10 +134,10 @@ class YTMusic(commands.Cog):
                     self
                 )
                 refresh_message = self.lang_manager.translate(str(guild_id), "commands", "play", "responses", "refreshed_ui")
-                await interaction.response.send_message(refresh_message, ephemeral=True, delete_after=5)
+                await interaction.followup.send(refresh_message, ephemeral=True)
             else:
                 no_song_message = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "nothing_playing")
-                await interaction.response.send_message(no_song_message, ephemeral=True, delete_after=5)
+                await interaction.followup.send(no_song_message, ephemeral=True)
             return
 
         # 如果有提供查詢，將音樂加入播放清單
@@ -143,7 +145,6 @@ class YTMusic(commands.Cog):
         
         # 檢查是否為URL
         if "youtube.com" in query or "youtu.be" in query:
-            await interaction.response.defer(ephemeral=True)
             # 檢查是否為播放清單
             if "list" in query:
                 await self._handle_playlist(interaction, query)
@@ -239,7 +240,6 @@ class YTMusic(commands.Cog):
 
     async def _handle_search(self, interaction: discord.Interaction, query: str):
         """Handle search query"""
-        await interaction.response.defer(ephemeral=True, thinking=True)
         results = await self.youtube.search_videos(query)
         guild_id = interaction.guild.id
         if not results:

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -138,11 +138,23 @@ class YTMusic(commands.Cog):
                 )
                 refresh_message = self.lang_manager.translate(str(guild_id), "commands", "play", "responses", "refreshed_ui")
                 msg = await interaction.followup.send(refresh_message, ephemeral=True, wait=True)
-                await msg.delete(delay=5)
+                async def _delete_refresh():
+                    await asyncio.sleep(5)
+                    try:
+                        await msg.delete()
+                    except Exception:
+                        pass
+                asyncio.create_task(_delete_refresh())
             else:
                 no_song_message = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "nothing_playing")
                 msg = await interaction.followup.send(no_song_message, ephemeral=True, wait=True)
-                await msg.delete(delay=5)
+                async def _delete_no_song():
+                    await asyncio.sleep(5)
+                    try:
+                        await msg.delete()
+                    except Exception:
+                        pass
+                asyncio.create_task(_delete_no_song())
             return
 
         # 如果有提供查詢，將音樂加入播放清單

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -94,11 +94,14 @@ class YTMusic(commands.Cog):
     async def play(self, interaction: discord.Interaction, query: Optional[str] = None):
         """播放音樂或刷新UI命令"""
         guild_id = interaction.guild.id
-        
+        if not self.lang_manager: # Ensure lang_manager is loaded
+            self.lang_manager = self.bot.get_cog("LanguageManager")
+            if not self.lang_manager:
+                await interaction.response.send_message("Language manager not loaded.", ephemeral=True)
+                return
+
         # 檢查使用者是否已在語音頻道
         if not interaction.user.voice:
-            if not self.lang_manager:
-                self.lang_manager = self.bot.get_cog("LanguageManager")
             title = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "no_voice_channel")
             embed = discord.Embed(title=f"❌ | {title}", color=discord.Color.red())
             await interaction.response.send_message(embed=embed, ephemeral=True)
@@ -134,10 +137,12 @@ class YTMusic(commands.Cog):
                     self
                 )
                 refresh_message = self.lang_manager.translate(str(guild_id), "commands", "play", "responses", "refreshed_ui")
-                await interaction.followup.send(refresh_message, ephemeral=True)
+                msg = await interaction.followup.send(refresh_message, ephemeral=True, wait=True)
+                await msg.delete(delay=5)
             else:
                 no_song_message = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "nothing_playing")
-                await interaction.followup.send(no_song_message, ephemeral=True)
+                msg = await interaction.followup.send(no_song_message, ephemeral=True, wait=True)
+                await msg.delete(delay=5)
             return
 
         # 如果有提供查詢，將音樂加入播放清單


### PR DESCRIPTION
**What:** Identified a major UX friction point where the `/play` command in `cogs/music.py` could encounter a Discord timeout ("The application did not respond") due to a delay when the bot connects to the voice channel.
**Where:** `cogs/music.py` lines 94-150.
**Why:** Because Discord interactions fail if the bot does not respond or defer within 3 seconds, operations that block or take time over the network (like `await channel.connect()`) cause a poor user experience.
**What was done:** 
- Moved `await interaction.response.defer(ephemeral=True, thinking=True)` to occur immediately after the fast pre-condition checks and before the voice channel connection block.
- Updated `interaction.response.send_message()` to `interaction.followup.send()` for the connection error handler and the empty query (refresh UI/nothing playing) blocks. 
- Removed redundant later calls to `interaction.response.defer(ephemeral=True)` inside `if "youtube.com"` and `_handle_search` methods to prevent double-deferral errors.
- Excluded unsupported `delete_after` keyword parameters from `followup.send()`.

---
*PR created automatically by Jules for task [290353041917808817](https://jules.google.com/task/290353041917808817) started by @starpig1129*