### PR TITLE
[Perf] Add TTL cache to EpisodicMemoryProvider

### DIFF
--- a/llm/memory/episodic.py
+++ b/llm/memory/episodic.py
@@ -6,8 +6,10 @@ Silent failure design: any error returns None without raising.
 """
 from __future__ import annotations
 
+import asyncio
 import re
-from typing import TYPE_CHECKING, Any, Optional
+import time
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 import discord
 
@@ -34,12 +36,20 @@ class EpisodicMemoryProvider:
         bot: Discord bot instance (must have vector_manager attribute).
         top_k: Maximum number of fragments to retrieve. Default 3.
         max_chars: Hard character limit for the returned string. Default 1500.
+        max_cache_size: Maximum number of entries to retain in the cache. Default 1000.
+        cache_ttl: Cache Time-To-Live in seconds. Default 300.0.
     """
 
-    def __init__(self, bot: Any, top_k: int = 3, max_chars: int = 1500) -> None:
+    def __init__(self, bot: Any, top_k: int = 3, max_chars: int = 1500, max_cache_size: int = 1000, cache_ttl: float = 300.0) -> None:
+        if max_cache_size < 0:
+            raise ValueError("max_cache_size must be >= 0")
         self.bot = bot
         self.top_k = top_k
         self.max_chars = max_chars
+        self.max_cache_size = max_cache_size
+        self.cache_ttl = cache_ttl
+        # key: (channel_id: str, query: str), value: (formatted_str: Optional[str], expire_at: float monotonic)
+        self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
 
     async def get(self, message: discord.Message) -> Optional[str]:
         """Return formatted episodic context string, or None if nothing relevant.
@@ -65,51 +75,76 @@ class EpisodicMemoryProvider:
         if len(query.split()) < _MIN_QUERY_TOKENS:
             return None
 
+        channel_id = str(message.channel.id)
+        cache_key = (channel_id, query)
+        now = time.monotonic()
+
+        entry = self._cache.get(cache_key)
+        if entry is not None and entry[1] > now:
+            return entry[0]
+
         try:
             fragments = await vector_manager.store.search_memories_by_vector(
                 query_text=query,
                 limit=self.top_k,
-                channel_id=str(message.channel.id),
+                channel_id=channel_id,
             )
         except Exception as e:
             await func.report_error(e, "EpisodicMemoryProvider.get: vector search failed")
             return None
 
         if not fragments:
-            return None
+            formatted_result = None
+        else:
+            lines = ["--- Relevant Past Memories ---"]
+            total_chars = len(lines[0])
 
-        lines = ["--- Relevant Past Memories ---"]
-        total_chars = len(lines[0])
+            for i, frag in enumerate(fragments, 1):
+                ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
+                jump_url = frag.metadata.get("jump_url")
 
-        for i, frag in enumerate(fragments, 1):
-            ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
-            jump_url = frag.metadata.get("jump_url")
-
-            # Build source label: prefer a Discord message link over plain timestamp
-            if jump_url and ts:
-                try:
-                    unix_ts = int(float(ts))
-                    source_str = f" [[來源 <t:{unix_ts}:R>]({jump_url})]"
-                except Exception:
+                # Build source label: prefer a Discord message link over plain timestamp
+                if jump_url and ts:
+                    try:
+                        unix_ts = int(float(ts))
+                        source_str = f" [[來源 <t:{unix_ts}:R>]({jump_url})]"
+                    except Exception:
+                        source_str = f" [[來源]({jump_url})]"
+                elif jump_url:
                     source_str = f" [[來源]({jump_url})]"
-            elif jump_url:
-                source_str = f" [[來源]({jump_url})]"
-            elif ts:
-                try:
-                    unix_ts = int(float(ts))
-                    source_str = f" [<t:{unix_ts}:R>]"
-                except Exception:
+                elif ts:
+                    try:
+                        unix_ts = int(float(ts))
+                        source_str = f" [<t:{unix_ts}:R>]"
+                    except Exception:
+                        source_str = ""
+                else:
                     source_str = ""
-            else:
-                source_str = ""
 
-            entry = f"[memory #{i}] {frag.content}{source_str}"
+                entry_str = f"[memory #{i}] {frag.content}{source_str}"
 
-            if total_chars + len(entry) + 1 > self.max_chars:
-                break
-            lines.append(entry)
-            total_chars += len(entry) + 1
+                if total_chars + len(entry_str) + 1 > self.max_chars:
+                    break
+                lines.append(entry_str)
+                total_chars += len(entry_str) + 1
 
-        lines.append("--- End Past Memories ---")
-        _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
-        return "\n".join(lines)
+            lines.append("--- End Past Memories ---")
+            _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
+            formatted_result = "\n".join(lines)
+
+        # Update cache
+        expire_at = time.monotonic() + self.cache_ttl
+        self._cache[cache_key] = (formatted_result, expire_at)
+
+        # Prune expired items if cache is getting large
+        if len(self._cache) > self.max_cache_size:
+            now_insert = time.monotonic()
+            self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+
+            # If still over size, remove oldest via insertion order
+            while len(self._cache) > self.max_cache_size:
+                oldest_key = next(iter(self._cache))
+                self._cache.pop(oldest_key, None)
+
+        return formatted_result
+

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -69,6 +69,17 @@ sys.modules["cogs"] = fake_cogs
 fake_cogs_memory = types.ModuleType("cogs.memory")
 fake_cogs_memory.__path__ = []
 sys.modules["cogs.memory"] = fake_cogs_memory
+
+fake_cogs_memory_db = types.ModuleType("cogs.memory.db")
+fake_cogs_memory_db.__path__ = []
+sys.modules["cogs.memory.db"] = fake_cogs_memory_db
+
+fake_cogs_memory_db_knowledge = types.ModuleType("cogs.memory.db.knowledge_storage")
+class _DummyKnowledgeStorage:
+    pass
+fake_cogs_memory_db_knowledge.KnowledgeStorage = _DummyKnowledgeStorage
+sys.modules["cogs.memory.db.knowledge_storage"] = fake_cogs_memory_db_knowledge
+
 fake_cogs_memory_users = types.ModuleType("cogs.memory.users")
 fake_cogs_memory_users.__path__ = []
 sys.modules["cogs.memory.users"] = fake_cogs_memory_users


### PR DESCRIPTION
**1. What** 
A major performance bottleneck was found in `llm/memory/episodic.py` where the `EpisodicMemoryProvider` performed a vector database (Qdrant) search on every incoming message (>= 4 tokens) without any caching mechanism. This caused redundant external API calls for identical queries.

**2. Where** 
`llm/memory/episodic.py` inside the `EpisodicMemoryProvider.get()` method.

**3. Why** 
Vector database searches are computationally expensive and incur network overhead. When multiple similar queries are sent or the bot receives repetitive messages, executing a vector search every time wastes API quota/resources and increases response latency significantly. 

**4. What was done** 
I implemented a thread-safe, in-memory TTL cache inside the `EpisodicMemoryProvider` class. It uses Python dictionaries (which inherently maintain insertion order) to securely bound the cache size up to `max_cache_size` and drops stale entries based on a configurable `cache_ttl`. This effectively serves duplicate context requests immediately from memory without hitting the vector store. The lock was omitted since asyncio dictionaries in Python are natively thread-safe against concurrent mutational `RuntimeError` due to the GIL and single-threaded event loops.

*(Other evaluated problems: 1. `_fetch_short_term_and_procedural` sequential fetch - less impactful than external Qdrant calls. 2. `ProceduralMemoryProvider` lock over cache iteration - negligible impact compared to network delays)*

---
*PR created automatically by Jules for task [9985798022155771843](https://jules.google.com/task/9985798022155771843) started by @starpig1129*