### PR TITLE
[Perf] Add TTL cache config to EpisodicMemoryProvider

### DIFF
--- a/addons/settings.py
+++ b/addons/settings.py
@@ -296,6 +296,8 @@ class MemoryConfig:
 
         # Procedural memory cache TTL in seconds
         self.procedural_cache_ttl: float = float(data.get("procedural_cache_ttl", 300.0))
+        # Episodic memory cache TTL in seconds
+        self.episodic_cache_ttl: float = float(data.get("episodic_cache_ttl", 300.0))
 
         # Storage / vector store configuration
         self.procedural_data_path: str = data.get("procedural_data_path", "data/memory/procedural.db")

--- a/llm/orchestrator.py
+++ b/llm/orchestrator.py
@@ -94,7 +94,12 @@ class Orchestrator:
 
         from addons.settings import memory_config
         if memory_enabled and getattr(bot, "vector_manager", None) is not None:
-            episodic_provider = EpisodicMemoryProvider(bot=bot, top_k=3, max_chars=1500)
+            episodic_provider = EpisodicMemoryProvider(
+                bot=bot,
+                top_k=3,
+                max_chars=1500,
+                cache_ttl=memory_config.episodic_cache_ttl,
+            )
 
         self.context_manager = ContextManager(
             short_term_provider=short_term_provider,


### PR DESCRIPTION
**What was found**: `EpisodicMemoryProvider` uses a hardcoded default cache TTL of `300.0` seconds instead of being configurable like `procedural_cache_ttl`.

**Where it is**: `llm/memory/episodic.py`, `llm/orchestrator.py` and `addons/settings.py`.

**Why it matters**: Allowing servers to configure the memory cache TTL gives them control over vector store refresh rates vs memory usage/DB latency, maintaining consistency with procedural memory cache config.

**What was done**: 
1. Added `episodic_cache_ttl` option to `MemoryConfig` in `addons/settings.py` (reads from YAML `episodic_cache_ttl` with `300.0` fallback).
2. Passed `cache_ttl=memory_config.episodic_cache_ttl` into the `EpisodicMemoryProvider` instantiation in `llm/orchestrator.py`.

---
*PR created automatically by Jules for task [3260218497170815859](https://jules.google.com/task/3260218497170815859) started by @starpig1129*