### PR TITLE
[Perf] Parallelize memory provider fetches

### DIFF
--- a/llm/context_manager.py
+++ b/llm/context_manager.py
@@ -45,53 +45,17 @@ class ContextManager:
         ShortTermMemoryProvider.
         """
 
-        async def _fetch_short_term_and_procedural() -> Tuple[ProceduralMemory, List[BaseMessage]]:
-            # 1) Fetch short-term messages
-            short_term_msgs: List[BaseMessage] = []
+        async def _fetch_short_term() -> List[BaseMessage]:
             try:
-                short_term_msgs = await self.short_term_provider.get(message)
+                return await self.short_term_provider.get(message)
             except asyncio.CancelledError:
                 raise
             except Exception as e:
-                # Report and continue with safe fallback per design
                 asyncio.create_task(
                     func.report_error(e, "ContextManager.get_context: short_term_provider.get failed")
                 )
                 _LOGGER.error("short_term_provider.get failed", exception=e)
-
-            # 2) Extract user ids to fetch procedural memory
-            try:
-                user_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:
-                asyncio.create_task(
-                    func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
-                )
-                _LOGGER.error("extract_user_ids failed", exception=e)
-                user_ids = []
-                try:
-                    fallback_author_id = getattr(getattr(message, "author", None), "id", None)
-                    if fallback_author_id is not None:
-                        user_ids.append(str(fallback_author_id))
-                except Exception:
-                    # Best-effort fallback; proceed with empty user_ids
-                    pass
-
-            # 3) Fetch procedural memory
-            try:
-                procedural_memory = await self.procedural_provider.get(user_ids)
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:
-                asyncio.create_task(
-                    func.report_error(e, "ContextManager.get_context: procedural_provider.get failed")
-                )
-                _LOGGER.error("procedural_provider.get failed", exception=e)
-                procedural_memory = ProceduralMemory(user_info={})
-
-            return procedural_memory, short_term_msgs
-
+                return []
 
         async def _fetch_episodic() -> Optional[str]:
             if not self.episodic_provider:
@@ -107,13 +71,58 @@ class ContextManager:
                 _LOGGER.error("episodic_provider.get failed", exception=e)
                 return None
 
-        # Fetch short-term/procedural memory AND episodic context in parallel to minimize latency
-        (procedural_memory, short_term_msgs), episodic_str = await asyncio.gather(
-            _fetch_short_term_and_procedural(),
+        async def _fetch_procedural(uids: List[str]) -> ProceduralMemory:
+            if not uids:
+                return ProceduralMemory(user_info={})
+            try:
+                return await self.procedural_provider.get(uids)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                asyncio.create_task(
+                    func.report_error(e, "ContextManager.get_context: procedural_provider.get failed")
+                )
+                _LOGGER.error("procedural_provider.get failed", exception=e)
+                return ProceduralMemory(user_info={})
+
+        # 1. Extract author ID to start their procedural memory fetch immediately
+        author_ids = []
+        try:
+            fallback_author_id = getattr(getattr(message, "author", None), "id", None)
+            if fallback_author_id is not None:
+                author_ids.append(str(fallback_author_id))
+        except Exception:
+            pass
+
+        # 2. Fetch short-term, episodic, and author procedural memory in parallel
+        short_term_msgs, episodic_str, author_procedural = await asyncio.gather(
+            _fetch_short_term(),
             _fetch_episodic(),
+            _fetch_procedural(author_ids),
         )
 
-        # 4) Format procedural memory into string (no STM serialization here)
+        # 3. Extract any additional user IDs from the fetched short-term messages
+        try:
+            extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
+        except Exception as e:
+            asyncio.create_task(
+                func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
+            )
+            _LOGGER.error("extract_user_ids failed", exception=e)
+            extracted_ids = []
+
+        # 4. Fetch procedural memory for any additional users
+        additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
+        if additional_ids:
+            additional_procedural = await _fetch_procedural(additional_ids)
+            # Merge procedural memories
+            merged_info = dict(getattr(author_procedural, "user_info", {}))
+            merged_info.update(getattr(additional_procedural, "user_info", {}))
+            procedural_memory = ProceduralMemory(user_info=merged_info)
+        else:
+            procedural_memory = author_procedural
+
+        # 5) Format procedural memory into string (no STM serialization here)
         try:
             channel_name = getattr(message.channel, "name", str(getattr(message.channel, "id", "")))
         except Exception:

--- a/llm/context_manager.py
+++ b/llm/context_manager.py
@@ -63,7 +63,7 @@ class ContextManager:
             try:
                 return await self.episodic_provider.get(message)
             except asyncio.CancelledError:
-                return None
+                raise
             except Exception as e:
                 asyncio.create_task(
                     func.report_error(e, "ContextManager.get_context: episodic_provider.get failed")

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -178,7 +178,7 @@ async def test_additional_users_from_stm_fetches_procedural_for_all(monkeypatch)
     procedural_str, short_term_msgs = await manager.get_context(_make_message(author_id))
 
     # All user ids that were requested across all provider calls
-    all_fetched_ids: set = set()
+    all_fetched_ids: set[str] = set()
     for call in procedural_provider.all_calls:
         all_fetched_ids.update(call)
 

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -100,11 +100,14 @@ class StubShortTermProvider:
 class StubProceduralProvider:
     def __init__(self):
         self.requested_ids = None
+        self.all_calls: list = []
 
     async def get(self, user_ids):
-        self.requested_ids = list(user_ids)
+        ids = list(user_ids)
+        self.requested_ids = ids
+        self.all_calls.append(ids)
         return ProceduralMemory(
-            user_info={uid: UserInfo(user_background="bg") for uid in user_ids}
+            user_info={uid: UserInfo(user_background="bg") for uid in ids}
         )
 
 
@@ -154,6 +157,49 @@ async def test_short_term_cancellation_propagates(monkeypatch):
     short_term_provider = StubShortTermProvider(fail_with=asyncio.CancelledError())
     procedural_provider = StubProceduralProvider()
     manager = ContextManager(short_term_provider, procedural_provider, episodic_provider=None)
+
+    with pytest.raises(asyncio.CancelledError):
+        await manager.get_context(_make_message())
+
+
+@pytest.mark.asyncio
+async def test_additional_users_from_stm_fetches_procedural_for_all(monkeypatch):
+    """Procedural provider is invoked for both author and additional STM user ids."""
+    monkeypatch.setattr(context_manager, "func", types.SimpleNamespace(report_error=_noop_report_error))
+
+    # STM returns a message whose content references a second user
+    second_user_id = "789"
+    stm_message = _BaseMessage(content=f"UserID:{second_user_id} said hello")
+    short_term_provider = StubShortTermProvider(messages=[stm_message])
+    procedural_provider = StubProceduralProvider()
+    manager = ContextManager(short_term_provider, procedural_provider, episodic_provider=None)
+
+    author_id = "123"
+    procedural_str, short_term_msgs = await manager.get_context(_make_message(author_id))
+
+    # All user ids that were requested across all provider calls
+    all_fetched_ids: set = set()
+    for call in procedural_provider.all_calls:
+        all_fetched_ids.update(call)
+
+    assert author_id in all_fetched_ids, "author id must be fetched"
+    assert second_user_id in all_fetched_ids, "additional user id from STM must be fetched"
+    assert f"User: {author_id}" in procedural_str
+    assert f"User: {second_user_id}" in procedural_str
+
+
+@pytest.mark.asyncio
+async def test_episodic_cancellation_propagates(monkeypatch):
+    """CancelledError from episodic provider must propagate out of get_context."""
+    monkeypatch.setattr(context_manager, "func", types.SimpleNamespace(report_error=_noop_report_error))
+
+    class _CancellingEpisodicProvider:
+        async def get(self, message):
+            raise asyncio.CancelledError()
+
+    short_term_provider = StubShortTermProvider(messages=[])
+    procedural_provider = StubProceduralProvider()
+    manager = ContextManager(short_term_provider, procedural_provider, episodic_provider=_CancellingEpisodicProvider())
 
     with pytest.raises(asyncio.CancelledError):
         await manager.get_context(_make_message())


### PR DESCRIPTION
Parallelizes the fetching of memory providers in `llm/context_manager.py` to reduce the total latency of the `handle_message` pipeline. Previously, procedural memory extraction was blocked sequentially on short-term memory fetching. This PR extracts the author's ID directly from the message object first, allowing their procedural profile, the short-term memory, and the episodic context to all be fetched concurrently via `asyncio.gather`. Any additional users mentioned in the short-term memory are still fetched afterwards.

---
*PR created automatically by Jules for task [11006396728234929908](https://jules.google.com/task/11006396728234929908) started by @starpig1129*