### PR TITLE
[Perf] Add TTL cache configuration to Episodic and Knowledge memory providers

### DIFF
--- a/addons/settings.py
+++ b/addons/settings.py
@@ -296,6 +296,10 @@ class MemoryConfig:
 
         # Procedural memory cache TTL in seconds
         self.procedural_cache_ttl: float = float(data.get("procedural_cache_ttl", 300.0))
+        self.knowledge_cache_ttl: float = float(data.get("knowledge_cache_ttl", 300.0))
+        self.episodic_cache_ttl: float = float(data.get("episodic_cache_ttl", 300.0))
+        self.knowledge_max_cache_size: int = int(data.get("knowledge_max_cache_size", 500))
+        self.episodic_max_cache_size: int = int(data.get("episodic_max_cache_size", 1000))
 
         # Storage / vector store configuration
         self.procedural_data_path: str = data.get("procedural_data_path", "data/memory/procedural.db")

--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -74,7 +74,7 @@ class KnowledgeMemoryProvider:
             content = None
             
         # Update cache
-        expire_at = now + getattr(memory_config, "procedural_cache_ttl", 300) # Default 5 mins
+        expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
         async with self._lock:
             self._cache[cache_key] = (content, expire_at)
             

--- a/llm/orchestrator.py
+++ b/llm/orchestrator.py
@@ -81,6 +81,8 @@ class Orchestrator:
         # Episodic provider: only when memory is enabled and vector store is available
         episodic_provider: Optional[EpisodicMemoryProvider] = None
         
+        from addons.settings import memory_config
+
         # Initialize Knowledge Provider
         knowledge_provider = None
         db = getattr(user_manager, "storage", None)
@@ -90,11 +92,19 @@ class Orchestrator:
             conn = getattr(db, "db", None)
             if conn:
                 knowledge_storage = KnowledgeStorage(conn)
-                knowledge_provider = KnowledgeMemoryProvider(knowledge_storage)
+                knowledge_provider = KnowledgeMemoryProvider(
+                    knowledge_storage,
+                    max_cache_size=memory_config.knowledge_max_cache_size
+                )
 
-        from addons.settings import memory_config
         if memory_enabled and getattr(bot, "vector_manager", None) is not None:
-            episodic_provider = EpisodicMemoryProvider(bot=bot, top_k=3, max_chars=1500)
+            episodic_provider = EpisodicMemoryProvider(
+                bot=bot,
+                top_k=3,
+                max_chars=1500,
+                max_cache_size=memory_config.episodic_max_cache_size,
+                cache_ttl=memory_config.episodic_cache_ttl
+            )
 
         self.context_manager = ContextManager(
             short_term_provider=short_term_provider,


### PR DESCRIPTION
**What:** The `EpisodicMemoryProvider` and `KnowledgeMemoryProvider` were using hardcoded defaults or falling back to the unrelated `procedural_cache_ttl` for their TTL and size limits. 
**Where:** 
- `addons/settings.py` (MemoryConfig)
- `llm/orchestrator.py`
- `llm/memory/knowledge.py`
**Why:** Adding these configuration settings directly to `MemoryConfig` aligns the episodic and knowledge memory providers with the project's YAML-based configuration schema, allowing server owners to fine-tune vector search and API latencies appropriately without modifying code.
**What was done:** 
- Added `episodic_cache_ttl`, `episodic_max_cache_size`, `knowledge_cache_ttl`, and `knowledge_max_cache_size` properties to `addons.settings.MemoryConfig` with sensible defaults.
- Updated `llm/orchestrator.py` to instantiate `EpisodicMemoryProvider` and `KnowledgeMemoryProvider` using these new config values.
- Updated `llm/memory/knowledge.py` to use `knowledge_cache_ttl` instead of falling back to `procedural_cache_ttl`.

---
*PR created automatically by Jules for task [17535986340239487036](https://jules.google.com/task/17535986340239487036) started by @starpig1129*