### PR TITLE
[Perf] Fetch author procedural memory concurrently with short-term messages

### DIFF
--- a/llm/context_manager.py
+++ b/llm/context_manager.py
@@ -49,20 +49,44 @@ class ContextManager:
         """
 
         async def _fetch_short_term_and_procedural() -> Tuple[ProceduralMemory, List[BaseMessage]]:
-            # 1) Fetch short-term messages
-            short_term_msgs: List[BaseMessage] = []
+            # Extract author ID early to kick off parallel fetch
+            author_ids = []
             try:
-                short_term_msgs = await self.short_term_provider.get(message)
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:
-                # Report and continue with safe fallback per design
-                asyncio.create_task(
-                    func.report_error(e, "ContextManager.get_context: short_term_provider.get failed")
-                )
-                _LOGGER.error("short_term_provider.get failed", exception=e)
+                fallback_author_id = getattr(getattr(message, "author", None), "id", None)
+                if fallback_author_id is not None:
+                    author_ids.append(str(fallback_author_id))
+            except Exception:
+                pass
 
-            # 2) Extract user ids to fetch procedural memory
+            # 1) Fetch short-term messages AND author's procedural memory concurrently
+            # This hides the DB latency of the author's profile lookup behind the Discord API call
+            async def _safe_short_term():
+                try:
+                    return await self.short_term_provider.get(message)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    asyncio.create_task(
+                        func.report_error(e, "ContextManager.get_context: short_term_provider.get failed")
+                    )
+                    _LOGGER.error("short_term_provider.get failed", exception=e)
+                    return []
+
+            async def _safe_author_procedural():
+                if not author_ids:
+                    return ProceduralMemory(user_info={})
+                try:
+                    return await self.procedural_provider.get(author_ids)
+                except Exception:
+                    # Ignore errors here; they will be handled in step 3
+                    return ProceduralMemory(user_info={})
+
+            short_term_msgs, _ = await asyncio.gather(
+                _safe_short_term(),
+                _safe_author_procedural()
+            )
+
+            # 2) Extract all user ids from the fetched short-term messages
             try:
                 user_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
             except asyncio.CancelledError:
@@ -72,16 +96,10 @@ class ContextManager:
                     func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
                 )
                 _LOGGER.error("extract_user_ids failed", exception=e)
-                user_ids = []
-                try:
-                    fallback_author_id = getattr(getattr(message, "author", None), "id", None)
-                    if fallback_author_id is not None:
-                        user_ids.append(str(fallback_author_id))
-                except Exception:
-                    # Best-effort fallback; proceed with empty user_ids
-                    pass
+                user_ids = author_ids
 
-            # 3) Fetch procedural memory
+            # 3) Fetch procedural memory for ALL users involved
+            # The author's profile is now cached, so this is instantaneous if no other users are found
             try:
                 procedural_memory = await self.procedural_provider.get(user_ids)
             except asyncio.CancelledError:

--- a/llm/context_manager.py
+++ b/llm/context_manager.py
@@ -77,11 +77,13 @@ class ContextManager:
                     return ProceduralMemory(user_info={})
                 try:
                     return await self.procedural_provider.get(author_ids)
+                except asyncio.CancelledError:
+                    raise
                 except Exception:
                     # Ignore errors here; they will be handled in step 3
                     return ProceduralMemory(user_info={})
 
-            short_term_msgs, _ = await asyncio.gather(
+            short_term_msgs, author_procedural_memory = await asyncio.gather(
                 _safe_short_term(),
                 _safe_author_procedural()
             )
@@ -98,18 +100,22 @@ class ContextManager:
                 _LOGGER.error("extract_user_ids failed", exception=e)
                 user_ids = author_ids
 
-            # 3) Fetch procedural memory for ALL users involved
-            # The author's profile is now cached, so this is instantaneous if no other users are found
-            try:
-                procedural_memory = await self.procedural_provider.get(user_ids)
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:
-                asyncio.create_task(
-                    func.report_error(e, "ContextManager.get_context: procedural_provider.get failed")
-                )
-                _LOGGER.error("procedural_provider.get failed", exception=e)
-                procedural_memory = ProceduralMemory(user_info={})
+            # 3) Fetch procedural memory for ALL users involved.
+            # If user_ids is exactly the author set (already prefetched), reuse the cached result
+            # to avoid a redundant provider call.
+            if set(user_ids) == set(author_ids):
+                procedural_memory = author_procedural_memory
+            else:
+                try:
+                    procedural_memory = await self.procedural_provider.get(user_ids)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    asyncio.create_task(
+                        func.report_error(e, "ContextManager.get_context: procedural_provider.get failed")
+                    )
+                    _LOGGER.error("procedural_provider.get failed", exception=e)
+                    procedural_memory = ProceduralMemory(user_info={})
 
             return procedural_memory, short_term_msgs
 

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -79,6 +79,15 @@ class _DummySQLiteUserManager:
 fake_cogs_memory_users_manager.SQLiteUserManager = _DummySQLiteUserManager
 sys.modules["cogs.memory.users.manager"] = fake_cogs_memory_users_manager
 
+fake_cogs_memory_db = types.ModuleType("cogs.memory.db")
+fake_cogs_memory_db.__path__ = []
+sys.modules["cogs.memory.db"] = fake_cogs_memory_db
+
+fake_cogs_memory_db_knowledge_storage = types.ModuleType("cogs.memory.db.knowledge_storage")
+fake_cogs_memory_db_knowledge_storage.KnowledgeStorage = object
+sys.modules["cogs.memory.db.knowledge_storage"] = fake_cogs_memory_db_knowledge_storage
+
+
 import llm.context_manager as context_manager
 from llm.context_manager import ContextManager
 from llm.memory.schema import ProceduralMemory, UserInfo

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -109,8 +109,10 @@ class StubShortTermProvider:
 class StubProceduralProvider:
     def __init__(self):
         self.requested_ids = None
+        self.call_count = 0
 
     async def get(self, user_ids):
+        self.call_count += 1
         self.requested_ids = list(user_ids)
         return ProceduralMemory(
             user_info={uid: UserInfo(user_background="bg") for uid in user_ids}
@@ -166,3 +168,19 @@ async def test_short_term_cancellation_propagates(monkeypatch):
 
     with pytest.raises(asyncio.CancelledError):
         await manager.get_context(_make_message())
+
+
+@pytest.mark.asyncio
+async def test_author_only_reuses_prefetch_skips_second_call(monkeypatch):
+    """When user_ids extracted equals author_ids, the prefetched result is reused
+    and procedural_provider.get is called only once (for the prefetch)."""
+    monkeypatch.setattr(context_manager, "func", types.SimpleNamespace(report_error=_noop_report_error))
+    short_term_provider = StubShortTermProvider(messages=[])
+    procedural_provider = StubProceduralProvider()
+    manager = ContextManager(short_term_provider, procedural_provider, episodic_provider=None)
+
+    procedural_str, _ = await manager.get_context(_make_message("789"))
+
+    assert procedural_provider.call_count == 1
+    assert procedural_provider.requested_ids == ["789"]
+    assert "User: 789" in procedural_str


### PR DESCRIPTION
**What**
The bot experienced latency in message processing because it waited to fetch short-term messages before fetching any user profiles (procedural memory).

**Where**
`llm/context_manager.py` in the `_fetch_short_term_and_procedural` method.

**Why**
Procedural memory fetching blocks the context injection step. Since `ProceduralMemoryProvider` uses a TTL cache, pre-fetching the immediate message author's profile hides the database/API latency behind the Discord API call for short-term messages.

**What was done**
Refactored `_fetch_short_term_and_procedural` to extract the author's ID early and fetch their procedural profile using `asyncio.gather` alongside the short-term messages fetch. Then, after extracting all user IDs from the short-term messages via `_extract_user_ids_from_messages`, it calls `procedural_provider.get` again to fetch the rest. The initial fetch warms the TTL cache for the author, making the secondary lookup instantaneous for them. Tested with `pytest` locally.

---
*PR created automatically by Jules for task [13087600296318132470](https://jules.google.com/task/13087600296318132470) started by @starpig1129*