### PR TITLE
[Perf] Bound channel history fetch limit to prevent memory exhaustion

### DIFF
--- a/cogs/memory/services/message_tracker.py
+++ b/cogs/memory/services/message_tracker.py
@@ -197,7 +197,9 @@ class MessageTracker:
             
             # Get messages after the calculated/found timestamp
             messages = []
-            async for message in channel.history(after=start_timestamp, limit=None):
+            # Fetch limit to prevent memory exhaustion
+            fetch_limit = getattr(self.settings, 'message_threshold', 50) * 2
+            async for message in channel.history(after=start_timestamp, limit=fetch_limit):
                 messages.append(message)
             
             all_messages.extend(messages)


### PR DESCRIPTION
### What was found
In `cogs/memory/services/message_tracker.py`, the `_process_channel_memory` method was using `channel.history(after=start_timestamp, limit=None)`. In active channels, this would fetch an unbound number of messages, causing severe latency, memory exhaustion, and Discord API rate limits.

### Where it is
`cogs/memory/services/message_tracker.py`, line 200:
`async for message in channel.history(after=start_timestamp, limit=None):`

### Why it matters
Fetching an unlimited number of messages blocks the event loop significantly for large channels, consumes excessive memory, and stresses the Discord API, leading to potential throttling or crashes of the episodic memory summarization background task. This degrades overall bot performance and responsiveness.

### What was done
Replaced `limit=None` with a bounded fetch limit: `fetch_limit = getattr(self.settings, 'message_threshold', 50) * 2`. This ensures the bot only fetches a reasonable, bounded number of missed messages, prioritizing stability and low latency.

---
*PR created automatically by Jules for task [14572052037290958927](https://jules.google.com/task/14572052037290958927) started by @starpig1129*