### PR TITLE
[UX] Fix ephemeral message deletion error in /play

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -137,24 +137,10 @@ class YTMusic(commands.Cog):
                     self
                 )
                 refresh_message = self.lang_manager.translate(str(guild_id), "commands", "play", "responses", "refreshed_ui")
-                msg = await interaction.followup.send(refresh_message, ephemeral=True, wait=True)
-                async def _delete_refresh():
-                    await asyncio.sleep(5)
-                    try:
-                        await msg.delete()
-                    except Exception:
-                        pass
-                asyncio.create_task(_delete_refresh())
+                await interaction.followup.send(refresh_message, ephemeral=True)
             else:
                 no_song_message = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "nothing_playing")
-                msg = await interaction.followup.send(no_song_message, ephemeral=True, wait=True)
-                async def _delete_no_song():
-                    await asyncio.sleep(5)
-                    try:
-                        await msg.delete()
-                    except Exception:
-                        pass
-                asyncio.create_task(_delete_no_song())
+                await interaction.followup.send(no_song_message, ephemeral=True)
             return
 
         # 如果有提供查詢，將音樂加入播放清單


### PR DESCRIPTION
1. **What:** The bot attempts to manually delete ephemeral followup messages (`refresh_message` and `no_song_message`) in `cogs/music.py`. This is not supported by Discord API and causes HTTP 400 Bad Request / NotFound errors when the background task triggers `await msg.delete()`.
2. **Where:** `cogs/music.py`, inside the `play` command (around lines 140-157).
3. **Why:** This creates backend errors and potential unexpected behavior. Ephemeral messages are already temporary by nature (dismissible by the user), so attempting to forcefully delete them is an anti-pattern.
4. **What was done:** Removed `wait=True` and the entire asynchronous deletion block for `refresh_message` and `no_song_message` in the `/play` command handler.

---
*PR created automatically by Jules for task [16334556953110650185](https://jules.google.com/task/16334556953110650185) started by @starpig1129*