### PR TITLE
[Perf] Optimize parallel context fetching to reduce latency

### DIFF
--- a/llm/context_manager.py
+++ b/llm/context_manager.py
@@ -104,43 +104,51 @@ class ContextManager:
                 _LOGGER.error("procedural_provider.get failed", exception=e)
                 return ProceduralMemory(user_info={})
 
-        # 1. Extract author ID to start their procedural memory fetch immediately
-        author_ids = []
-        try:
-            fallback_author_id = getattr(getattr(message, "author", None), "id", None)
-            if fallback_author_id is not None:
-                author_ids.append(str(fallback_author_id))
-        except Exception:
-            pass
+        async def _fetch_short_term_and_procedural() -> Tuple[List[BaseMessage], ProceduralMemory]:
+            # 1. Extract author ID to start their procedural memory fetch immediately
+            author_ids = []
+            try:
+                fallback_author_id = getattr(getattr(message, "author", None), "id", None)
+                if fallback_author_id is not None:
+                    author_ids.append(str(fallback_author_id))
+            except Exception:
+                pass
 
-        # 2. Fetch short-term, episodic, author procedural, and knowledge memory in parallel
-        short_term_msgs, episodic_str, author_procedural, knowledge = await asyncio.gather(
-            _fetch_short_term(),
+            # 2. Fetch short-term messages and author procedural memory in parallel
+            short_term_msgs, author_procedural = await asyncio.gather(
+                _fetch_short_term(),
+                _fetch_procedural(author_ids),
+            )
+
+            # 3. Extract any additional user IDs from the fetched short-term messages
+            try:
+                extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
+            except Exception as e:
+                asyncio.create_task(
+                    func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
+                )
+                _LOGGER.error("extract_user_ids failed", exception=e)
+                extracted_ids = []
+
+            # 4. Fetch procedural memory for any additional users
+            additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
+            if additional_ids:
+                additional_procedural = await _fetch_procedural(additional_ids)
+                # Merge procedural memories
+                merged_info = dict(getattr(author_procedural, "user_info", {}))
+                merged_info.update(getattr(additional_procedural, "user_info", {}))
+                procedural_memory = ProceduralMemory(user_info=merged_info)
+            else:
+                procedural_memory = author_procedural
+
+            return short_term_msgs, procedural_memory
+
+        # Fetch short-term/procedural sequence, episodic, and knowledge memory in parallel
+        (short_term_msgs, procedural_memory), episodic_str, knowledge = await asyncio.gather(
+            _fetch_short_term_and_procedural(),
             _fetch_episodic(),
-            _fetch_procedural(author_ids),
             _fetch_knowledge(),
         )
-
-        # 3. Extract any additional user IDs from the fetched short-term messages
-        try:
-            extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
-        except Exception as e:
-            asyncio.create_task(
-                func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
-            )
-            _LOGGER.error("extract_user_ids failed", exception=e)
-            extracted_ids = []
-
-        # 4. Fetch procedural memory for any additional users
-        additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
-        if additional_ids:
-            additional_procedural = await _fetch_procedural(additional_ids)
-            # Merge procedural memories
-            merged_info = dict(getattr(author_procedural, "user_info", {}))
-            merged_info.update(getattr(additional_procedural, "user_info", {}))
-            procedural_memory = ProceduralMemory(user_info=merged_info)
-        else:
-            procedural_memory = author_procedural
 
         # 5) Format procedural memory into string (no STM serialization here)
         try:


### PR DESCRIPTION
**What**:
The ContextManager in `llm/context_manager.py` had a structural performance bottleneck where extracting extra user IDs from short-term memory (and fetching their procedural memory) was delayed until *all* other memory sources, including slow vector database queries (`episodic_provider`), were completely finished.

**Where**:
`llm/context_manager.py` near line 116.

**Why**:
Vector search queries to retrieve episodic memories are consistently the most IO-intensive operation in context building. By running the sequence `[fetch short-term] -> [extract IDs] -> [fetch extra procedural]` completely in parallel with `[fetch episodic]`, we can eliminate the sequential blocking and significantly reduce overall context-gathering latency.

**What was done**:
Introduced a new internal async helper `_fetch_short_term_and_procedural()` which handles the sequential logic required for mapping short-term IDs to procedural memory. This composite task is then awaited concurrently alongside the independent `_fetch_episodic()` and `_fetch_knowledge()` functions within the main `asyncio.gather()`. Tested using the `test_context_manager.py` unit tests with `pytest-asyncio` to ensure identical data outputs.

---
*PR created automatically by Jules for task [781580764968064459](https://jules.google.com/task/781580764968064459) started by @starpig1129*