### PR TITLE
[UX] Fix invalid ephemeral message deletion logic in music cog

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -137,24 +137,10 @@ class YTMusic(commands.Cog):
                     self
                 )
                 refresh_message = self.lang_manager.translate(str(guild_id), "commands", "play", "responses", "refreshed_ui")
-                msg = await interaction.followup.send(refresh_message, ephemeral=True, wait=True)
-                async def _delete_refresh():
-                    await asyncio.sleep(5)
-                    try:
-                        await msg.delete()
-                    except Exception:
-                        pass
-                asyncio.create_task(_delete_refresh())
+                await interaction.followup.send(refresh_message, ephemeral=True)
             else:
                 no_song_message = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "nothing_playing")
-                msg = await interaction.followup.send(no_song_message, ephemeral=True, wait=True)
-                async def _delete_no_song():
-                    await asyncio.sleep(5)
-                    try:
-                        await msg.delete()
-                    except Exception:
-                        pass
-                asyncio.create_task(_delete_no_song())
+                await interaction.followup.send(no_song_message, ephemeral=True)
             return
 
         # 如果有提供查詢，將音樂加入播放清單


### PR DESCRIPTION
**What**
The Discord bot was throwing silent HTTP 400 errors in the background when attempting to manually delete its own ephemeral messages in the `/play` command. Because the API doesn't support bots deleting ephemeral responses, users experienced stuck UI feedback that they had to manually dismiss anyway.

**Where**
`cogs/music.py`, lines 139-157 (in the `play` command handler).

**Why**
This friction point confused users when expected message feedback lingered and created unnecessary background task errors on the server. Letting the native Discord ephemeral UI handle it natively (via the "Dismiss message" link) prevents the backend error and cleans up the code by removing redundant `create_task` and `asyncio.sleep` calls.

**What was done**
- Removed the `wait=True` argument from `interaction.followup.send()` for the ephemeral UI refreshes.
- Removed the internal `_delete_refresh` and `_delete_no_song` async sleep/delete loops.
- Avoided the resulting HTTP 400 Bad Request errors.

---
*PR created automatically by Jules for task [6124967793551722691](https://jules.google.com/task/6124967793551722691) started by @starpig1129*