### PR TITLE
[Perf] Add TTL cache to EpisodicMemoryProvider

### DIFF
--- a/llm/memory/episodic.py
+++ b/llm/memory/episodic.py
@@ -41,12 +41,18 @@ class EpisodicMemoryProvider:
     """
 
     def __init__(self, bot: Any, top_k: int = 3, max_chars: int = 1500, ttl_seconds: float = 300.0, max_cache_size: int = 1000) -> None:
+        if max_cache_size < 0:
+            raise ValueError("max_cache_size must be >= 0")
+        if ttl_seconds < 0:
+            raise ValueError("ttl_seconds must be >= 0")
         self.bot = bot
         self.top_k = top_k
         self.max_chars = max_chars
         self.ttl_seconds = ttl_seconds
         self.max_cache_size = max_cache_size
         self._cache: Dict[str, Tuple[Optional[str], float]] = {}
+        # Per-key in-flight futures to prevent cache stampede
+        self._inflight: Dict[str, "asyncio.Future[Optional[str]]"] = {}
         self._lock = asyncio.Lock()
 
     async def get(self, message: discord.Message) -> Optional[str]:
@@ -77,70 +83,94 @@ class EpisodicMemoryProvider:
         cache_key = f"{channel_id}:{query}"
         now = time.monotonic()
 
-        async with self._lock:
-            entry = self._cache.get(cache_key)
-            if entry is not None and entry[1] > now:
-                return entry[0]
+        await_fut: Optional["asyncio.Future[Optional[str]]"] = None
+        my_fut: Optional["asyncio.Future[Optional[str]]"] = None
 
+        async with self._lock:
+            cached = self._cache.get(cache_key)
+            if cached is not None and cached[1] > now:
+                return cached[0]
+
+            if cache_key in self._inflight:
+                # Another coroutine is already fetching this key; wait for it
+                await_fut = self._inflight[cache_key]
+            else:
+                # We are the owner of this fetch
+                my_fut = asyncio.get_running_loop().create_future()
+                self._inflight[cache_key] = my_fut
+
+        if await_fut is not None:
+            return await await_fut
+
+        # We are the owner: perform the vector search and resolve waiters when done
+        result_str: Optional[str] = None
         try:
-            fragments = await vector_manager.store.search_memories_by_vector(
-                query_text=query,
-                limit=self.top_k,
-                channel_id=channel_id,
-            )
-        except Exception as e:
-            await func.report_error(e, "EpisodicMemoryProvider.get: vector search failed")
-            return None
+            try:
+                fragments = await vector_manager.store.search_memories_by_vector(
+                    query_text=query,
+                    limit=self.top_k,
+                    channel_id=channel_id,
+                )
+            except Exception as e:
+                await func.report_error(e, "EpisodicMemoryProvider.get: vector search failed")
+                fragments = []
 
-        result_str = None
-        if fragments:
+            if fragments:
+                lines = ["--- Relevant Past Memories ---"]
+                total_chars = len(lines[0])
 
-            lines = ["--- Relevant Past Memories ---"]
-            total_chars = len(lines[0])
+                for i, frag in enumerate(fragments, 1):
+                    ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
+                    jump_url = frag.metadata.get("jump_url")
 
-            for i, frag in enumerate(fragments, 1):
-                ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
-                jump_url = frag.metadata.get("jump_url")
-
-                # Build source label: prefer a Discord message link over plain timestamp
-                if jump_url and ts:
-                    try:
-                        unix_ts = int(float(ts))
-                        source_str = f" [[來源 <t:{unix_ts}:R>]({jump_url})]"
-                    except Exception:
+                    # Build source label: prefer a Discord message link over plain timestamp
+                    if jump_url and ts:
+                        try:
+                            unix_ts = int(float(ts))
+                            source_str = f" [[來源 <t:{unix_ts}:R>]({jump_url})]"
+                        except Exception:
+                            source_str = f" [[來源]({jump_url})]"
+                    elif jump_url:
                         source_str = f" [[來源]({jump_url})]"
-                elif jump_url:
-                    source_str = f" [[來源]({jump_url})]"
-                elif ts:
-                    try:
-                        unix_ts = int(float(ts))
-                        source_str = f" [<t:{unix_ts}:R>]"
-                    except Exception:
+                    elif ts:
+                        try:
+                            unix_ts = int(float(ts))
+                            source_str = f" [<t:{unix_ts}:R>]"
+                        except Exception:
+                            source_str = ""
+                    else:
                         source_str = ""
-                else:
-                    source_str = ""
 
-                entry = f"[memory #{i}] {frag.content}{source_str}"
+                    entry_line = f"[memory #{i}] {frag.content}{source_str}"
 
-                if total_chars + len(entry) + 1 > self.max_chars:
-                    break
-                lines.append(entry)
-                total_chars += len(entry) + 1
+                    if total_chars + len(entry_line) + 1 > self.max_chars:
+                        break
+                    lines.append(entry_line)
+                    total_chars += len(entry_line) + 1
 
-            lines.append("--- End Past Memories ---")
-            _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
-            result_str = "\n".join(lines)
+                lines.append("--- End Past Memories ---")
+                _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
+                result_str = "\n".join(lines)
 
-        expire_at = time.monotonic() + self.ttl_seconds
-        async with self._lock:
-            self._cache[cache_key] = (result_str, expire_at)
+            # Cache positive results only; misses are not cached so fresh data can be
+            # picked up on the next call without waiting for TTL expiry.
+            if result_str is not None:
+                expire_at = time.monotonic() + self.ttl_seconds
+                async with self._lock:
+                    self._cache[cache_key] = (result_str, expire_at)
 
-            if len(self._cache) > self.max_cache_size:
-                now_insert = time.monotonic()
-                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+                    if len(self._cache) > self.max_cache_size:
+                        now_insert = time.monotonic()
+                        self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
 
-                while len(self._cache) > self.max_cache_size:
-                    oldest_key = next(iter(self._cache))
-                    self._cache.pop(oldest_key)
+                        while len(self._cache) > self.max_cache_size:
+                            oldest_key = next(iter(self._cache))
+                            self._cache.pop(oldest_key)
+        finally:
+            # Always resolve the in-flight future so waiting coroutines are unblocked
+            async with self._lock:
+                self._inflight.pop(cache_key, None)
+            if my_fut is not None and not my_fut.done():
+                my_fut.set_result(result_str)
 
         return result_str

--- a/llm/memory/episodic.py
+++ b/llm/memory/episodic.py
@@ -7,7 +7,9 @@ Silent failure design: any error returns None without raising.
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any, Optional
+import time
+import asyncio
+from typing import TYPE_CHECKING, Any, Optional, Dict, Tuple
 
 import discord
 
@@ -34,12 +36,18 @@ class EpisodicMemoryProvider:
         bot: Discord bot instance (must have vector_manager attribute).
         top_k: Maximum number of fragments to retrieve. Default 3.
         max_chars: Hard character limit for the returned string. Default 1500.
+        ttl_seconds: Cache time-to-live in seconds. Default 300.0.
+        max_cache_size: Maximum cache size. Default 1000.
     """
 
-    def __init__(self, bot: Any, top_k: int = 3, max_chars: int = 1500) -> None:
+    def __init__(self, bot: Any, top_k: int = 3, max_chars: int = 1500, ttl_seconds: float = 300.0, max_cache_size: int = 1000) -> None:
         self.bot = bot
         self.top_k = top_k
         self.max_chars = max_chars
+        self.ttl_seconds = ttl_seconds
+        self.max_cache_size = max_cache_size
+        self._cache: Dict[str, Tuple[Optional[str], float]] = {}
+        self._lock = asyncio.Lock()
 
     async def get(self, message: discord.Message) -> Optional[str]:
         """Return formatted episodic context string, or None if nothing relevant.
@@ -65,51 +73,74 @@ class EpisodicMemoryProvider:
         if len(query.split()) < _MIN_QUERY_TOKENS:
             return None
 
+        channel_id = str(message.channel.id)
+        cache_key = f"{channel_id}:{query}"
+        now = time.monotonic()
+
+        async with self._lock:
+            entry = self._cache.get(cache_key)
+            if entry is not None and entry[1] > now:
+                return entry[0]
+
         try:
             fragments = await vector_manager.store.search_memories_by_vector(
                 query_text=query,
                 limit=self.top_k,
-                channel_id=str(message.channel.id),
+                channel_id=channel_id,
             )
         except Exception as e:
             await func.report_error(e, "EpisodicMemoryProvider.get: vector search failed")
             return None
 
-        if not fragments:
-            return None
+        result_str = None
+        if fragments:
 
-        lines = ["--- Relevant Past Memories ---"]
-        total_chars = len(lines[0])
+            lines = ["--- Relevant Past Memories ---"]
+            total_chars = len(lines[0])
 
-        for i, frag in enumerate(fragments, 1):
-            ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
-            jump_url = frag.metadata.get("jump_url")
+            for i, frag in enumerate(fragments, 1):
+                ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
+                jump_url = frag.metadata.get("jump_url")
 
-            # Build source label: prefer a Discord message link over plain timestamp
-            if jump_url and ts:
-                try:
-                    unix_ts = int(float(ts))
-                    source_str = f" [[來源 <t:{unix_ts}:R>]({jump_url})]"
-                except Exception:
+                # Build source label: prefer a Discord message link over plain timestamp
+                if jump_url and ts:
+                    try:
+                        unix_ts = int(float(ts))
+                        source_str = f" [[來源 <t:{unix_ts}:R>]({jump_url})]"
+                    except Exception:
+                        source_str = f" [[來源]({jump_url})]"
+                elif jump_url:
                     source_str = f" [[來源]({jump_url})]"
-            elif jump_url:
-                source_str = f" [[來源]({jump_url})]"
-            elif ts:
-                try:
-                    unix_ts = int(float(ts))
-                    source_str = f" [<t:{unix_ts}:R>]"
-                except Exception:
+                elif ts:
+                    try:
+                        unix_ts = int(float(ts))
+                        source_str = f" [<t:{unix_ts}:R>]"
+                    except Exception:
+                        source_str = ""
+                else:
                     source_str = ""
-            else:
-                source_str = ""
 
-            entry = f"[memory #{i}] {frag.content}{source_str}"
+                entry = f"[memory #{i}] {frag.content}{source_str}"
 
-            if total_chars + len(entry) + 1 > self.max_chars:
-                break
-            lines.append(entry)
-            total_chars += len(entry) + 1
+                if total_chars + len(entry) + 1 > self.max_chars:
+                    break
+                lines.append(entry)
+                total_chars += len(entry) + 1
 
-        lines.append("--- End Past Memories ---")
-        _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
-        return "\n".join(lines)
+            lines.append("--- End Past Memories ---")
+            _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
+            result_str = "\n".join(lines)
+
+        expire_at = time.monotonic() + self.ttl_seconds
+        async with self._lock:
+            self._cache[cache_key] = (result_str, expire_at)
+
+            if len(self._cache) > self.max_cache_size:
+                now_insert = time.monotonic()
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+
+                while len(self._cache) > self.max_cache_size:
+                    oldest_key = next(iter(self._cache))
+                    self._cache.pop(oldest_key)
+
+        return result_str

--- a/tests/test_episodic_memory.py
+++ b/tests/test_episodic_memory.py
@@ -1,0 +1,203 @@
+"""Unit tests for EpisodicMemoryProvider TTL cache behaviour."""
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+from typing import List, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+project_root = Path(__file__).resolve().parent.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+# Provide required env vars so addons.tokens validation does not exit during import
+os.environ.setdefault("TOKEN", "test-token")
+os.environ.setdefault("CLIENT_ID", "123")
+os.environ.setdefault("CLIENT_SECRET_ID", "secret")
+os.environ.setdefault("SERCET_KEY", "secret-key")
+os.environ.setdefault("BUG_REPORT_CHANNEL_ID", "1")
+os.environ.setdefault("BOT_OWNER_ID", "1")
+
+from llm.memory.episodic import EpisodicMemoryProvider
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _Fragment:
+    """Minimal stand-in for a vector search result fragment."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.metadata: dict = {}
+
+
+def _make_message(channel_id: str = "42", content: str = "tell me about the history of rockets") -> MagicMock:
+    msg = MagicMock()
+    msg.content = content
+    msg.channel.id = channel_id
+    return msg
+
+
+def _make_bot(fragments: Optional[List[_Fragment]] = None, *, call_count_box: Optional[list] = None) -> MagicMock:
+    """Build a bot stub whose vector_manager returns *fragments* on each search."""
+
+    async def _search(**_kwargs):
+        if call_count_box is not None:
+            call_count_box[0] += 1
+        return fragments or []
+
+    store = MagicMock()
+    store.search_memories_by_vector = _search
+    vector_manager = MagicMock()
+    vector_manager.store = store
+    bot = MagicMock()
+    bot.vector_manager = vector_manager
+    return bot
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_cache_hit_within_ttl():
+    """Second call within TTL should return cached value without a new search."""
+    call_count = [0]
+    fragments = [_Fragment("rockets were invented in China")]
+    bot = _make_bot(fragments, call_count_box=call_count)
+    provider = EpisodicMemoryProvider(bot, ttl_seconds=60)
+    msg = _make_message()
+
+    async def run():
+        result1 = await provider.get(msg)
+        result2 = await provider.get(msg)
+        assert result1 is not None
+        assert result2 == result1
+        assert call_count[0] == 1  # vector search called only once
+
+    asyncio.run(run())
+
+
+def test_cache_expires_and_refetches():
+    """After TTL expiry, a subsequent call should trigger a new vector search."""
+    call_count = [0]
+    fragments = [_Fragment("rockets were invented in China")]
+    bot = _make_bot(fragments, call_count_box=call_count)
+    provider = EpisodicMemoryProvider(bot, ttl_seconds=0.05)
+    msg = _make_message()
+
+    async def run():
+        await provider.get(msg)
+        assert call_count[0] == 1
+
+        # Within TTL: cache should be hit
+        await provider.get(msg)
+        assert call_count[0] == 1
+
+        # After TTL: cache entry should be expired
+        await asyncio.sleep(0.07)
+        await provider.get(msg)
+        assert call_count[0] == 2
+
+    asyncio.run(run())
+
+
+def test_miss_not_cached():
+    """Results for empty fragment lists (None) should NOT be cached."""
+    call_count = [0]
+    bot = _make_bot(fragments=[], call_count_box=call_count)
+    provider = EpisodicMemoryProvider(bot, ttl_seconds=60)
+    msg = _make_message()
+
+    async def run():
+        result = await provider.get(msg)
+        assert result is None
+        assert len(provider._cache) == 0  # nothing cached
+
+        # Second call should also hit the vector search (not a stale None)
+        await provider.get(msg)
+        assert call_count[0] == 2
+
+    asyncio.run(run())
+
+
+def test_max_cache_size_evicts_entries():
+    """Cache size must not exceed max_cache_size; oldest entries are evicted."""
+    call_count = [0]
+    fragments = [_Fragment("content")]
+    bot = _make_bot(fragments, call_count_box=call_count)
+    max_size = 3
+    provider = EpisodicMemoryProvider(bot, ttl_seconds=60, max_cache_size=max_size)
+
+    async def run():
+        for i in range(max_size + 2):
+            msg = _make_message(channel_id=str(i), content="tell me about the history of rockets")
+            await provider.get(msg)
+
+        assert len(provider._cache) <= max_size
+
+    asyncio.run(run())
+
+
+def test_max_cache_size_prunes_expired_entries_first():
+    """Expired entries should be pruned before evicting live entries."""
+    call_count = [0]
+    fragments = [_Fragment("content")]
+    bot = _make_bot(fragments, call_count_box=call_count)
+    provider = EpisodicMemoryProvider(bot, ttl_seconds=0.05, max_cache_size=3)
+
+    async def run():
+        for i in range(3):
+            msg = _make_message(channel_id=str(i), content="tell me about the history of rockets")
+            await provider.get(msg)
+
+        await asyncio.sleep(0.1)  # let those entries expire
+
+        for i in range(10, 14):
+            msg = _make_message(channel_id=str(i), content="tell me about the history of rockets")
+            await provider.get(msg)
+
+        assert len(provider._cache) <= 3
+
+    asyncio.run(run())
+
+
+def test_negative_max_cache_size_raises():
+    """Passing a negative max_cache_size should raise ValueError."""
+    bot = _make_bot()
+    with pytest.raises(ValueError, match=r"max_cache_size"):
+        EpisodicMemoryProvider(bot, max_cache_size=-1)
+
+
+def test_negative_ttl_seconds_raises():
+    """Passing a negative ttl_seconds should raise ValueError."""
+    bot = _make_bot()
+    with pytest.raises(ValueError, match=r"ttl_seconds"):
+        EpisodicMemoryProvider(bot, ttl_seconds=-1.0)
+
+
+def test_stampede_prevention():
+    """Concurrent calls for the same key should only trigger one vector search."""
+    call_count = [0]
+    fragments = [_Fragment("rockets were invented in China")]
+    bot = _make_bot(fragments, call_count_box=call_count)
+    provider = EpisodicMemoryProvider(bot, ttl_seconds=60)
+    msg = _make_message()
+
+    async def run():
+        results = await asyncio.gather(
+            provider.get(msg),
+            provider.get(msg),
+            provider.get(msg),
+        )
+        # All concurrent callers should receive the same non-None result
+        assert all(r is not None for r in results)
+        assert results[0] == results[1] == results[2]
+        # Vector search should have been called exactly once
+        assert call_count[0] == 1
+
+    asyncio.run(run())


### PR DESCRIPTION
**What** was found
The `EpisodicMemoryProvider` lacked an in-memory TTL cache, resulting in redundant vector searches for recent identical queries within the same channel. This constraint was hinted at as a priority extension.

**Where** it is
`llm/memory/episodic.py` around line 36.

**Why** it matters
Without a cache, every message triggering episodic memory triggers a full search query, potentially putting heavy read loads on the vector database for identical contexts and queries.

**What was done**
Implemented a fast and fully thread-safe (via `asyncio.Lock`) TTL cache bound to `(channel_id, query)`. Expired results are fetched again and re-cached, saving operations. Sized using an FIFO bounds check algorithm.

---
*PR created automatically by Jules for task [13131718209555584925](https://jules.google.com/task/13131718209555584925) started by @starpig1129*