### PR TITLE
[UX] Remove invalid delete_after parameter from ephemeral message

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -735,7 +735,7 @@ class YTMusic(commands.Cog):
         
         title = self.lang_manager.translate(str(guild_id), "system", "music", "autoplay", "toggled", status=status_str)
         
-        await interaction.response.send_message(f"✅ | {title}", ephemeral=True, delete_after=5)
+        await interaction.response.send_message(f"✅ | {title}", ephemeral=True)
 
         # If autoplay is enabled, check if the upcoming queue is empty to fill it
         if state.autoplay and len(self.queue_manager.get_queue_snapshot(interaction.guild.id)) == 0:


### PR DESCRIPTION
### What
Found `delete_after=5` combined with `ephemeral=True` in `handle_toggle_autoplay` in `cogs/music.py`.

### Where
`cogs/music.py`, line 738.

### Why
Discord's API does not allow bots to delete ephemeral messages. Passing `delete_after` to an ephemeral message via discord.py causes a background task to attempt deletion which fails, often resulting in silent backend errors or the message being permanently stuck in the user's UI until the client is reloaded. This is a common but impactful friction point when users click buttons on UI elements and get stuck messages.

### What was done
Removed the `delete_after=5` parameter from the `interaction.response.send_message` call, allowing the message to correctly function as a standard ephemeral message that the user can dismiss naturally. Tested via pytest suite to ensure no regressions.

---
*PR created automatically by Jules for task [7686446388876207675](https://jules.google.com/task/7686446388876207675) started by @starpig1129*