### PR TITLE
[Perf] Add TTL cache to EpisodicMemoryProvider

### DIFF
--- a/llm/memory/episodic.py
+++ b/llm/memory/episodic.py
@@ -6,7 +6,9 @@ Silent failure design: any error returns None without raising.
 """
 from __future__ import annotations
 
+import asyncio
 import re
+import time
 from typing import TYPE_CHECKING, Any, Optional
 
 import discord
@@ -36,10 +38,14 @@ class EpisodicMemoryProvider:
         max_chars: Hard character limit for the returned string. Default 1500.
     """
 
-    def __init__(self, bot: Any, top_k: int = 3, max_chars: int = 1500) -> None:
+    def __init__(self, bot: Any, top_k: int = 3, max_chars: int = 1500, max_cache_size: int = 100, cache_ttl: float = 300.0) -> None:
         self.bot = bot
         self.top_k = top_k
         self.max_chars = max_chars
+        self.max_cache_size = max_cache_size
+        self.cache_ttl = cache_ttl
+        self._cache: dict[str, tuple[Optional[str], float]] = {}
+        self._lock = asyncio.Lock()
 
     async def get(self, message: discord.Message) -> Optional[str]:
         """Return formatted episodic context string, or None if nothing relevant.
@@ -65,6 +71,13 @@ class EpisodicMemoryProvider:
         if len(query.split()) < _MIN_QUERY_TOKENS:
             return None
 
+        cache_key = f"{message.channel.id}:{query}"
+        async with self._lock:
+            if cache_key in self._cache:
+                result, expire_at = self._cache[cache_key]
+                if expire_at > time.monotonic():
+                    return result
+
         try:
             fragments = await vector_manager.store.search_memories_by_vector(
                 query_text=query,
@@ -75,41 +88,53 @@ class EpisodicMemoryProvider:
             await func.report_error(e, "EpisodicMemoryProvider.get: vector search failed")
             return None
 
+        result_str: Optional[str] = None
         if not fragments:
-            return None
+            result_str = None
+        else:
+            lines = ["--- Relevant Past Memories ---"]
+            total_chars = len(lines[0])
 
-        lines = ["--- Relevant Past Memories ---"]
-        total_chars = len(lines[0])
+            for i, frag in enumerate(fragments, 1):
+                ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
+                jump_url = frag.metadata.get("jump_url")
 
-        for i, frag in enumerate(fragments, 1):
-            ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
-            jump_url = frag.metadata.get("jump_url")
-
-            # Build source label: prefer a Discord message link over plain timestamp
-            if jump_url and ts:
-                try:
-                    unix_ts = int(float(ts))
-                    source_str = f" [[來源 <t:{unix_ts}:R>]({jump_url})]"
-                except Exception:
+                # Build source label: prefer a Discord message link over plain timestamp
+                if jump_url and ts:
+                    try:
+                        unix_ts = int(float(ts))
+                        source_str = f" [[來源 <t:{unix_ts}:R>]({jump_url})]"
+                    except Exception:
+                        source_str = f" [[來源]({jump_url})]"
+                elif jump_url:
                     source_str = f" [[來源]({jump_url})]"
-            elif jump_url:
-                source_str = f" [[來源]({jump_url})]"
-            elif ts:
-                try:
-                    unix_ts = int(float(ts))
-                    source_str = f" [<t:{unix_ts}:R>]"
-                except Exception:
+                elif ts:
+                    try:
+                        unix_ts = int(float(ts))
+                        source_str = f" [<t:{unix_ts}:R>]"
+                    except Exception:
+                        source_str = ""
+                else:
                     source_str = ""
-            else:
-                source_str = ""
 
-            entry = f"[memory #{i}] {frag.content}{source_str}"
+                entry = f"[memory #{i}] {frag.content}{source_str}"
 
-            if total_chars + len(entry) + 1 > self.max_chars:
-                break
-            lines.append(entry)
-            total_chars += len(entry) + 1
+                if total_chars + len(entry) + 1 > self.max_chars:
+                    break
+                lines.append(entry)
+                total_chars += len(entry) + 1
 
-        lines.append("--- End Past Memories ---")
-        _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
-        return "\n".join(lines)
+            lines.append("--- End Past Memories ---")
+            _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
+            result_str = "\n".join(lines)
+
+        async with self._lock:
+            self._cache[cache_key] = (result_str, time.monotonic() + self.cache_ttl)
+            if len(self._cache) > self.max_cache_size:
+                now_insert = time.monotonic()
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+                while len(self._cache) > self.max_cache_size:
+                    oldest_key = next(iter(self._cache))
+                    self._cache.pop(oldest_key)
+
+        return result_str

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -67,6 +67,14 @@ fake_cogs = types.ModuleType("cogs")
 fake_cogs.__path__ = []
 sys.modules["cogs"] = fake_cogs
 fake_cogs_memory = types.ModuleType("cogs.memory")
+fake_cogs_memory_db = types.ModuleType("cogs.memory.db")
+fake_cogs_memory_db.__path__ = []
+sys.modules["cogs.memory.db"] = fake_cogs_memory_db
+fake_cogs_memory_db_knowledge_storage = types.ModuleType("cogs.memory.db.knowledge_storage")
+class _DummyKnowledgeStorage:
+    pass
+fake_cogs_memory_db_knowledge_storage.KnowledgeStorage = _DummyKnowledgeStorage
+sys.modules["cogs.memory.db.knowledge_storage"] = fake_cogs_memory_db_knowledge_storage
 fake_cogs_memory.__path__ = []
 sys.modules["cogs.memory"] = fake_cogs_memory
 fake_cogs_memory_users = types.ModuleType("cogs.memory.users")


### PR DESCRIPTION
Added an in-memory TTL cache to `EpisodicMemoryProvider.get()`. The episodic memory provider was performing identical vector searches for the same query in the same channel repeatedly within short timeframes. This cache prevents redundant expensive database lookups and minimizes latency. Added an asynchronous LRU-style TTL cache using `asyncio.Lock()`, storing semantic search results (or None) using a `channel_id:query` compound key. The size is capped, popping the oldest keys when exceeded. Default cache settings were added cleanly to `__init__` to avoid backwards compatibility issues with `configs/`. Tests were executed to verify code safety.

---
*PR created automatically by Jules for task [15407702813486876836](https://jules.google.com/task/15407702813486876836) started by @starpig1129*