### PR TITLE
[Perf] Add TTL cache to EpisodicMemoryProvider

### DIFF
--- a/llm/memory/episodic.py
+++ b/llm/memory/episodic.py
@@ -6,12 +6,15 @@ Silent failure design: any error returns None without raising.
 """
 from __future__ import annotations
 
+import asyncio
 import re
-from typing import TYPE_CHECKING, Any, Optional
+import time
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 import discord
 
 from addons.logging import get_logger
+from addons.settings import memory_config
 from function import func
 
 _LOGGER = get_logger(server_id="Bot", source="llm.memory.episodic")
@@ -34,12 +37,18 @@ class EpisodicMemoryProvider:
         bot: Discord bot instance (must have vector_manager attribute).
         top_k: Maximum number of fragments to retrieve. Default 3.
         max_chars: Hard character limit for the returned string. Default 1500.
+        max_cache_size: Maximum number of queries to cache. Default 1000.
     """
 
-    def __init__(self, bot: Any, top_k: int = 3, max_chars: int = 1500) -> None:
+    def __init__(self, bot: Any, top_k: int = 3, max_chars: int = 1500, max_cache_size: int = 1000) -> None:
         self.bot = bot
         self.top_k = top_k
         self.max_chars = max_chars
+        self.max_cache_size = max_cache_size
+
+        # key: (channel_id, query_text), value: (formatted_result_string, expire_at)
+        self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
+        self._lock = asyncio.Lock()
 
     async def get(self, message: discord.Message) -> Optional[str]:
         """Return formatted episodic context string, or None if nothing relevant.
@@ -65,51 +74,86 @@ class EpisodicMemoryProvider:
         if len(query.split()) < _MIN_QUERY_TOKENS:
             return None
 
+        channel_id = str(message.channel.id)
+        cache_key = (channel_id, query)
+        now = time.monotonic()
+
+        # Check cache
+        async with self._lock:
+            entry = self._cache.get(cache_key)
+            if entry is not None and entry[1] > now:
+                return entry[0]
+
         try:
             fragments = await vector_manager.store.search_memories_by_vector(
                 query_text=query,
                 limit=self.top_k,
-                channel_id=str(message.channel.id),
+                channel_id=channel_id,
             )
         except Exception as e:
             await func.report_error(e, "EpisodicMemoryProvider.get: vector search failed")
+            # We don't cache failures
             return None
 
         if not fragments:
-            return None
+            result_str = None
+        else:
+            lines = ["--- Relevant Past Memories ---"]
+            total_chars = len(lines[0])
 
-        lines = ["--- Relevant Past Memories ---"]
-        total_chars = len(lines[0])
+            for i, frag in enumerate(fragments, 1):
+                ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
+                jump_url = frag.metadata.get("jump_url")
 
-        for i, frag in enumerate(fragments, 1):
-            ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
-            jump_url = frag.metadata.get("jump_url")
-
-            # Build source label: prefer a Discord message link over plain timestamp
-            if jump_url and ts:
-                try:
-                    unix_ts = int(float(ts))
-                    source_str = f" [[來源 <t:{unix_ts}:R>]({jump_url})]"
-                except Exception:
+                # Build source label: prefer a Discord message link over plain timestamp
+                if jump_url and ts:
+                    try:
+                        unix_ts = int(float(ts))
+                        source_str = f" [[來源 <t:{unix_ts}:R>]({jump_url})]"
+                    except Exception:
+                        source_str = f" [[來源]({jump_url})]"
+                elif jump_url:
                     source_str = f" [[來源]({jump_url})]"
-            elif jump_url:
-                source_str = f" [[來源]({jump_url})]"
-            elif ts:
-                try:
-                    unix_ts = int(float(ts))
-                    source_str = f" [<t:{unix_ts}:R>]"
-                except Exception:
+                elif ts:
+                    try:
+                        unix_ts = int(float(ts))
+                        source_str = f" [<t:{unix_ts}:R>]"
+                    except Exception:
+                        source_str = ""
+                else:
                     source_str = ""
-            else:
-                source_str = ""
 
-            entry = f"[memory #{i}] {frag.content}{source_str}"
+                entry = f"[memory #{i}] {frag.content}{source_str}"
 
-            if total_chars + len(entry) + 1 > self.max_chars:
-                break
-            lines.append(entry)
-            total_chars += len(entry) + 1
+                if total_chars + len(entry) + 1 > self.max_chars:
+                    break
+                lines.append(entry)
+                total_chars += len(entry) + 1
 
-        lines.append("--- End Past Memories ---")
-        _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
-        return "\n".join(lines)
+            lines.append("--- End Past Memories ---")
+            result_str = "\n".join(lines)
+
+        # Update cache
+        ttl = getattr(memory_config, "procedural_cache_ttl", 300.0)
+        expire_at = now + ttl
+
+        async with self._lock:
+            self._cache[cache_key] = (result_str, expire_at)
+
+            # Enforce max_cache_size by evicting the oldest entry
+            # relies on Python 3.7+ dict insertion order preservation
+            if len(self._cache) > self.max_cache_size:
+                now_insert = time.monotonic()
+                # first remove expired
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+
+                # if still too large, pop oldest
+                while len(self._cache) > self.max_cache_size:
+                    oldest_key = next(iter(self._cache))
+                    self._cache.pop(oldest_key)
+
+        if result_str:
+            _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
+
+        return result_str
+

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -69,9 +69,21 @@ sys.modules["cogs"] = fake_cogs
 fake_cogs_memory = types.ModuleType("cogs.memory")
 fake_cogs_memory.__path__ = []
 sys.modules["cogs.memory"] = fake_cogs_memory
+
+fake_cogs_memory_db = types.ModuleType("cogs.memory.db")
+fake_cogs_memory_db.__path__ = []
+sys.modules["cogs.memory.db"] = fake_cogs_memory_db
+
+fake_cogs_memory_db_knowledge_storage = types.ModuleType("cogs.memory.db.knowledge_storage")
+class _DummyKnowledgeStorage:
+    pass
+fake_cogs_memory_db_knowledge_storage.KnowledgeStorage = _DummyKnowledgeStorage
+sys.modules["cogs.memory.db.knowledge_storage"] = fake_cogs_memory_db_knowledge_storage
+
 fake_cogs_memory_users = types.ModuleType("cogs.memory.users")
 fake_cogs_memory_users.__path__ = []
 sys.modules["cogs.memory.users"] = fake_cogs_memory_users
+
 fake_cogs_memory_users_manager = types.ModuleType("cogs.memory.users.manager")
 class _DummySQLiteUserManager:
     async def get_multiple_users(self, user_ids):


### PR DESCRIPTION
**What was found**:
The `EpisodicMemoryProvider` performs vector searches for every incoming message. Frequent or identical queries within a short timeframe lead to redundant database hits, slowing down the processing pipeline unnecessarily.

**Where it is**:
`llm/memory/episodic.py`
`tests/test_context_manager.py`

**Why it matters**:
Reducing database hits improves overall response latency and reduces load on the vector store, especially in active channels where similar phrases or identical contexts are discussed rapidly.

**What was done**:
1. Added an asynchronous locking mechanism and a local memory dictionary cache in `EpisodicMemoryProvider.__init__`.
2. Created cache keys based on `(channel_id, query)` tuples.
3. Updated the `get` method to check the cache before querying the vector store.
4. Set the cache TTL to `memory_config.procedural_cache_ttl` (defaulting to 300 seconds) and capped maximum items to 1000.
5. Cached both successful and empty vector results (to avoid querying for non-existent memories), while bypassing the cache for true errors.
6. Updated `tests/test_context_manager.py` to ensure correct mocking of `cogs.memory.db` and avoid module collection errors.

---
*PR created automatically by Jules for task [6927722392289848463](https://jules.google.com/task/6927722392289848463) started by @starpig1129*