### PR TITLE
[Security] Fix insecure deserialization in eat train module

### DIFF
--- a/cogs/eat/train/train.py
+++ b/cogs/eat/train/train.py
@@ -9,7 +9,7 @@ import torch
 import torch.nn.functional
 from torch.autograd import Variable
 
-import pickle
+import json
 
 from .data_loader import DataLoader
 from .model import Net
@@ -77,21 +77,25 @@ class Train():
         model.eval()
         torch.save(model.state_dict(), SAVE_URI + f"{discord_id}.model")
 
-        with open(SAVE_URI + f"{discord_id}.pickle", "wb") as file:
-            pickle.dump((dataX, voc_to_int, int_to_voc, vocabulary), file)
+        with open(SAVE_URI + f"{discord_id}.json", "w") as file:
+            json.dump([dataX, voc_to_int, int_to_voc, vocabulary], file)
 
-        return (SAVE_URI + f"{discord_id}.model", SAVE_URI + f"{discord_id}.pickle")
+        return (SAVE_URI + f"{discord_id}.model", SAVE_URI + f"{discord_id}.json")
 
 
     def predict(self, discord_id:str):
-        if os.path.exists(SAVE_URI + f"{discord_id}.pickle") and os.path.exists(SAVE_URI + f"{discord_id}.model"):
-            with open(SAVE_URI + f"{discord_id}.pickle", "rb") as file:
-                dataX, voc_to_int, int_to_voc, vocabulary = pickle.load(file)
+        if os.path.exists(SAVE_URI + f"{discord_id}.json") and os.path.exists(SAVE_URI + f"{discord_id}.model"):
+            with open(SAVE_URI + f"{discord_id}.json", "r") as file:
+                data = json.load(file)
+                dataX = data[0]
+                voc_to_int = data[1]
+                int_to_voc = {int(k): v for k, v in data[2].items()}
+                vocabulary = data[3]
             
             dataLoader = DataLoader(db=self.db)
             model = Net(len(vocabulary), self.embedding_dim, self.hidden_dim, self.dropout)
             
-            model.load_state_dict(torch.load(SAVE_URI + f"{discord_id}.model"))
+            model.load_state_dict(torch.load(SAVE_URI + f"{discord_id}.model", weights_only=True))
 
             n_voc = len(dataX)
 

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -76,8 +76,18 @@ fake_cogs_memory_users_manager = types.ModuleType("cogs.memory.users.manager")
 class _DummySQLiteUserManager:
     async def get_multiple_users(self, user_ids):
         return {}
+
 fake_cogs_memory_users_manager.SQLiteUserManager = _DummySQLiteUserManager
 sys.modules["cogs.memory.users.manager"] = fake_cogs_memory_users_manager
+
+fake_cogs_memory_db = types.ModuleType("cogs.memory.db")
+fake_cogs_memory_db.__path__ = []
+sys.modules["cogs.memory.db"] = fake_cogs_memory_db
+fake_cogs_memory_db_knowledge_storage = types.ModuleType("cogs.memory.db.knowledge_storage")
+class _DummyKnowledgeStorage:
+    pass
+fake_cogs_memory_db_knowledge_storage.KnowledgeStorage = _DummyKnowledgeStorage
+sys.modules["cogs.memory.db.knowledge_storage"] = fake_cogs_memory_db_knowledge_storage
 
 import llm.context_manager as context_manager
 from llm.context_manager import ContextManager


### PR DESCRIPTION
**What**
An insecure deserialization vulnerability was found in the `cogs/eat/train/train.py` module. The code previously used `pickle.load()` and `torch.load()` without the `weights_only=True` flag to load machine learning models and dataset metadata. `pickle` is inherently unsafe when handling untrusted data, as it allows arbitrary code execution.

**Where**
- `cogs/eat/train/train.py`: `Train.genModel` and `Train.predict` methods.

**Why**
Loading untrusted `.pickle` files or `torch` state dictionaries can lead to remote code execution (RCE). If an attacker could place a malicious file into the `models/` directory, the bot's host system could be compromised when `predict` is called.

**What was done**
1. Replaced all occurrences of `pickle.dump` and `pickle.load` with `json.dump` and `json.load` for saving/loading dataset vocabulary and metadata.
2. Migrated the saved file format from `.pickle` to `.json` (e.g., `{discord_id}.json`).
3. Added the `weights_only=True` flag to `torch.load(...)` to restrict deserialization to basic tensor types, preventing execution of arbitrary code during PyTorch loading.
4. Added a dictionary comprehension when loading `int_to_voc` from JSON to explicitly convert its keys back from strings to integers, maintaining proper model functionality.

---
*PR created automatically by Jules for task [15204076257352255682](https://jules.google.com/task/15204076257352255682) started by @starpig1129*