### PR TITLE
[Bugfix] Invalidate procedural cache on slash command memory save

### DIFF
--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -494,6 +494,21 @@ class UserDataCog(commands.Cog):
             )
             
             if success:
+                # Invalidate ProceduralMemoryProvider cache
+                try:
+                    orchestrator = getattr(self.bot, "orchestrator", None)
+                    if orchestrator:
+                        provider = getattr(
+                            getattr(orchestrator, "context_manager", None),
+                            "procedural_provider",
+                            None,
+                        )
+                        if provider and hasattr(provider, "invalidate"):
+                            await provider.invalidate(str(user_id))
+                except Exception as cache_err:
+                    self.logger.warning(f"Failed to invalidate procedural cache for {user_id}: {cache_err}")
+
+
                 response_key = "data_updated" if existing_data else "data_created"
                 
                 # Format merged_data for display
@@ -726,8 +741,9 @@ class UserDataCog(commands.Cog):
                         )
                         if provider and hasattr(provider, "invalidate"):
                             await provider.invalidate(str(user_id))
-                except Exception:
-                    pass
+                except Exception as cache_err:
+                    self.logger.warning(f"Failed to invalidate procedural cache for {user_id}: {cache_err}")
+
 
                 return self._translate(
                     guild_id,


### PR DESCRIPTION
- **What**: The `ProceduralMemoryProvider` cache was not being properly invalidated when users ran the direct Discord slash command `/memory save` to update their profile context, leaving the LLM orchestrator using stale data for up to 5 minutes.
- **Where**: `cogs/userdata.py` in the `_save_user_data` method.
- **Why**: This creates an inconsistent and confusing user experience where the bot would acknowledge an update ("Got it!") but immediately forget it in follow-up chats due to the active cache TTL.
- **What was done**: Added explicit cache invalidation immediately after the successful `self.user_manager.update_user_data()` database update, mirroring existing reliable logic in `_clear_user_data`. Additionally, exception handling logic for cache invalidation was updated to cleanly log via `self.logger` without blocking the primary command sequence.

---
*PR created automatically by Jules for task [18005625187066138337](https://jules.google.com/task/18005625187066138337) started by @starpig1129*