### PR TITLE
[UX] Fix timeout issue in /play command by deferring early

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -104,6 +104,8 @@ class YTMusic(commands.Cog):
             await interaction.response.send_message(embed=embed, ephemeral=True)
             return
             
+        await interaction.response.defer(ephemeral=True)
+
         # 連接至語音頻道
         channel = interaction.user.voice.channel
         if interaction.guild.voice_client is None:
@@ -113,7 +115,7 @@ class YTMusic(commands.Cog):
                 await func.report_error(e, "music.py/play/channel.connect")
                 title = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "voice_connect_failed")
                 embed = discord.Embed(title=f"❌ | {title}", color=discord.Color.red())
-                await interaction.response.send_message(embed=embed, ephemeral=True)
+                await interaction.followup.send(embed=embed, ephemeral=True)
                 return
 
         # 如果沒有提供查詢，刷新UI
@@ -132,10 +134,10 @@ class YTMusic(commands.Cog):
                     self
                 )
                 refresh_message = self.lang_manager.translate(str(guild_id), "commands", "play", "responses", "refreshed_ui")
-                await interaction.response.send_message(refresh_message, ephemeral=True, delete_after=5)
+                await interaction.followup.send(refresh_message, ephemeral=True)
             else:
                 no_song_message = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "nothing_playing")
-                await interaction.response.send_message(no_song_message, ephemeral=True, delete_after=5)
+                await interaction.followup.send(no_song_message, ephemeral=True)
             return
 
         # 如果有提供查詢，將音樂加入播放清單
@@ -143,7 +145,6 @@ class YTMusic(commands.Cog):
         
         # 檢查是否為URL
         if "youtube.com" in query or "youtu.be" in query:
-            await interaction.response.defer(ephemeral=True)
             # 檢查是否為播放清單
             if "list" in query:
                 await self._handle_playlist(interaction, query)
@@ -239,7 +240,6 @@ class YTMusic(commands.Cog):
 
     async def _handle_search(self, interaction: discord.Interaction, query: str):
         """Handle search query"""
-        await interaction.response.defer(ephemeral=True, thinking=True)
         results = await self.youtube.search_videos(query)
         guild_id = interaction.guild.id
         if not results:

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -71,6 +71,14 @@ fake_cogs_memory.__path__ = []
 sys.modules["cogs.memory"] = fake_cogs_memory
 fake_cogs_memory_users = types.ModuleType("cogs.memory.users")
 fake_cogs_memory_users.__path__ = []
+fake_cogs_memory_db = types.ModuleType("cogs.memory.db")
+fake_cogs_memory_db.__path__ = []
+sys.modules["cogs.memory.db"] = fake_cogs_memory_db
+fake_cogs_memory_db_knowledge_storage = types.ModuleType("cogs.memory.db.knowledge_storage")
+class _DummyKnowledgeStorage:
+    pass
+fake_cogs_memory_db_knowledge_storage.KnowledgeStorage = _DummyKnowledgeStorage
+sys.modules["cogs.memory.db.knowledge_storage"] = fake_cogs_memory_db_knowledge_storage
 sys.modules["cogs.memory.users"] = fake_cogs_memory_users
 fake_cogs_memory_users_manager = types.ModuleType("cogs.memory.users.manager")
 class _DummySQLiteUserManager:


### PR DESCRIPTION
**What**: The `/play` command in `cogs/music.py` was establishing a voice connection (`channel.connect()`) before calling `defer()`. Because voice connection is a network request that can take multiple seconds (especially on slower Discord servers or high load), the initial command response would frequently time out (giving "Interaction failed" to the user), even if the bot successfully joined a second later. Additionally, `interaction.response.send_message` with `delete_after` was being called which behaves poorly when later changed to `followup.send`.

**Where**: `cogs/music.py`, `play` command.

**Why**: To improve UX and eliminate 3-second interaction timeout crashes during music playback.

**What was done**:
1. Added `await interaction.response.defer(ephemeral=True)` immediately after the initial voice channel presence validation and *before* `channel.connect()`.
2. Changed subsequent early termination/error `send_message` calls to `followup.send()`.
3. Removed the `delete_after=5` parameter from the new `followup.send` calls, as webhooks in discord.py do not support `delete_after` and it would throw a TypeError.
4. Removed redundant `defer` calls later in the method (`_handle_search` and `youtube.com` check blocks) since the interaction is now already deferred.
5. Added missing mocks to `test_context_manager.py` to fix existing testing issues.

---
*PR created automatically by Jules for task [1007530916683702964](https://jules.google.com/task/1007530916683702964) started by @starpig1129*