### PR TITLE
[Bugfix] Invalidate knowledge cache on update

### DIFF
--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -505,6 +505,21 @@ class UserDataCog(commands.Cog):
             
             if success:
                 self.logger.info(f"Successfully persisted {target_type} knowledge.")
+
+                # Invalidate KnowledgeMemoryProvider cache
+                try:
+                    orchestrator = getattr(self.bot, "orchestrator", None)
+                    if orchestrator:
+                        provider = getattr(
+                            getattr(orchestrator, "context_manager", None),
+                            "knowledge_provider",
+                            None,
+                        )
+                        if provider and hasattr(provider, "invalidate"):
+                            await provider.invalidate(target_type, target_id)
+                except Exception as cache_err:
+                    self.logger.warning(f"Failed to invalidate knowledge cache for {target_type} {target_id}: {cache_err}")
+
                 return f"Successfully updated {target_type} knowledge."
             else:
                 self.logger.error(f"Failed to persist {target_type} knowledge to database.")


### PR DESCRIPTION
**What:** The `KnowledgeMemoryProvider` implements a TTL cache for guild/channel knowledge, but this cache is not invalidated when the underlying data is updated via `UserDataCog._save_knowledge_data`.

**Where:** `cogs/userdata.py` inside `_save_knowledge_data` method.

**Why:** When users or agents add inside jokes, relationships, or general knowledge via the `update_guild_knowledge` or `update_channel_knowledge` tools, the orchestrator might not see the new facts for up to 5 minutes (default `procedural_cache_ttl`) due to cache hits. Invalidating the cache immediately ensures that subsequent queries will accurately reflect the latest system context, preventing the agent from ignoring its own newly-saved facts.

**What was done:** Added a cache invalidation block after successfully saving knowledge in `UserDataCog._save_knowledge_data`. This matches the existing pattern used for procedural memory invalidation in `_save_user_data` and `_clear_user_data`.

---
*PR created automatically by Jules for task [4052383278172022686](https://jules.google.com/task/4052383278172022686) started by @starpig1129*