### PR TITLE
[Perf] Add configuration mapping for Episodic and ShortTerm memory provider parameters

### DIFF
--- a/addons/settings.py
+++ b/addons/settings.py
@@ -295,6 +295,11 @@ class MemoryConfig:
         # Toggle to enable/disable memory subsystem
         self.enabled: bool = bool(data.get("enabled", True))
 
+        # Context providers settings
+        self.short_term_limit: int = int(data.get("short_term_limit", 15))
+        self.episodic_top_k: int = int(data.get("episodic_top_k", 3))
+        self.episodic_max_chars: int = int(data.get("episodic_max_chars", 1500))
+
         # Procedural memory cache TTL in seconds
         self.procedural_cache_ttl: float = float(data.get("procedural_cache_ttl", 300.0))
 

--- a/llm/orchestrator.py
+++ b/llm/orchestrator.py
@@ -66,6 +66,9 @@ class Orchestrator:
 
         from addons.settings import memory_config
         memory_enabled = getattr(memory_config, "enabled", True)
+        short_term_limit = getattr(memory_config, "short_term_limit", 15)
+        episodic_top_k = getattr(memory_config, "episodic_top_k", 3)
+        episodic_max_chars = getattr(memory_config, "episodic_max_chars", 1500)
 
         if user_manager is None and memory_enabled:
             asyncio.create_task(
@@ -75,7 +78,7 @@ class Orchestrator:
                 )
             )
 
-        short_term_provider = ShortTermMemoryProvider(bot=bot, limit=15)
+        short_term_provider = ShortTermMemoryProvider(bot=bot, limit=short_term_limit)
         procedural_provider = ProceduralMemoryProvider(user_manager=user_manager)
 
         # Episodic provider: only when memory is enabled and vector store is available
@@ -92,9 +95,8 @@ class Orchestrator:
                 knowledge_storage = KnowledgeStorage(conn)
                 knowledge_provider = KnowledgeMemoryProvider(knowledge_storage)
 
-        from addons.settings import memory_config
         if memory_enabled and getattr(bot, "vector_manager", None) is not None:
-            episodic_provider = EpisodicMemoryProvider(bot=bot, top_k=3, max_chars=1500)
+            episodic_provider = EpisodicMemoryProvider(bot=bot, top_k=episodic_top_k, max_chars=episodic_max_chars)
 
         self.context_manager = ContextManager(
             short_term_provider=short_term_provider,


### PR DESCRIPTION
**What:**
EpisodicMemoryProvider and ShortTermMemoryProvider bounds were hardcoded to `top_k=3`, `max_chars=1500`, and `limit=15` respectively during their instantiation in the Orchestrator.

**Where:**
- `addons/settings.py` (Lines 298-301)
- `llm/orchestrator.py` (Lines 69-71, 81, 99)

**Why:**
Server admins lack the ability to control how much context the LLM injects into prompts. Hardcoded limits force identical parameters across different setups, causing either context loss for complex setups or token bloat for simple ones. Moving these to configuration is highly visible and impactful for users wanting to tweak their memory subsystems without touching the source code.

**What was done:**
1. Modified `MemoryConfig` to load `short_term_limit`, `episodic_top_k`, and `episodic_max_chars` parameters from `memory.yaml`, explicitly setting the default fallbacks to the existing hardcoded values to ensure backwards compatibility.
2. Updated the Orchestrator's provider initialization step to use the newly exposed configuration properties instead of static numbers.

---
*PR created automatically by Jules for task [5393042765041841148](https://jules.google.com/task/5393042765041841148) started by @starpig1129*