### PR TITLE
[Perf] Pre-fetch author procedural memory concurrently

### DIFF
--- a/llm/context_manager.py
+++ b/llm/context_manager.py
@@ -49,11 +49,26 @@ class ContextManager:
         """
 
         async def _fetch_short_term_and_procedural() -> Tuple[ProceduralMemory, List[BaseMessage]]:
-            # 1) Fetch short-term messages
+            # 1) Pre-fetch author procedural memory to warm the TTL cache concurrently with short term messages
+            author_id = None
+            prefetch_task = None
+            try:
+                if getattr(message, "author", None) is not None:
+                    aid = getattr(message.author, "id", None)
+                    if aid is not None:
+                        author_id = str(aid)
+                        # Fire and forget to warm cache; we will await the final result later
+                        prefetch_task = asyncio.create_task(self.procedural_provider.get([author_id]))
+            except Exception:
+                pass
+
+            # 2) Fetch short-term messages
             short_term_msgs: List[BaseMessage] = []
             try:
                 short_term_msgs = await self.short_term_provider.get(message)
             except asyncio.CancelledError:
+                if prefetch_task:
+                    prefetch_task.cancel()
                 raise
             except Exception as e:
                 # Report and continue with safe fallback per design
@@ -62,7 +77,14 @@ class ContextManager:
                 )
                 _LOGGER.error("short_term_provider.get failed", exception=e)
 
-            # 2) Extract user ids to fetch procedural memory
+            # Ensure prefetch completes before we proceed to main procedural fetch
+            if prefetch_task:
+                try:
+                    await prefetch_task
+                except Exception:
+                    pass
+
+            # 3) Extract user ids to fetch procedural memory
             try:
                 user_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
             except asyncio.CancelledError:
@@ -81,7 +103,7 @@ class ContextManager:
                     # Best-effort fallback; proceed with empty user_ids
                     pass
 
-            # 3) Fetch procedural memory
+            # 4) Fetch procedural memory (this will hit TTL cache for author)
             try:
                 procedural_memory = await self.procedural_provider.get(user_ids)
             except asyncio.CancelledError:

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -79,6 +79,15 @@ class _DummySQLiteUserManager:
 fake_cogs_memory_users_manager.SQLiteUserManager = _DummySQLiteUserManager
 sys.modules["cogs.memory.users.manager"] = fake_cogs_memory_users_manager
 
+fake_cogs_memory_db = types.ModuleType("cogs.memory.db")
+fake_cogs_memory_db.__path__ = []
+sys.modules["cogs.memory.db"] = fake_cogs_memory_db
+fake_cogs_memory_db_knowledge_storage = types.ModuleType("cogs.memory.db.knowledge_storage")
+class _DummyKnowledgeStorage:
+    pass
+fake_cogs_memory_db_knowledge_storage.KnowledgeStorage = _DummyKnowledgeStorage
+sys.modules["cogs.memory.db.knowledge_storage"] = fake_cogs_memory_db_knowledge_storage
+
 import llm.context_manager as context_manager
 from llm.context_manager import ContextManager
 from llm.memory.schema import ProceduralMemory, UserInfo


### PR DESCRIPTION
1. **What**: The context manager was sequentially fetching short-term messages and then procedural memory profiles, adding unnecessary latency.
2. **Where**: `llm/context_manager.py`, inside `_fetch_short_term_and_procedural`.
3. **Why**: Fetching procedural memory for the message author sequentially after short-term messages blocks the request pipeline unecessarily when they can be run concurrently. By warming the procedural memory cache with the author's ID, the bot responds faster as the main procedural memory fetch will hit the cache.
4. **What was done**: Extracted the author's ID early and spun up a fire-and-forget `asyncio.create_task` to preemptively fetch their procedural profile while awaiting short-term messages. Also handled task cancellation and exception fallback gracefully.

Tests passed successfully via `python3 -m pytest tests/`.

---
*PR created automatically by Jules for task [17188420757346247454](https://jules.google.com/task/17188420757346247454) started by @starpig1129*