### PR TITLE
[Perf] Add TTL cache to EpisodicMemoryProvider

### DIFF
--- a/episodic_patch.diff
+++ b/episodic_patch.diff
@@ -1,0 +1,128 @@
+--- llm/memory/episodic.py
++++ llm/memory/episodic.py
+@@ -10,13 +10,16 @@
+ from __future__ import annotations
+
++import asyncio
+ import re
+-from typing import TYPE_CHECKING, Any, Optional
++import time
++from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
+
+ import discord
+
+ from addons.logging import get_logger
++from addons.settings import memory_config
+ from function import func
+
+ _LOGGER = get_logger(server_id="Bot", source="llm.memory.episodic")
+
+@@ -34,14 +37,18 @@
+     Args:
+         bot: Discord bot instance (must have vector_manager attribute).
+         top_k: Maximum number of fragments to retrieve. Default 3.
+         max_chars: Hard character limit for the returned string. Default 1500.
++        max_cache_size: Maximum number of entries to keep in cache. Default 500.
+     """
+
+-    def __init__(self, bot: Any, top_k: int = 3, max_chars: int = 1500) -> None:
++    def __init__(self, bot: Any, top_k: int = 3, max_chars: int = 1500, max_cache_size: int = 500) -> None:
+         self.bot = bot
+         self.top_k = top_k
+         self.max_chars = max_chars
++        self.max_cache_size = max_cache_size
++        # key: (channel_id, query), value: (formatted_result, expire_at)
++        self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
++        self._lock = asyncio.Lock()
+
+     async def get(self, message: discord.Message) -> Optional[str]:
+         """Return formatted episodic context string, or None if nothing relevant.
+@@ -64,6 +71,15 @@
+         if len(query.split()) < _MIN_QUERY_TOKENS:
+             return None
+
++        now = time.monotonic()
++        channel_id = str(message.channel.id)
++        cache_key = (channel_id, query)
++
++        async with self._lock:
++            entry = self._cache.get(cache_key)
++            if entry is not None and entry[1] > now:
++                return entry[0]
++
+         try:
+             fragments = await vector_manager.store.search_memories_by_vector(
+                 query_text=query,
+-                limit=self.top_k,
+-                channel_id=str(message.channel.id),
++                limit=self.top_k,
++                channel_id=channel_id,
+             )
+         except Exception as e:
+             await func.report_error(e, "EpisodicMemoryProvider.get: vector search failed")
+-            return None
++            formatted_result = None
++        else:
++            if not fragments:
++                formatted_result = None
++            else:
++                lines = ["--- Relevant Past Memories ---"]
++                total_chars = len(lines[0])
++
++                for i, frag in enumerate(fragments, 1):
++                    ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
++                    jump_url = frag.metadata.get("jump_url")
++
++                    # Build source label: prefer a Discord message link over plain timestamp
++                    if jump_url and ts:
++                        try:
++                            unix_ts = int(float(ts))
++                            source_str = f" [[來源 <t:{unix_ts}:R>]({jump_url})]"
++                        except Exception:
++                            source_str = f" [[來源]({jump_url})]"
++                    elif jump_url:
++                        source_str = f" [[來源]({jump_url})]"
++                    elif ts:
++                        try:
++                            unix_ts = int(float(ts))
++                            source_str = f" [<t:{unix_ts}:R>]"
++                        except Exception:
++                            source_str = ""
++                    else:
++                        source_str = ""
++
++                    entry_str = f"[memory #{i}] {frag.content}{source_str}"
++
++                    if total_chars + len(entry_str) + 1 > self.max_chars:
++                        break
++                    lines.append(entry_str)
++                    total_chars += len(entry_str) + 1
++
++                lines.append("--- End Past Memories ---")
++                _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
++                formatted_result = "\n".join(lines)
++
++        # Update cache
++        expire_at = now + getattr(memory_config, "procedural_cache_ttl", 300)
++        async with self._lock:
++            self._cache[cache_key] = (formatted_result, expire_at)
++
++            # Prune cache if needed
++            if len(self._cache) > self.max_cache_size:
++                self._cache = {k: v for k, v in self._cache.items() if v[1] > now}
++                while len(self._cache) > self.max_cache_size:
++                    oldest_key = next(iter(self._cache))
++                    self._cache.pop(oldest_key)
++
++        return formatted_result
++
++    async def invalidate(self, channel_id: str) -> None:
++        """Invalidate all cache entries for a specific channel.
++
++        Args:
++            channel_id: The Discord channel ID to invalidate.
++        """
++        async with self._lock:
++            keys_to_remove = [k for k in self._cache.keys() if k[0] == str(channel_id)]
++            for k in keys_to_remove:
++                self._cache.pop(k, None)

--- a/llm/memory/episodic.py
+++ b/llm/memory/episodic.py
@@ -6,12 +6,15 @@ Silent failure design: any error returns None without raising.
 """
 from __future__ import annotations
 
+import asyncio
 import re
-from typing import TYPE_CHECKING, Any, Optional
+import time
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 import discord
 
 from addons.logging import get_logger
+from addons.settings import memory_config
 from function import func
 
 _LOGGER = get_logger(server_id="Bot", source="llm.memory.episodic")
@@ -34,12 +37,17 @@ class EpisodicMemoryProvider:
         bot: Discord bot instance (must have vector_manager attribute).
         top_k: Maximum number of fragments to retrieve. Default 3.
         max_chars: Hard character limit for the returned string. Default 1500.
+        max_cache_size: Maximum number of entries to keep in cache. Default 500.
     """
 
-    def __init__(self, bot: Any, top_k: int = 3, max_chars: int = 1500) -> None:
+    def __init__(self, bot: Any, top_k: int = 3, max_chars: int = 1500, max_cache_size: int = 500) -> None:
         self.bot = bot
         self.top_k = top_k
         self.max_chars = max_chars
+        self.max_cache_size = max_cache_size
+        # key: (channel_id, query), value: (formatted_result, expire_at)
+        self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
+        self._lock = asyncio.Lock()
 
     async def get(self, message: discord.Message) -> Optional[str]:
         """Return formatted episodic context string, or None if nothing relevant.
@@ -65,51 +73,85 @@ class EpisodicMemoryProvider:
         if len(query.split()) < _MIN_QUERY_TOKENS:
             return None
 
+        now = time.monotonic()
+        channel_id = str(message.channel.id)
+        cache_key = (channel_id, query)
+
+        async with self._lock:
+            entry = self._cache.get(cache_key)
+            if entry is not None and entry[1] > now:
+                return entry[0]
+
         try:
             fragments = await vector_manager.store.search_memories_by_vector(
                 query_text=query,
                 limit=self.top_k,
-                channel_id=str(message.channel.id),
+                channel_id=channel_id,
             )
         except Exception as e:
             await func.report_error(e, "EpisodicMemoryProvider.get: vector search failed")
-            return None
-
-        if not fragments:
-            return None
-
-        lines = ["--- Relevant Past Memories ---"]
-        total_chars = len(lines[0])
-
-        for i, frag in enumerate(fragments, 1):
-            ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
-            jump_url = frag.metadata.get("jump_url")
-
-            # Build source label: prefer a Discord message link over plain timestamp
-            if jump_url and ts:
-                try:
-                    unix_ts = int(float(ts))
-                    source_str = f" [[來源 <t:{unix_ts}:R>]({jump_url})]"
-                except Exception:
-                    source_str = f" [[來源]({jump_url})]"
-            elif jump_url:
-                source_str = f" [[來源]({jump_url})]"
-            elif ts:
-                try:
-                    unix_ts = int(float(ts))
-                    source_str = f" [<t:{unix_ts}:R>]"
-                except Exception:
-                    source_str = ""
+            formatted_result = None
+        else:
+            if not fragments:
+                formatted_result = None
             else:
-                source_str = ""
+                lines = ["--- Relevant Past Memories ---"]
+                total_chars = len(lines[0])
 
-            entry = f"[memory #{i}] {frag.content}{source_str}"
+                for i, frag in enumerate(fragments, 1):
+                    ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
+                    jump_url = frag.metadata.get("jump_url")
 
-            if total_chars + len(entry) + 1 > self.max_chars:
-                break
-            lines.append(entry)
-            total_chars += len(entry) + 1
+                    # Build source label: prefer a Discord message link over plain timestamp
+                    if jump_url and ts:
+                        try:
+                            unix_ts = int(float(ts))
+                            source_str = f" [[來源 <t:{unix_ts}:R>]({jump_url})]"
+                        except Exception:
+                            source_str = f" [[來源]({jump_url})]"
+                    elif jump_url:
+                        source_str = f" [[來源]({jump_url})]"
+                    elif ts:
+                        try:
+                            unix_ts = int(float(ts))
+                            source_str = f" [<t:{unix_ts}:R>]"
+                        except Exception:
+                            source_str = ""
+                    else:
+                        source_str = ""
 
-        lines.append("--- End Past Memories ---")
-        _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
-        return "\n".join(lines)
+                    entry_str = f"[memory #{i}] {frag.content}{source_str}"
+
+                    if total_chars + len(entry_str) + 1 > self.max_chars:
+                        break
+                    lines.append(entry_str)
+                    total_chars += len(entry_str) + 1
+
+                lines.append("--- End Past Memories ---")
+                _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
+                formatted_result = "\n".join(lines)
+
+        # Update cache
+        expire_at = now + getattr(memory_config, "procedural_cache_ttl", 300)
+        async with self._lock:
+            self._cache[cache_key] = (formatted_result, expire_at)
+
+            # Prune cache if needed
+            if len(self._cache) > self.max_cache_size:
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now}
+                while len(self._cache) > self.max_cache_size:
+                    oldest_key = next(iter(self._cache))
+                    self._cache.pop(oldest_key)
+
+        return formatted_result
+
+    async def invalidate(self, channel_id: str) -> None:
+        """Invalidate all cache entries for a specific channel.
+
+        Args:
+            channel_id: The Discord channel ID to invalidate.
+        """
+        async with self._lock:
+            keys_to_remove = [k for k in self._cache.keys() if k[0] == str(channel_id)]
+            for k in keys_to_remove:
+                self._cache.pop(k, None)

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -13,6 +13,21 @@ fake_discord = types.ModuleType("discord")
 fake_discord.Message = object
 sys.modules.setdefault("discord", fake_discord)
 
+# Mock cogs.memory.db and cogs.memory.db.knowledge_storage.KnowledgeStorage
+fake_cogs_memory = types.ModuleType("cogs.memory")
+fake_cogs_memory.__path__ = []
+fake_cogs_memory_db = types.ModuleType("cogs.memory.db")
+fake_cogs_memory_db.__path__ = []
+fake_cogs_memory_db_knowledge_storage = types.ModuleType("cogs.memory.db.knowledge_storage")
+class _KnowledgeStorage:
+    pass
+fake_cogs_memory_db_knowledge_storage.KnowledgeStorage = _KnowledgeStorage
+sys.modules["cogs"] = types.ModuleType("cogs")
+sys.modules["cogs.__path__"] = []
+sys.modules["cogs.memory"] = fake_cogs_memory
+sys.modules["cogs.memory.db"] = fake_cogs_memory_db
+sys.modules["cogs.memory.db.knowledge_storage"] = fake_cogs_memory_db_knowledge_storage
+
 fake_langchain_messages = types.ModuleType("langchain_core.messages")
 class _BaseMessage:
     def __init__(self, content=None, name=None):


### PR DESCRIPTION
[Perf] Add TTL cache to EpisodicMemoryProvider

What:
The EpisodicMemoryProvider in `llm/memory/episodic.py` fetched memory context via a vector DB query on every message processed by the orchestrator.

Where:
`llm/memory/episodic.py` (init and get methods).

Why:
Performing repeated semantic vector searches for identical queries within the same channel creates unnecessary load and latency for the LLM pipeline, which is particularly evident during conversational back-and-forth.

What was done:
Added an in-memory TTL cache to `EpisodicMemoryProvider.get()` using `asyncio.Lock()` and a fixed-size dictionary. The cache is keyed by `(channel_id, query)` and honors the `memory_config.procedural_cache_ttl` duration. Eviction uses dict insertion order when exceeding `max_cache_size`. An `invalidate()` method was also added for future cache control.

---
*PR created automatically by Jules for task [13983575567932367064](https://jules.google.com/task/13983575567932367064) started by @starpig1129*