### PR TITLE
[Perf] Add TTL cache to EpisodicMemoryProvider

### DIFF
--- a/addons/settings.py
+++ b/addons/settings.py
@@ -298,6 +298,10 @@ class MemoryConfig:
         # Procedural memory cache TTL in seconds
         self.procedural_cache_ttl: float = float(data.get("procedural_cache_ttl", 300.0))
 
+        # Episodic memory cache settings
+        self.episodic_cache_ttl: float = float(data.get("episodic_cache_ttl", 300.0))
+        self.episodic_max_cache_size: int = int(data.get("episodic_max_cache_size", 1000))
+
         # Storage / vector store configuration
         self.procedural_data_path: str = data.get("procedural_data_path", "data/memory/procedural.db")
         self.episodic_data_path: str = data.get("episodic_data_path", "data/memory/episodic.db")

--- a/llm/memory/episodic.py
+++ b/llm/memory/episodic.py
@@ -6,12 +6,15 @@ Silent failure design: any error returns None without raising.
 """
 from __future__ import annotations
 
+import asyncio
 import re
-from typing import TYPE_CHECKING, Any, Optional
+import time
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 import discord
 
 from addons.logging import get_logger
+from addons.settings import memory_config
 from function import func
 
 _LOGGER = get_logger(server_id="Bot", source="llm.memory.episodic")
@@ -40,6 +43,11 @@ class EpisodicMemoryProvider:
         self.bot = bot
         self.top_k = top_k
         self.max_chars = max_chars
+        self.cache_ttl = getattr(memory_config, "episodic_cache_ttl", 300.0)
+        self.max_cache_size = getattr(memory_config, "episodic_max_cache_size", 1000)
+        # key: (query, channel_id), value: (formatted_string, expire_at)
+        self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
+        self._lock = asyncio.Lock()
 
     async def get(self, message: discord.Message) -> Optional[str]:
         """Return formatted episodic context string, or None if nothing relevant.
@@ -65,17 +73,32 @@ class EpisodicMemoryProvider:
         if len(query.split()) < _MIN_QUERY_TOKENS:
             return None
 
+        channel_id = str(message.channel.id)
+        cache_key = (query, channel_id)
+        now = time.monotonic()
+
+        async with self._lock:
+            if cache_key in self._cache:
+                cached_result, expire_at = self._cache[cache_key]
+                if expire_at > now:
+                    return cached_result
+                else:
+                    del self._cache[cache_key]
+
         try:
             fragments = await vector_manager.store.search_memories_by_vector(
                 query_text=query,
                 limit=self.top_k,
-                channel_id=str(message.channel.id),
+                channel_id=channel_id,
             )
         except Exception as e:
             await func.report_error(e, "EpisodicMemoryProvider.get: vector search failed")
             return None
 
         if not fragments:
+            async with self._lock:
+                self._cache[cache_key] = (None, now + self.cache_ttl)
+                self._prune_cache()
             return None
 
         lines = ["--- Relevant Past Memories ---"]
@@ -112,4 +135,28 @@ class EpisodicMemoryProvider:
 
         lines.append("--- End Past Memories ---")
         _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
-        return "\n".join(lines)
+
+        result_str = "\n".join(lines)
+
+        async with self._lock:
+            self._cache[cache_key] = (result_str, now + self.cache_ttl)
+            self._prune_cache()
+
+        return result_str
+
+    def _prune_cache(self) -> None:
+        """Removes the oldest entries from the cache if it exceeds the max size."""
+        if len(self._cache) > self.max_cache_size:
+            # Sort by expiration time, keep the newest ones
+            now = time.monotonic()
+
+            # First, filter out any already expired items
+            expired_keys = [k for k, v in self._cache.items() if v[1] <= now]
+            for k in expired_keys:
+                del self._cache[k]
+
+            # If still too large, remove the ones that will expire soonest
+            while len(self._cache) > self.max_cache_size:
+                # Find the key with the smallest expiration time
+                oldest_key = min(self._cache.keys(), key=lambda k: self._cache[k][1])
+                del self._cache[oldest_key]


### PR DESCRIPTION
**What was found:**
The `EpisodicMemoryProvider` performs a vector database search via `vector_manager.store.search_memories_by_vector` for every processed message (that meets the minimum length requirement). Repeated queries or rapidly flowing identical phrases can cause redundant, expensive searches.

**Where it is:**
- `llm/memory/episodic.py` in the `get` method.

**Why it matters:**
Vector searches are generally more resource-intensive and have higher latency than local cache lookups. Redundant queries to the same channel can occur, and caching the episodic results avoids hammering the backend datastore without impacting functionality.

**What was done:**
- Added `episodic_cache_ttl` (default: 300.0s) and `episodic_max_cache_size` (default: 1000) settings to `MemoryConfig` in `addons/settings.py`.
- Updated `EpisodicMemoryProvider` to initialize an `asyncio.Lock` and a `_cache` dictionary.
- Wrapped the vector search in `llm/memory/episodic.py` with a cache lookup using `(query, channel_id)` as the key.
- Implemented `_prune_cache()` to evict expired items and enforce the cache size limit, keeping memory footprint bounded.

---
*PR created automatically by Jules for task [7634533899182993104](https://jules.google.com/task/7634533899182993104) started by @starpig1129*