### PR TITLE
[Fix] Invalidate KnowledgeMemoryProvider cache on update

### DIFF
--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -504,6 +504,20 @@ class UserDataCog(commands.Cog):
             success = await self.knowledge_storage.update_knowledge(target_type, target_id, merged)
             
             if success:
+                # Invalidate KnowledgeMemoryProvider cache
+                try:
+                    orchestrator = getattr(self.bot, "orchestrator", None)
+                    if orchestrator:
+                        provider = getattr(
+                            getattr(orchestrator, "context_manager", None),
+                            "knowledge_provider",
+                            None,
+                        )
+                        if provider and hasattr(provider, "invalidate"):
+                            await provider.invalidate(target_type, target_id)
+                except Exception as cache_err:
+                    self.logger.warning(f"Failed to invalidate knowledge cache for {target_type} {target_id}: {cache_err}")
+
                 self.logger.info(f"Successfully persisted {target_type} knowledge.")
                 return f"Successfully updated {target_type} knowledge."
             else:


### PR DESCRIPTION
What: Added cache invalidation for KnowledgeMemoryProvider inside _save_knowledge_data.
Where: cogs/userdata.py (lines ~505-515)
Why: Ensures that when the bot updates guild or channel level knowledge, the LLM context manager immediately fetches the new value instead of relying on a stale cache.
What was done: Added an orchestrator lookup to grab the knowledge_provider and call its invalidate method upon a successful database update, similar to the existing procedural memory invalidation.

---
*PR created automatically by Jules for task [11529663372212231376](https://jules.google.com/task/11529663372212231376) started by @starpig1129*