### PR TITLE
[Perf] Add TTL cache to EpisodicMemoryProvider

### DIFF
--- a/llm/memory/episodic.py
+++ b/llm/memory/episodic.py
@@ -41,6 +41,10 @@ class EpisodicMemoryProvider:
     """
 
     def __init__(self, bot: Any, top_k: int = 3, max_chars: int = 1500, max_cache_size: int = 500, cache_ttl: float = 300.0) -> None:
+        if max_cache_size < 0:
+            raise ValueError("max_cache_size must be >= 0")
+        if cache_ttl < 0:
+            raise ValueError("cache_ttl must be >= 0")
         self.bot = bot
         self.top_k = top_k
         self.max_chars = max_chars
@@ -133,12 +137,15 @@ class EpisodicMemoryProvider:
             result = "\n".join(lines)
 
         async with self._lock:
-            self._cache[cache_key] = (result, now + self.cache_ttl)
+            now_insert = time.monotonic()
+            # Pop then reinsert to move updated entries to the end (FIFO eviction)
+            self._cache.pop(cache_key, None)
+            self._cache[cache_key] = (result, now_insert + self.cache_ttl)
 
             if len(self._cache) > self.max_cache_size:
                 # Prune expired entries first
-                self._cache = {k: v for k, v in self._cache.items() if v[1] > now}
-                # If still over limit, pop arbitrary items (since dict preserves insertion order, popping first item removes oldest)
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+                # If still over limit, pop oldest inserted items first
                 while len(self._cache) > self.max_cache_size:
                     oldest_key = next(iter(self._cache))
                     self._cache.pop(oldest_key)
@@ -159,5 +166,5 @@ class EpisodicMemoryProvider:
                 self._cache = {k: v for k, v in self._cache.items() if k[0] != channel_id}
             elif channel_id is not None and query is not None:
                 self._cache.pop((channel_id, query), None)
-            else: # query is not None and channel_id is None (unlikely, but handled)
+            else:  # query is not None and channel_id is None (unlikely, but handled)
                 self._cache = {k: v for k, v in self._cache.items() if k[1] != query}

--- a/llm/memory/episodic.py
+++ b/llm/memory/episodic.py
@@ -6,8 +6,10 @@ Silent failure design: any error returns None without raising.
 """
 from __future__ import annotations
 
+import asyncio
 import re
-from typing import TYPE_CHECKING, Any, Optional
+import time
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 import discord
 
@@ -34,12 +36,19 @@ class EpisodicMemoryProvider:
         bot: Discord bot instance (must have vector_manager attribute).
         top_k: Maximum number of fragments to retrieve. Default 3.
         max_chars: Hard character limit for the returned string. Default 1500.
+        max_cache_size: Maximum entries in the TTL cache. Default 500.
+        cache_ttl: Time-to-live for cache entries in seconds. Default 300.0.
     """
 
-    def __init__(self, bot: Any, top_k: int = 3, max_chars: int = 1500) -> None:
+    def __init__(self, bot: Any, top_k: int = 3, max_chars: int = 1500, max_cache_size: int = 500, cache_ttl: float = 300.0) -> None:
         self.bot = bot
         self.top_k = top_k
         self.max_chars = max_chars
+        self.max_cache_size = max_cache_size
+        self.cache_ttl = cache_ttl
+        # Key: (channel_id, query_text), Value: (formatted_string or None, expire_at)
+        self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
+        self._lock = asyncio.Lock()
 
     async def get(self, message: discord.Message) -> Optional[str]:
         """Return formatted episodic context string, or None if nothing relevant.
@@ -65,51 +74,90 @@ class EpisodicMemoryProvider:
         if len(query.split()) < _MIN_QUERY_TOKENS:
             return None
 
+        channel_id_str = str(message.channel.id)
+        cache_key = (channel_id_str, query)
+        now = time.monotonic()
+
+        async with self._lock:
+            entry = self._cache.get(cache_key)
+            if entry is not None and entry[1] > now:
+                return entry[0]
+
         try:
             fragments = await vector_manager.store.search_memories_by_vector(
                 query_text=query,
                 limit=self.top_k,
-                channel_id=str(message.channel.id),
+                channel_id=channel_id_str,
             )
         except Exception as e:
             await func.report_error(e, "EpisodicMemoryProvider.get: vector search failed")
             return None
 
         if not fragments:
-            return None
+            result = None
+        else:
+            lines = ["--- Relevant Past Memories ---"]
+            total_chars = len(lines[0])
 
-        lines = ["--- Relevant Past Memories ---"]
-        total_chars = len(lines[0])
+            for i, frag in enumerate(fragments, 1):
+                ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
+                jump_url = frag.metadata.get("jump_url")
 
-        for i, frag in enumerate(fragments, 1):
-            ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
-            jump_url = frag.metadata.get("jump_url")
-
-            # Build source label: prefer a Discord message link over plain timestamp
-            if jump_url and ts:
-                try:
-                    unix_ts = int(float(ts))
-                    source_str = f" [[來源 <t:{unix_ts}:R>]({jump_url})]"
-                except Exception:
+                # Build source label: prefer a Discord message link over plain timestamp
+                if jump_url and ts:
+                    try:
+                        unix_ts = int(float(ts))
+                        source_str = f" [[來源 <t:{unix_ts}:R>]({jump_url})]"
+                    except Exception:
+                        source_str = f" [[來源]({jump_url})]"
+                elif jump_url:
                     source_str = f" [[來源]({jump_url})]"
-            elif jump_url:
-                source_str = f" [[來源]({jump_url})]"
-            elif ts:
-                try:
-                    unix_ts = int(float(ts))
-                    source_str = f" [<t:{unix_ts}:R>]"
-                except Exception:
+                elif ts:
+                    try:
+                        unix_ts = int(float(ts))
+                        source_str = f" [<t:{unix_ts}:R>]"
+                    except Exception:
+                        source_str = ""
+                else:
                     source_str = ""
-            else:
-                source_str = ""
 
-            entry = f"[memory #{i}] {frag.content}{source_str}"
+                entry = f"[memory #{i}] {frag.content}{source_str}"
 
-            if total_chars + len(entry) + 1 > self.max_chars:
-                break
-            lines.append(entry)
-            total_chars += len(entry) + 1
+                if total_chars + len(entry) + 1 > self.max_chars:
+                    break
+                lines.append(entry)
+                total_chars += len(entry) + 1
 
-        lines.append("--- End Past Memories ---")
-        _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
-        return "\n".join(lines)
+            lines.append("--- End Past Memories ---")
+            _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
+            result = "\n".join(lines)
+
+        async with self._lock:
+            self._cache[cache_key] = (result, now + self.cache_ttl)
+
+            if len(self._cache) > self.max_cache_size:
+                # Prune expired entries first
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now}
+                # If still over limit, pop arbitrary items (since dict preserves insertion order, popping first item removes oldest)
+                while len(self._cache) > self.max_cache_size:
+                    oldest_key = next(iter(self._cache))
+                    self._cache.pop(oldest_key)
+
+        return result
+
+    async def invalidate(self, channel_id: Optional[str] = None, query: Optional[str] = None) -> None:
+        """Invalidate cache entries.
+
+        If both channel_id and query are provided, invalidates the exact match.
+        If only channel_id is provided, invalidates all queries for that channel.
+        If neither is provided, clears the entire cache.
+        """
+        async with self._lock:
+            if channel_id is None and query is None:
+                self._cache.clear()
+            elif channel_id is not None and query is None:
+                self._cache = {k: v for k, v in self._cache.items() if k[0] != channel_id}
+            elif channel_id is not None and query is not None:
+                self._cache.pop((channel_id, query), None)
+            else: # query is not None and channel_id is None (unlikely, but handled)
+                self._cache = {k: v for k, v in self._cache.items() if k[1] != query}

--- a/tests/test_episodic_memory.py
+++ b/tests/test_episodic_memory.py
@@ -1,0 +1,201 @@
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+project_root = Path(__file__).resolve().parent.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+# Provide required env vars so addons.tokens validation does not exit during import
+os.environ.setdefault("TOKEN", "test-token")
+os.environ.setdefault("CLIENT_ID", "123")
+os.environ.setdefault("CLIENT_SECRET_ID", "secret")
+os.environ.setdefault("SERCET_KEY", "secret-key")
+os.environ.setdefault("BUG_REPORT_CHANNEL_ID", "1")
+os.environ.setdefault("BOT_OWNER_ID", "1")
+
+from llm.memory.episodic import EpisodicMemoryProvider
+
+
+def _make_bot(search_results=None, search_calls_counter=None):
+    """Build a minimal bot stub with a vector_manager that records calls."""
+    if search_results is None:
+        search_results = []
+
+    async def fake_search(query_text, limit, channel_id):
+        if search_calls_counter is not None:
+            search_calls_counter["n"] += 1
+        return search_results
+
+    store = MagicMock()
+    store.search_memories_by_vector = fake_search
+    vector_manager = MagicMock()
+    vector_manager.store = store
+    bot = MagicMock()
+    bot.vector_manager = vector_manager
+    return bot
+
+
+def _make_message(content="hello world this is a test message", channel_id="100"):
+    msg = MagicMock()
+    msg.content = content
+    msg.channel.id = channel_id
+    return msg
+
+
+def test_negative_max_cache_size_raises():
+    bot = _make_bot()
+    with pytest.raises(ValueError, match="max_cache_size"):
+        EpisodicMemoryProvider(bot, max_cache_size=-1)
+
+
+def test_negative_cache_ttl_raises():
+    bot = _make_bot()
+    with pytest.raises(ValueError, match="cache_ttl"):
+        EpisodicMemoryProvider(bot, cache_ttl=-1.0)
+
+
+def test_cache_hit_avoids_vector_search():
+    """A second identical query within TTL should not trigger another vector search."""
+    counter = {"n": 0}
+    frag = MagicMock()
+    frag.content = "some memory"
+    frag.metadata = {}
+    bot = _make_bot(search_results=[frag], search_calls_counter=counter)
+    provider = EpisodicMemoryProvider(bot, cache_ttl=60.0)
+
+    async def run():
+        msg = _make_message()
+        result1 = await provider.get(msg)
+        assert result1 is not None
+        assert counter["n"] == 1
+
+        result2 = await provider.get(msg)
+        assert result2 == result1
+        assert counter["n"] == 1  # no new search
+
+    asyncio.run(run())
+
+
+def test_ttl_expiry_re_queries():
+    """After TTL expiry, a repeated query should trigger a new vector search."""
+    counter = {"n": 0}
+    frag = MagicMock()
+    frag.content = "some memory"
+    frag.metadata = {}
+    bot = _make_bot(search_results=[frag], search_calls_counter=counter)
+    provider = EpisodicMemoryProvider(bot, cache_ttl=0.05)
+
+    async def run():
+        msg = _make_message()
+        await provider.get(msg)
+        assert counter["n"] == 1
+
+        # Within TTL: cache hit
+        await provider.get(msg)
+        assert counter["n"] == 1
+
+        # After TTL expiry: cache miss, re-queries
+        await asyncio.sleep(0.07)
+        await provider.get(msg)
+        assert counter["n"] == 2
+
+    asyncio.run(run())
+
+
+def test_max_size_eviction():
+    """Cache should not exceed max_cache_size entries."""
+    counter = {"n": 0}
+    frag = MagicMock()
+    frag.content = "memory"
+    frag.metadata = {}
+    bot = _make_bot(search_results=[frag], search_calls_counter=counter)
+    max_size = 3
+    provider = EpisodicMemoryProvider(bot, max_cache_size=max_size, cache_ttl=60.0)
+
+    async def run():
+        for i in range(max_size + 5):
+            msg = _make_message(
+                content=f"hello world this is message number {i}",
+                channel_id="100",
+            )
+            await provider.get(msg)
+
+        assert len(provider._cache) <= max_size
+
+    asyncio.run(run())
+
+
+def test_invalidate_single_entry():
+    """invalidate with both channel_id and query removes the exact entry."""
+    counter = {"n": 0}
+    frag = MagicMock()
+    frag.content = "memory"
+    frag.metadata = {}
+    bot = _make_bot(search_results=[frag], search_calls_counter=counter)
+    provider = EpisodicMemoryProvider(bot, cache_ttl=60.0)
+
+    async def run():
+        msg = _make_message(content="hello world this is a test message", channel_id="42")
+        await provider.get(msg)
+        assert counter["n"] == 1
+
+        await provider.invalidate(channel_id="42", query="hello world this is a test message")
+
+        # Cache is gone; next call re-queries
+        await provider.get(msg)
+        assert counter["n"] == 2
+
+    asyncio.run(run())
+
+
+def test_invalidate_channel_clears_all_channel_entries():
+    """invalidate with only channel_id removes all entries for that channel."""
+    frag = MagicMock()
+    frag.content = "memory"
+    frag.metadata = {}
+    bot = _make_bot(search_results=[frag])
+    provider = EpisodicMemoryProvider(bot, cache_ttl=60.0)
+
+    async def run():
+        for suffix in ["one two three four", "five six seven eight"]:
+            await provider.get(_make_message(content=suffix, channel_id="99"))
+
+        # Also populate a different channel
+        await provider.get(_make_message(content="alpha beta gamma delta", channel_id="55"))
+
+        assert any(k[0] == "99" for k in provider._cache)
+        assert any(k[0] == "55" for k in provider._cache)
+
+        await provider.invalidate(channel_id="99")
+
+        assert not any(k[0] == "99" for k in provider._cache)
+        assert any(k[0] == "55" for k in provider._cache)
+
+    asyncio.run(run())
+
+
+def test_invalidate_all_clears_entire_cache():
+    """invalidate with no arguments clears the entire cache."""
+    frag = MagicMock()
+    frag.content = "memory"
+    frag.metadata = {}
+    bot = _make_bot(search_results=[frag])
+    provider = EpisodicMemoryProvider(bot, cache_ttl=60.0)
+
+    async def run():
+        for ch in ["1", "2", "3"]:
+            await provider.get(_make_message(channel_id=ch))
+
+        assert len(provider._cache) > 0
+
+        await provider.invalidate()
+
+        assert len(provider._cache) == 0
+
+    asyncio.run(run())


### PR DESCRIPTION
### What
The `EpisodicMemoryProvider` fetched context using vector searches for every incoming message without caching, leading to potentially redundant external database or API calls for identical or highly frequent interactions.

### Where
`llm/memory/episodic.py` in the `EpisodicMemoryProvider` initialization and the `get` method.

### Why
Repeated semantic searches for identical messages in the same channel are slow and consume unnecessary API quota or local resources. Introducing a TTL cache mirroring `ProceduralMemoryProvider` resolves this bottleneck.

### What was done
1. Added an in-memory dictionary `_cache` mapped to `(channel_id, query_text)`.
2. Implemented an async lock (`asyncio.Lock`) to ensure safe concurrency across the discord bot's event loops.
3. Added `max_cache_size` and `cache_ttl` arguments initialized to `500` and `300.0` seconds respectively.
4. If a valid, non-expired cache entry exists, it skips the vector search and returns early.
5. Implemented `invalidate` method to allow explicit dropping of specific cache segments when required.

---
*PR created automatically by Jules for task [5917291331018834470](https://jules.google.com/task/5917291331018834470) started by @starpig1129*