### PR TITLE
[UX] Defer /play interaction early to prevent timeouts

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -93,6 +93,7 @@ class YTMusic(commands.Cog):
     @app_commands.command(name="play", description="播放影片(網址或關鍵字) 或 刷新UI")
     async def play(self, interaction: discord.Interaction, query: Optional[str] = None):
         """播放音樂或刷新UI命令"""
+        await interaction.response.defer(ephemeral=True)
         guild_id = interaction.guild.id
         
         # 檢查使用者是否已在語音頻道
@@ -101,7 +102,7 @@ class YTMusic(commands.Cog):
                 self.lang_manager = self.bot.get_cog("LanguageManager")
             title = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "no_voice_channel")
             embed = discord.Embed(title=f"❌ | {title}", color=discord.Color.red())
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await interaction.followup.send(embed=embed, ephemeral=True)
             return
             
         # 連接至語音頻道
@@ -113,7 +114,7 @@ class YTMusic(commands.Cog):
                 await func.report_error(e, "music.py/play/channel.connect")
                 title = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "voice_connect_failed")
                 embed = discord.Embed(title=f"❌ | {title}", color=discord.Color.red())
-                await interaction.response.send_message(embed=embed, ephemeral=True)
+                await interaction.followup.send(embed=embed, ephemeral=True)
                 return
 
         # 如果沒有提供查詢，刷新UI
@@ -132,10 +133,10 @@ class YTMusic(commands.Cog):
                     self
                 )
                 refresh_message = self.lang_manager.translate(str(guild_id), "commands", "play", "responses", "refreshed_ui")
-                await interaction.response.send_message(refresh_message, ephemeral=True, delete_after=5)
+                await interaction.followup.send(refresh_message, ephemeral=True)
             else:
                 no_song_message = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "nothing_playing")
-                await interaction.response.send_message(no_song_message, ephemeral=True, delete_after=5)
+                await interaction.followup.send(no_song_message, ephemeral=True)
             return
 
         # 如果有提供查詢，將音樂加入播放清單
@@ -143,7 +144,6 @@ class YTMusic(commands.Cog):
         
         # 檢查是否為URL
         if "youtube.com" in query or "youtu.be" in query:
-            await interaction.response.defer(ephemeral=True)
             # 檢查是否為播放清單
             if "list" in query:
                 await self._handle_playlist(interaction, query)
@@ -239,7 +239,6 @@ class YTMusic(commands.Cog):
 
     async def _handle_search(self, interaction: discord.Interaction, query: str):
         """Handle search query"""
-        await interaction.response.defer(ephemeral=True, thinking=True)
         results = await self.youtube.search_videos(query)
         guild_id = interaction.guild.id
         if not results:

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -69,6 +69,17 @@ sys.modules["cogs"] = fake_cogs
 fake_cogs_memory = types.ModuleType("cogs.memory")
 fake_cogs_memory.__path__ = []
 sys.modules["cogs.memory"] = fake_cogs_memory
+
+fake_cogs_memory_db = types.ModuleType("cogs.memory.db")
+fake_cogs_memory_db.__path__ = []
+sys.modules["cogs.memory.db"] = fake_cogs_memory_db
+
+fake_cogs_memory_db_knowledge_storage = types.ModuleType("cogs.memory.db.knowledge_storage")
+class _DummyKnowledgeStorage:
+    pass
+fake_cogs_memory_db_knowledge_storage.KnowledgeStorage = _DummyKnowledgeStorage
+sys.modules["cogs.memory.db.knowledge_storage"] = fake_cogs_memory_db_knowledge_storage
+
 fake_cogs_memory_users = types.ModuleType("cogs.memory.users")
 fake_cogs_memory_users.__path__ = []
 sys.modules["cogs.memory.users"] = fake_cogs_memory_users


### PR DESCRIPTION
**What:** Users experiencing slow network connections or delayed voice channel joins would hit the 3-second Discord interaction timeout when executing the `/play` command in `cogs/music.py`, resulting in an unhelpful "The application did not respond" error.

**Where:** `cogs/music.py`, inside the `play` command.

**Why:** The call to `await channel.connect()` blocking before the bot acknowledges the interaction is dangerous UX. Moving `await interaction.response.defer(ephemeral=True)` to the very beginning guarantees a fast visual "thinking" state.

**What was done:** 
- Moved `defer()` to the first line of the `play` command.
- Replaced subsequent `send_message` references with `followup.send`.
- Removed `delete_after` properties since WebhookMessage followup does not support it natively.
- Removed duplicate `defer()` calls deeper in `play` and `_handle_search` methods to avoid "Interaction already responded" errors.
- Mocked missing dependencies in `tests/test_context_manager.py` to ensure local tests pass.

---
*PR created automatically by Jules for task [12550948489695128821](https://jules.google.com/task/12550948489695128821) started by @starpig1129*