### PR TITLE
[Refactor] Dynamic tool routing using agent_mode attributes

### DIFF
--- a/llm/tools_factory.py
+++ b/llm/tools_factory.py
@@ -348,15 +348,15 @@ def get_tools(
             
             # Check metadata or custom attributes on the original wrapped function if present
             # Langchain's StructuredTool hides custom attributes, so we try multiple ways
-            _raw_mode: object = None
+            raw_mode: object = None
             try:
                 metadata = getattr(t, "metadata", None)
                 if isinstance(metadata, dict) and "target_agent_mode" in metadata:
-                    _raw_mode = metadata["target_agent_mode"]
+                    raw_mode = metadata["target_agent_mode"]
                 elif hasattr(t, "target_agent_mode"):
-                    _raw_mode = getattr(t, "target_agent_mode")
+                    raw_mode = getattr(t, "target_agent_mode")
                 elif hasattr(t, "func") and hasattr(t.func, "target_agent_mode"):
-                    _raw_mode = getattr(t.func, "target_agent_mode")
+                    raw_mode = getattr(t.func, "target_agent_mode")
             except (AttributeError, KeyError, TypeError) as e:
                 logger.warning(
                     "Failed to extract target_agent_mode for tool %s: %s",
@@ -364,15 +364,15 @@ def get_tools(
                     e,
                 )
 
-            if _raw_mode is not None:
-                _normalized = str(_raw_mode).lower()
-                if _normalized in _VALID_AGENT_MODES:
-                    target_agent_mode = _normalized
+            if raw_mode is not None:
+                normalized_mode = str(raw_mode).lower()
+                if normalized_mode in _VALID_AGENT_MODES:
+                    target_agent_mode = normalized_mode
                 else:
                     logger.warning(
                         "Tool %s has unknown target_agent_mode %r; falling back to 'info'.",
                         getattr(t, "name", repr(t)),
-                        _raw_mode,
+                        raw_mode,
                     )
 
             if agent_mode == "info" and target_agent_mode == "message":

--- a/llm/tools_factory.py
+++ b/llm/tools_factory.py
@@ -238,10 +238,6 @@ def _get_user_permissions(user: discord.Member, guid: discord.Guild) -> dict:
 from llm.schema import OrchestratorRequest
 
 
-# Tools specific to the message agent (action-oriented interaction tools)
-# Currently empty - message agent uses text-only responses
-MESSAGE_AGENT_TOOLS = set()
-
 def get_tools(
     user: discord.Member, 
     guid: discord.Guild, 
@@ -334,20 +330,28 @@ def get_tools(
                 if not allowed:
                     continue
 
-            # Filter based on agent_mode
-            tool_name = getattr(t, "name", getattr(t, "__name__", repr(t)))
+            # Filter based on agent_mode using target_agent_mode attribute
+            target_agent_mode = "info"
             
-            if agent_mode == "info":
-                if tool_name in MESSAGE_AGENT_TOOLS:
-                    continue
-            elif agent_mode == "message":
-                if tool_name not in MESSAGE_AGENT_TOOLS:
-                    continue
+            # Check metadata or custom attributes on the original wrapped function if present
+            # Langchain's StructuredTool hides custom attributes, so we try multiple ways
+            try:
+                if hasattr(t, "metadata") and getattr(t, "metadata") and "target_agent_mode" in getattr(t, "metadata"):
+                    target_agent_mode = getattr(t, "metadata")["target_agent_mode"]
+                elif hasattr(t, "target_agent_mode"):
+                    target_agent_mode = getattr(t, "target_agent_mode")
+                elif hasattr(t, "func") and hasattr(t.func, "target_agent_mode"):
+                    target_agent_mode = getattr(t.func, "target_agent_mode")
+            except Exception:
+                pass
+
+            if agent_mode == "info" and target_agent_mode == "message":
+                continue
+            elif agent_mode == "message" and target_agent_mode == "info":
+                continue
             
             # Assign agent_mode to the tool for identification
-            # Note: This modifies the tool instance in place. Since tools are disjoint
-            # between info/message modes (based on MESSAGE_AGENT_TOOLS logic above),
-            # this is generally safe. For "all" mode, it will be "all".
+            # Note: This modifies the tool instance in place.
             try:
                 t.agent_mode = agent_mode
             except Exception:

--- a/llm/tools_factory.py
+++ b/llm/tools_factory.py
@@ -252,14 +252,26 @@ def get_tools(
     - 若工具沒有宣告 `required_permission`，則預設對所有使用者開放。
     - 權限屬性可以設在 BaseTool 實例或原始 callable 上。
 
+    工具路由策略 (target_agent_mode):
+    - 每個工具可以宣告 `target_agent_mode` 來指定其所屬的 Agent。
+      支援的值：
+        - "info"    (預設) — 僅供 Info Agent 使用，Message Agent 不會收到此工具。
+        - "message"         — 僅供 Message Agent 使用，Info Agent 不會收到此工具。
+        - "all"             — 兩個 Agent 皆可使用。
+      未知值會被視為 "info" 並記錄 warning。
+    - 宣告方式（優先順序）：
+        1. tool.metadata["target_agent_mode"] — 適用於 LangChain StructuredTool
+        2. tool.target_agent_mode — 直接屬性
+        3. tool.func.target_agent_mode — 原始 callable 上的屬性
+
     Args:
         user: Discord 使用者
         guid: Discord Guild
         runtime: 執行時 context
         agent_mode: 工具過濾模式 ("all", "info", "message")
             - "all": 回傳所有可用工具
-            - "info": 回傳 Info Agent 專用工具 (排除 Message Agent 專用工具)
-            - "message": 僅回傳 Message Agent 專用工具
+            - "info": 回傳 Info Agent 專用工具 (排除 target_agent_mode=="message" 的工具)
+            - "message": 僅回傳 Message Agent 專用工具 (排除 target_agent_mode=="info" 的工具)
 
     Returns:
         List[BaseTool]: 可供 LangChain 使用的工具清單（靜態類型上會 cast 為 List[BaseTool]）。
@@ -331,19 +343,37 @@ def get_tools(
                     continue
 
             # Filter based on agent_mode using target_agent_mode attribute
+            _VALID_AGENT_MODES = {"info", "message", "all"}
             target_agent_mode = "info"
             
             # Check metadata or custom attributes on the original wrapped function if present
             # Langchain's StructuredTool hides custom attributes, so we try multiple ways
+            _raw_mode: object = None
             try:
-                if hasattr(t, "metadata") and getattr(t, "metadata") and "target_agent_mode" in getattr(t, "metadata"):
-                    target_agent_mode = getattr(t, "metadata")["target_agent_mode"]
+                metadata = getattr(t, "metadata", None)
+                if isinstance(metadata, dict) and "target_agent_mode" in metadata:
+                    _raw_mode = metadata["target_agent_mode"]
                 elif hasattr(t, "target_agent_mode"):
-                    target_agent_mode = getattr(t, "target_agent_mode")
+                    _raw_mode = getattr(t, "target_agent_mode")
                 elif hasattr(t, "func") and hasattr(t.func, "target_agent_mode"):
-                    target_agent_mode = getattr(t.func, "target_agent_mode")
-            except Exception:
-                pass
+                    _raw_mode = getattr(t.func, "target_agent_mode")
+            except (AttributeError, KeyError, TypeError) as e:
+                logger.warning(
+                    "Failed to extract target_agent_mode for tool %s: %s",
+                    getattr(t, "name", repr(t)),
+                    e,
+                )
+
+            if _raw_mode is not None:
+                _normalized = str(_raw_mode).lower()
+                if _normalized in _VALID_AGENT_MODES:
+                    target_agent_mode = _normalized
+                else:
+                    logger.warning(
+                        "Tool %s has unknown target_agent_mode %r; falling back to 'info'.",
+                        getattr(t, "name", repr(t)),
+                        _raw_mode,
+                    )
 
             if agent_mode == "info" and target_agent_mode == "message":
                 continue


### PR DESCRIPTION
### What
Replaced the hardcoded, centralized list (`MESSAGE_AGENT_TOOLS`) for action-oriented tool filtering with a declarative attribute-based routing system.

### Where
- `llm/tools_factory.py`

### Why
Previously, to define an action tool for the `message_agent`, developers had to add its name to `MESSAGE_AGENT_TOOLS = set()` in `tools_factory.py`. This was brittle, violated separation of concerns, and made it easy to misconfigure tools. By reading a `target_agent_mode` attribute dynamically from the tools, the system is now decentralized and tools self-declare where they belong.

### What was done
- Removed `MESSAGE_AGENT_TOOLS` from `tools_factory.py`.
- Updated `get_tools` to dynamically evaluate `target_agent_mode` (defaulting to `"info"`) by checking `metadata` or `.func.target_agent_mode` for the `StructuredTool`.
- Preserved disjoint agent logic: `info` agent skips `message` tools, `message` agent skips `info` tools, and `"all"` tools go to both.
- Existing tools implicitly fall back to `"info"` mode, meaning no functionality regressions for current features.

---
*PR created automatically by Jules for task [3782746895643656308](https://jules.google.com/task/3782746895643656308) started by @starpig1129*