### PR TITLE
[Perf] Add TTL cache to EpisodicMemoryProvider

### DIFF
--- a/llm/memory/episodic.py
+++ b/llm/memory/episodic.py
@@ -6,7 +6,9 @@ Silent failure design: any error returns None without raising.
 """
 from __future__ import annotations
 
+import asyncio
 import re
+import time
 from typing import TYPE_CHECKING, Any, Optional
 
 import discord
@@ -34,12 +36,18 @@ class EpisodicMemoryProvider:
         bot: Discord bot instance (must have vector_manager attribute).
         top_k: Maximum number of fragments to retrieve. Default 3.
         max_chars: Hard character limit for the returned string. Default 1500.
+        cache_ttl: Time-to-live for cache entries in seconds. Default 300.0 (5 mins).
+        max_cache_size: Maximum number of items to keep in cache. Default 1000.
     """
 
-    def __init__(self, bot: Any, top_k: int = 3, max_chars: int = 1500) -> None:
+    def __init__(self, bot: Any, top_k: int = 3, max_chars: int = 1500, cache_ttl: float = 300.0, max_cache_size: int = 1000) -> None:
         self.bot = bot
         self.top_k = top_k
         self.max_chars = max_chars
+        self.cache_ttl = cache_ttl
+        self.max_cache_size = max_cache_size
+        self._cache: dict[str, tuple[Optional[str], float]] = {}
+        self._lock = asyncio.Lock()
 
     async def get(self, message: discord.Message) -> Optional[str]:
         """Return formatted episodic context string, or None if nothing relevant.
@@ -65,6 +73,17 @@ class EpisodicMemoryProvider:
         if len(query.split()) < _MIN_QUERY_TOKENS:
             return None
 
+        cache_key = f"{message.channel.id}:{query}"
+        now = time.monotonic()
+
+        async with self._lock:
+            if cache_key in self._cache:
+                cached_result, expire_at = self._cache[cache_key]
+                if now < expire_at:
+                    return cached_result
+                else:
+                    del self._cache[cache_key]
+
         try:
             fragments = await vector_manager.store.search_memories_by_vector(
                 query_text=query,
@@ -76,40 +95,52 @@ class EpisodicMemoryProvider:
             return None
 
         if not fragments:
-            return None
+            result_str = None
+        else:
+            lines = ["--- Relevant Past Memories ---"]
+            total_chars = len(lines[0])
 
-        lines = ["--- Relevant Past Memories ---"]
-        total_chars = len(lines[0])
+            for i, frag in enumerate(fragments, 1):
+                ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
+                jump_url = frag.metadata.get("jump_url")
 
-        for i, frag in enumerate(fragments, 1):
-            ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
-            jump_url = frag.metadata.get("jump_url")
-
-            # Build source label: prefer a Discord message link over plain timestamp
-            if jump_url and ts:
-                try:
-                    unix_ts = int(float(ts))
-                    source_str = f" [[來源 <t:{unix_ts}:R>]({jump_url})]"
-                except Exception:
+                # Build source label: prefer a Discord message link over plain timestamp
+                if jump_url and ts:
+                    try:
+                        unix_ts = int(float(ts))
+                        source_str = f" [[來源 <t:{unix_ts}:R>]({jump_url})]"
+                    except Exception:
+                        source_str = f" [[來源]({jump_url})]"
+                elif jump_url:
                     source_str = f" [[來源]({jump_url})]"
-            elif jump_url:
-                source_str = f" [[來源]({jump_url})]"
-            elif ts:
-                try:
-                    unix_ts = int(float(ts))
-                    source_str = f" [<t:{unix_ts}:R>]"
-                except Exception:
+                elif ts:
+                    try:
+                        unix_ts = int(float(ts))
+                        source_str = f" [<t:{unix_ts}:R>]"
+                    except Exception:
+                        source_str = ""
+                else:
                     source_str = ""
-            else:
-                source_str = ""
 
-            entry = f"[memory #{i}] {frag.content}{source_str}"
+                entry = f"[memory #{i}] {frag.content}{source_str}"
 
-            if total_chars + len(entry) + 1 > self.max_chars:
-                break
-            lines.append(entry)
-            total_chars += len(entry) + 1
+                if total_chars + len(entry) + 1 > self.max_chars:
+                    break
+                lines.append(entry)
+                total_chars += len(entry) + 1
 
-        lines.append("--- End Past Memories ---")
-        _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
-        return "\n".join(lines)
+            lines.append("--- End Past Memories ---")
+            _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
+            result_str = "\n".join(lines)
+
+        async with self._lock:
+            if len(self._cache) >= self.max_cache_size:
+                # Evict oldest item
+                try:
+                    oldest_key = next(iter(self._cache))
+                    del self._cache[oldest_key]
+                except StopIteration:
+                    pass
+            self._cache[cache_key] = (result_str, time.monotonic() + self.cache_ttl)
+
+        return result_str


### PR DESCRIPTION
**What**
Added an in-memory TTL cache to `EpisodicMemoryProvider`.

**Where**
`llm/memory/episodic.py`

**Why**
Vector database searches (via Qdrant/embeddings) are slow and expensive. Repeated or very similar inputs triggered redundant lookups, causing noticeable response latency for users. This cache dramatically speeds up processing for duplicate queries within a short window.

**What was done**
Implemented a fast, dictionary-based cache for `EpisodicMemoryProvider.get`. Configured with a default TTL of 5 minutes (`300.0`s) and a `max_cache_size` of `1000`. Dictionary eviction is handled cleanly by leveraging Python's insertion order logic. Cache reads and writes use `time.monotonic()` for safety and efficiency.

---
*PR created automatically by Jules for task [9282451540109227281](https://jules.google.com/task/9282451540109227281) started by @starpig1129*