### PR TITLE
[Fix] Remove invalid ephemeral message deletion in music cog

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -137,24 +137,10 @@ class YTMusic(commands.Cog):
                     self
                 )
                 refresh_message = self.lang_manager.translate(str(guild_id), "commands", "play", "responses", "refreshed_ui")
-                msg = await interaction.followup.send(refresh_message, ephemeral=True, wait=True)
-                async def _delete_refresh():
-                    await asyncio.sleep(5)
-                    try:
-                        await msg.delete()
-                    except Exception:
-                        pass
-                asyncio.create_task(_delete_refresh())
+                await interaction.followup.send(refresh_message, ephemeral=True)
             else:
                 no_song_message = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "nothing_playing")
-                msg = await interaction.followup.send(no_song_message, ephemeral=True, wait=True)
-                async def _delete_no_song():
-                    await asyncio.sleep(5)
-                    try:
-                        await msg.delete()
-                    except Exception:
-                        pass
-                asyncio.create_task(_delete_no_song())
+                await interaction.followup.send(no_song_message, ephemeral=True)
             return
 
         # 如果有提供查詢，將音樂加入播放清單


### PR DESCRIPTION
1. **What was found**: `discord.py` does not natively support deleting ephemeral messages using `msg.delete()`. In `cogs/music.py`, the code sends an ephemeral message using `await interaction.followup.send(..., ephemeral=True, wait=True)` and then attempts to delete it after 5 seconds via a background task using `msg.delete()`. This will cause a silent or logged `discord.errors.HTTPException: 400 Bad Request` or simply fail because Discord API doesn't allow bots to delete ephemeral messages using the standard delete endpoint. This can cause stuck temporary messages that never disappear.

2. **Where it is**: `cogs/music.py`, inside the `play` command.
   - Lines 140-146
   - Lines 150-156

3. **Why it matters**: Attempting to delete ephemeral messages via `Message.delete()` is not supported by Discord. This leads to broken background tasks, potential errors in logs, and messages that the user expects to disappear remaining on their screen until they restart their client or the message expires naturally on Discord's side (which might be confusing). Ephemeral messages handle their own lifecycle natively.

4. **What was done**: Removed the background task and the `msg.delete()` logic entirely. Just send the ephemeral message using `interaction.followup.send`. Ephemeral messages have a "Dismiss message" button for the user anyway.

---
*PR created automatically by Jules for task [5643421771601499585](https://jules.google.com/task/5643421771601499585) started by @starpig1129*