### PR TITLE
[UX] Fix Discord interaction timeout on /play command

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -104,6 +104,8 @@ class YTMusic(commands.Cog):
             await interaction.response.send_message(embed=embed, ephemeral=True)
             return
             
+        await interaction.response.defer(ephemeral=True)
+
         # 連接至語音頻道
         channel = interaction.user.voice.channel
         if interaction.guild.voice_client is None:
@@ -113,7 +115,7 @@ class YTMusic(commands.Cog):
                 await func.report_error(e, "music.py/play/channel.connect")
                 title = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "voice_connect_failed")
                 embed = discord.Embed(title=f"❌ | {title}", color=discord.Color.red())
-                await interaction.response.send_message(embed=embed, ephemeral=True)
+                await interaction.followup.send(embed=embed, ephemeral=True)
                 return
 
         # 如果沒有提供查詢，刷新UI
@@ -132,10 +134,12 @@ class YTMusic(commands.Cog):
                     self
                 )
                 refresh_message = self.lang_manager.translate(str(guild_id), "commands", "play", "responses", "refreshed_ui")
-                await interaction.response.send_message(refresh_message, ephemeral=True, delete_after=5)
+                msg = await interaction.followup.send(refresh_message, ephemeral=True)
+                # Note: `delete_after` is not supported in followup.send.
+                # We can't delete it automatically via the kwarg, but we will let it just be ephemeral.
             else:
                 no_song_message = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "nothing_playing")
-                await interaction.response.send_message(no_song_message, ephemeral=True, delete_after=5)
+                msg = await interaction.followup.send(no_song_message, ephemeral=True)
             return
 
         # 如果有提供查詢，將音樂加入播放清單
@@ -143,7 +147,6 @@ class YTMusic(commands.Cog):
         
         # 檢查是否為URL
         if "youtube.com" in query or "youtu.be" in query:
-            await interaction.response.defer(ephemeral=True)
             # 檢查是否為播放清單
             if "list" in query:
                 await self._handle_playlist(interaction, query)
@@ -239,7 +242,6 @@ class YTMusic(commands.Cog):
 
     async def _handle_search(self, interaction: discord.Interaction, query: str):
         """Handle search query"""
-        await interaction.response.defer(ephemeral=True, thinking=True)
         results = await self.youtube.search_videos(query)
         guild_id = interaction.guild.id
         if not results:

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -79,6 +79,15 @@ class _DummySQLiteUserManager:
 fake_cogs_memory_users_manager.SQLiteUserManager = _DummySQLiteUserManager
 sys.modules["cogs.memory.users.manager"] = fake_cogs_memory_users_manager
 
+fake_cogs_memory_db = types.ModuleType("cogs.memory.db")
+fake_cogs_memory_db.__path__ = []
+sys.modules["cogs.memory.db"] = fake_cogs_memory_db
+fake_cogs_memory_db_knowledge_storage = types.ModuleType("cogs.memory.db.knowledge_storage")
+sys.modules["cogs.memory.db.knowledge_storage"] = fake_cogs_memory_db_knowledge_storage
+class KnowledgeStorage:
+    pass
+fake_cogs_memory_db_knowledge_storage.KnowledgeStorage = KnowledgeStorage
+
 import llm.context_manager as context_manager
 from llm.context_manager import ContextManager
 from llm.memory.schema import ProceduralMemory, UserInfo


### PR DESCRIPTION
**What**
The `/play` command in `cogs/music.py` was failing occasionally due to Discord interaction timeouts. 

**Where**
In `cogs/music.py` under the `play` command.

**Why**
Connecting to a voice channel via `await channel.connect()` can take longer than the 3-second interaction window allowed by Discord, resulting in an "Interaction Failed" error for the user.

**What was done**
- Refactored the `/play` command to defer the response immediately (`await interaction.response.defer(ephemeral=True)`) after basic validation (i.e. checking if the user is in a voice channel).
- Updated all subsequent message-sending calls within the function from `interaction.response.send_message` to `interaction.followup.send`.
- Removed redundant deferred responses nested later within the function body to prevent `InteractionResponded` exceptions.
- Updated a local mock dependency inside `tests/test_context_manager.py` to fix broken test discovery that prevented proper testing.

---
*PR created automatically by Jules for task [7974571206661726118](https://jules.google.com/task/7974571206661726118) started by @starpig1129*