### PR TITLE
[User Experience] Fix ephemeral message deletion error in /play

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -137,24 +137,10 @@ class YTMusic(commands.Cog):
                     self
                 )
                 refresh_message = self.lang_manager.translate(str(guild_id), "commands", "play", "responses", "refreshed_ui")
-                msg = await interaction.followup.send(refresh_message, ephemeral=True, wait=True)
-                async def _delete_refresh():
-                    await asyncio.sleep(5)
-                    try:
-                        await msg.delete()
-                    except Exception:
-                        pass
-                asyncio.create_task(_delete_refresh())
+                await interaction.followup.send(refresh_message, ephemeral=True)
             else:
                 no_song_message = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "nothing_playing")
-                msg = await interaction.followup.send(no_song_message, ephemeral=True, wait=True)
-                async def _delete_no_song():
-                    await asyncio.sleep(5)
-                    try:
-                        await msg.delete()
-                    except Exception:
-                        pass
-                asyncio.create_task(_delete_no_song())
+                await interaction.followup.send(no_song_message, ephemeral=True)
             return
 
         # 如果有提供查詢，將音樂加入播放清單


### PR DESCRIPTION
What:
The bot was throwing HTTP 400 Bad Request errors when users executed the `/play` command (either without arguments to refresh UI, or when no song was playing).

Where:
`cogs/music.py` lines 140-158 inside the `play` command handler.

Why:
Ephemeral messages are only visible to the user who triggered them. The Discord API does not support manual deletion of ephemeral messages via the bot (i.e. `await msg.delete()`). The `play` command was explicitly tracking the returned message object (`wait=True`) and creating a background `asyncio.sleep(5)` task to delete it, which would crash and log HTTP errors because the operation is invalid for ephemeral messages. Additionally, auto-deleting ephemeral error messages creates a poor user experience because users might miss the feedback.

What was done:
Removed the `wait=True` argument from `interaction.followup.send()` and stripped out the background tasks (`_delete_refresh` and `_delete_no_song`) that were attempting to manually delete the ephemeral message. The ephemeral messages will now stay in the user's view until they dismiss them manually, fixing the errors and improving the UX.

---
*PR created automatically by Jules for task [11935555209141387731](https://jules.google.com/task/11935555209141387731) started by @starpig1129*