### PR TITLE
[UX] Defer interaction early in `/play` command to prevent timeout

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -264,7 +264,7 @@ class YTMusic(commands.Cog):
             color=discord.Color.blue()
         )
         
-        await interaction.followup.send(embed=embed, view=view, ephemeral=True)
+        await interaction.edit_original_response(embed=embed, view=view)
 
     async def play_next(self, interaction: discord.Interaction, force_new: bool = False):
         """Play the next song in queue"""

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -93,6 +93,7 @@ class YTMusic(commands.Cog):
     @app_commands.command(name="play", description="播放影片(網址或關鍵字) 或 刷新UI")
     async def play(self, interaction: discord.Interaction, query: Optional[str] = None):
         """播放音樂或刷新UI命令"""
+        await interaction.response.defer(ephemeral=True, thinking=True)
         guild_id = interaction.guild.id
         
         # 檢查使用者是否已在語音頻道
@@ -101,7 +102,7 @@ class YTMusic(commands.Cog):
                 self.lang_manager = self.bot.get_cog("LanguageManager")
             title = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "no_voice_channel")
             embed = discord.Embed(title=f"❌ | {title}", color=discord.Color.red())
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await interaction.followup.send(embed=embed, ephemeral=True)
             return
             
         # 連接至語音頻道
@@ -113,7 +114,7 @@ class YTMusic(commands.Cog):
                 await func.report_error(e, "music.py/play/channel.connect")
                 title = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "voice_connect_failed")
                 embed = discord.Embed(title=f"❌ | {title}", color=discord.Color.red())
-                await interaction.response.send_message(embed=embed, ephemeral=True)
+                await interaction.followup.send(embed=embed, ephemeral=True)
                 return
 
         # 如果沒有提供查詢，刷新UI
@@ -132,10 +133,10 @@ class YTMusic(commands.Cog):
                     self
                 )
                 refresh_message = self.lang_manager.translate(str(guild_id), "commands", "play", "responses", "refreshed_ui")
-                await interaction.response.send_message(refresh_message, ephemeral=True, delete_after=5)
+                await interaction.followup.send(refresh_message, ephemeral=True)
             else:
                 no_song_message = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "nothing_playing")
-                await interaction.response.send_message(no_song_message, ephemeral=True, delete_after=5)
+                await interaction.followup.send(no_song_message, ephemeral=True)
             return
 
         # 如果有提供查詢，將音樂加入播放清單
@@ -143,7 +144,6 @@ class YTMusic(commands.Cog):
         
         # 檢查是否為URL
         if "youtube.com" in query or "youtu.be" in query:
-            await interaction.response.defer(ephemeral=True)
             # 檢查是否為播放清單
             if "list" in query:
                 await self._handle_playlist(interaction, query)
@@ -159,7 +159,6 @@ class YTMusic(commands.Cog):
         voice_client = interaction.guild.voice_client
         if not voice_client.is_playing():
             await self.play_next(interaction)
-
     async def _handle_playlist(self, interaction: discord.Interaction, url: str):
         """Handle playlist URL"""
         guild_id = interaction.guild.id
@@ -239,7 +238,6 @@ class YTMusic(commands.Cog):
 
     async def _handle_search(self, interaction: discord.Interaction, query: str):
         """Handle search query"""
-        await interaction.response.defer(ephemeral=True, thinking=True)
         results = await self.youtube.search_videos(query)
         guild_id = interaction.guild.id
         if not results:


### PR DESCRIPTION
**What was found:** 
Users encounter "Interaction failed" errors when running the `/play` command if the bot takes longer than 3 seconds to connect to the voice channel or resolve YouTube search results. 

**Where it is:**
`cogs/music.py` lines 96-156

**Why it matters:** 
A timeout prevents the bot from playing the requested music and provides a poor, confusing user experience ("Interaction failed") instead of signalling that the bot is thinking/processing the request.

**What was done:** 
Moved the `await interaction.response.defer(ephemeral=True, thinking=True)` to the very beginning of the `play` command. Updated subsequent response calls inside `play` and `_handle_search` to use `interaction.followup.send` instead of `send_message`, and removed the `delete_after` keyword argument since it is not supported natively by `followup.send`. Removed redundant secondary deferral calls.

---
*PR created automatically by Jules for task [8573774366983817991](https://jules.google.com/task/8573774366983817991) started by @starpig1129*