### PR TITLE
[UX] Fix interaction timeout during /play voice connection

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -93,6 +93,7 @@ class YTMusic(commands.Cog):
     @app_commands.command(name="play", description="播放影片(網址或關鍵字) 或 刷新UI")
     async def play(self, interaction: discord.Interaction, query: Optional[str] = None):
         """播放音樂或刷新UI命令"""
+        await interaction.response.defer(ephemeral=True)
         guild_id = interaction.guild.id
         
         # 檢查使用者是否已在語音頻道
@@ -101,7 +102,7 @@ class YTMusic(commands.Cog):
                 self.lang_manager = self.bot.get_cog("LanguageManager")
             title = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "no_voice_channel")
             embed = discord.Embed(title=f"❌ | {title}", color=discord.Color.red())
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await interaction.followup.send(embed=embed, ephemeral=True)
             return
             
         # 連接至語音頻道
@@ -113,7 +114,7 @@ class YTMusic(commands.Cog):
                 await func.report_error(e, "music.py/play/channel.connect")
                 title = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "voice_connect_failed")
                 embed = discord.Embed(title=f"❌ | {title}", color=discord.Color.red())
-                await interaction.response.send_message(embed=embed, ephemeral=True)
+                await interaction.followup.send(embed=embed, ephemeral=True)
                 return
 
         # 如果沒有提供查詢，刷新UI
@@ -132,10 +133,10 @@ class YTMusic(commands.Cog):
                     self
                 )
                 refresh_message = self.lang_manager.translate(str(guild_id), "commands", "play", "responses", "refreshed_ui")
-                await interaction.response.send_message(refresh_message, ephemeral=True, delete_after=5)
+                await interaction.followup.send(refresh_message, ephemeral=True)
             else:
                 no_song_message = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "nothing_playing")
-                await interaction.response.send_message(no_song_message, ephemeral=True, delete_after=5)
+                await interaction.followup.send(no_song_message, ephemeral=True)
             return
 
         # 如果有提供查詢，將音樂加入播放清單
@@ -143,7 +144,6 @@ class YTMusic(commands.Cog):
         
         # 檢查是否為URL
         if "youtube.com" in query or "youtu.be" in query:
-            await interaction.response.defer(ephemeral=True)
             # 檢查是否為播放清單
             if "list" in query:
                 await self._handle_playlist(interaction, query)
@@ -239,7 +239,6 @@ class YTMusic(commands.Cog):
 
     async def _handle_search(self, interaction: discord.Interaction, query: str):
         """Handle search query"""
-        await interaction.response.defer(ephemeral=True, thinking=True)
         results = await self.youtube.search_videos(query)
         guild_id = interaction.guild.id
         if not results:

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -79,6 +79,13 @@ class _DummySQLiteUserManager:
 fake_cogs_memory_users_manager.SQLiteUserManager = _DummySQLiteUserManager
 sys.modules["cogs.memory.users.manager"] = fake_cogs_memory_users_manager
 
+fake_knowledge_storage = types.ModuleType("cogs.memory.db.knowledge_storage")
+class _KnowledgeStorage:
+    pass
+fake_knowledge_storage.KnowledgeStorage = _KnowledgeStorage
+sys.modules.setdefault("cogs.memory.db", types.ModuleType("cogs.memory.db"))
+sys.modules.setdefault("cogs.memory.db.knowledge_storage", fake_knowledge_storage)
+
 import llm.context_manager as context_manager
 from llm.context_manager import ContextManager
 from llm.memory.schema import ProceduralMemory, UserInfo


### PR DESCRIPTION
**What was found:**
Users frequently experienced a UX friction point where the Discord bot threw a "The application did not respond" timeout error when executing the `/play` command. The command logic attempted to establish a potentially slow voice channel connection prior to deferring the command interaction.

**Where it is:**
- `cogs/music.py`: The `play` command execution path.
- `tests/test_context_manager.py`: Mock initialization missing `cogs.memory.db.knowledge_storage`.

**Why it matters:**
Discord interaction timeouts cause significant user confusion as the bot fails silently visually on their end, leading to repeated command spam or a perception that the bot is offline.

**What was done:**
- Moved `await interaction.response.defer(ephemeral=True)` to the very beginning of the `/play` command handler.
- Refactored subsequent `interaction.response.send_message` calls inside the handler to `interaction.followup.send` because the interaction is now deferred immediately.
- Removed the `delete_after` parameter from `followup.send` calls as `discord.py` webhook followups do not natively support this parameter, effectively utilizing the fallback `ephemeral=True` property for non-persistency.
- Cleaned up redundant `await interaction.response.defer(ephemeral=True)` calls deeper in the function execution path and inside `_handle_search`.
- Patched `tests/test_context_manager.py` by mocking the newly required `cogs.memory.db.knowledge_storage` dependency, allowing the test suite to execute successfully without collection errors.

---
*PR created automatically by Jules for task [2985718196321534460](https://jules.google.com/task/2985718196321534460) started by @starpig1129*