### PR TITLE
[UX] Remove background deletion of ephemeral messages

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -137,24 +137,10 @@ class YTMusic(commands.Cog):
                     self
                 )
                 refresh_message = self.lang_manager.translate(str(guild_id), "commands", "play", "responses", "refreshed_ui")
-                msg = await interaction.followup.send(refresh_message, ephemeral=True, wait=True)
-                async def _delete_refresh():
-                    await asyncio.sleep(5)
-                    try:
-                        await msg.delete()
-                    except Exception:
-                        pass
-                asyncio.create_task(_delete_refresh())
+                await interaction.followup.send(refresh_message, ephemeral=True)
             else:
                 no_song_message = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "nothing_playing")
-                msg = await interaction.followup.send(no_song_message, ephemeral=True, wait=True)
-                async def _delete_no_song():
-                    await asyncio.sleep(5)
-                    try:
-                        await msg.delete()
-                    except Exception:
-                        pass
-                asyncio.create_task(_delete_no_song())
+                await interaction.followup.send(no_song_message, ephemeral=True)
             return
 
         # 如果有提供查詢，將音樂加入播放清單


### PR DESCRIPTION
### What was found
A significant UX friction point was found in the `play` command of the music cog. When sending "Refreshed UI" or "Nothing playing" feedback, the bot sent the messages with `ephemeral=True` but then spawned an `asyncio.create_task` to sleep for 5 seconds and forcibly delete the message (`await msg.delete()`).

### Where it is
In `cogs/music.py` at line 140 and 150.

### Why it matters
1.  **UX Friction:** Ephemeral messages are already private to the user. Deleting them forcibly via the bot takes control away from the user, who might not have finished reading the message or might have looked away. The user can dismiss ephemeral messages manually at their own convenience.
2.  **API Errors:** The Discord API explicitly prohibits deleting ephemeral messages via the API. Any attempt to call `await msg.delete()` on a message sent with `ephemeral=True` triggers an `HTTP 400 Bad Request` or an error, causing hidden exceptions to be logged or swallowed.
3.  **Performance:** Spawning arbitrary un-awaited `asyncio` tasks for simple message deletion adds unnecessary overhead and clutters the task queue.

### What was done
I removed the `wait=True` parameter from the `interaction.followup.send` call (which is not needed if we aren't manipulating the returned message object) and completely removed the asynchronous background tasks attempting the deletion. This simplifies the command and brings it perfectly in line with Discord's expected UX for ephemeral messages.

---
*PR created automatically by Jules for task [1516440964243097886](https://jules.google.com/task/1516440964243097886) started by @starpig1129*