### PR TITLE
[Perf] Add TTL cache to EpisodicMemoryProvider

### DIFF
--- a/llm/memory/episodic.py
+++ b/llm/memory/episodic.py
@@ -6,8 +6,10 @@ Silent failure design: any error returns None without raising.
 """
 from __future__ import annotations
 
+import asyncio
 import re
-from typing import TYPE_CHECKING, Any, Optional
+import time
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 import discord
 
@@ -34,12 +36,21 @@ class EpisodicMemoryProvider:
         bot: Discord bot instance (must have vector_manager attribute).
         top_k: Maximum number of fragments to retrieve. Default 3.
         max_chars: Hard character limit for the returned string. Default 1500.
+        cache_ttl: TTL for cache entries in seconds. Default 300.
+        max_cache_size: Maximum number of entries in the cache. Default 1000.
     """
 
-    def __init__(self, bot: Any, top_k: int = 3, max_chars: int = 1500) -> None:
+    def __init__(self, bot: Any, top_k: int = 3, max_chars: int = 1500, cache_ttl: float = 300.0, max_cache_size: int = 1000) -> None:
         self.bot = bot
         self.top_k = top_k
         self.max_chars = max_chars
+        self.cache_ttl = cache_ttl
+        self.max_cache_size = max_cache_size
+
+        # cache stores Tuple[result_string, expire_at]
+        # key is (channel_id, query)
+        self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
+        self._lock = asyncio.Lock()
 
     async def get(self, message: discord.Message) -> Optional[str]:
         """Return formatted episodic context string, or None if nothing relevant.
@@ -65,17 +76,30 @@ class EpisodicMemoryProvider:
         if len(query.split()) < _MIN_QUERY_TOKENS:
             return None
 
+        channel_id = str(message.channel.id)
+        cache_key = (channel_id, query)
+        now = time.monotonic()
+
+        async with self._lock:
+            entry = self._cache.get(cache_key)
+            if entry is not None and entry[1] > now:
+                return entry[0]
+
         try:
             fragments = await vector_manager.store.search_memories_by_vector(
                 query_text=query,
                 limit=self.top_k,
-                channel_id=str(message.channel.id),
+                channel_id=channel_id,
             )
         except Exception as e:
             await func.report_error(e, "EpisodicMemoryProvider.get: vector search failed")
             return None
 
         if not fragments:
+            # Cache the negative result as well to prevent repeated searches
+            async with self._lock:
+                self._cache[cache_key] = (None, now + self.cache_ttl)
+                self._prune_cache(now)
             return None
 
         lines = ["--- Relevant Past Memories ---"]
@@ -112,4 +136,19 @@ class EpisodicMemoryProvider:
 
         lines.append("--- End Past Memories ---")
         _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
-        return "\n".join(lines)
+        result = "\n".join(lines)
+
+        async with self._lock:
+            self._cache[cache_key] = (result, time.monotonic() + self.cache_ttl)
+            self._prune_cache(now)
+
+        return result
+
+    def _prune_cache(self, now: float) -> None:
+        """Prunes expired entries from the cache and enforces max_cache_size."""
+        if len(self._cache) > self.max_cache_size:
+            self._cache = {k: v for k, v in self._cache.items() if v[1] > now}
+
+            while len(self._cache) > self.max_cache_size:
+                oldest_key = next(iter(self._cache))
+                self._cache.pop(oldest_key)

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -79,6 +79,15 @@ class _DummySQLiteUserManager:
 fake_cogs_memory_users_manager.SQLiteUserManager = _DummySQLiteUserManager
 sys.modules["cogs.memory.users.manager"] = fake_cogs_memory_users_manager
 
+fake_cogs_memory_db = types.ModuleType("cogs.memory.db")
+fake_cogs_memory_db.__path__ = []
+sys.modules["cogs.memory.db"] = fake_cogs_memory_db
+fake_cogs_memory_db_knowledge_storage = types.ModuleType("cogs.memory.db.knowledge_storage")
+class _DummyKnowledgeStorage:
+    pass
+fake_cogs_memory_db_knowledge_storage.KnowledgeStorage = _DummyKnowledgeStorage
+sys.modules["cogs.memory.db.knowledge_storage"] = fake_cogs_memory_db_knowledge_storage
+
 import llm.context_manager as context_manager
 from llm.context_manager import ContextManager
 from llm.memory.schema import ProceduralMemory, UserInfo


### PR DESCRIPTION
**What**: Found that `EpisodicMemoryProvider` executes a vector search for every incoming message, regardless of whether the message content matches recently processed queries, leading to unnecessary latency and load on the vector database.

**Where**: `llm/memory/episodic.py` in the `EpisodicMemoryProvider.get` method.

**Why**: Implementing an in-memory TTL cache for semantic searches significantly reduces redundant vector database calls. Repeated queries will resolve instantly from memory, improving the bot's overall response time and reducing the resource footprint. This fits well within the existing memory architecture (which uses a TTL cache for procedural memory) without introducing new dependencies.

**What was done**:
1. Added `_cache`, `_lock`, `cache_ttl`, and `max_cache_size` to the `EpisodicMemoryProvider` class initialization.
2. Updated the `get` method to use `(channel_id, query)` as a cache key.
3. Implemented a cache hit check before executing the vector search.
4. Added logic to store both valid results (formatted context strings) and empty results (negative caching) to prevent repeated failed lookups.
5. Implemented a `_prune_cache` method to remove expired entries and enforce the `max_cache_size` using a FIFO fallback if necessary.
6. Updated unit tests (`tests/test_context_manager.py`) with stubs to prevent test collection errors locally, and verified the changes.

---
*PR created automatically by Jules for task [9607797161242717346](https://jules.google.com/task/9607797161242717346) started by @starpig1129*