### PR TITLE
[Perf] Bound channel history fetch to prevent rate limits

### DIFF
--- a/cogs/memory/services/message_tracker.py
+++ b/cogs/memory/services/message_tracker.py
@@ -197,7 +197,8 @@ class MessageTracker:
             
             # Get messages after the calculated/found timestamp
             messages = []
-            async for message in channel.history(after=start_timestamp, limit=None):
+            fetch_limit = getattr(self.settings, "message_threshold", 100) * 2
+            async for message in channel.history(after=start_timestamp, limit=fetch_limit):
                 messages.append(message)
             
             all_messages.extend(messages)


### PR DESCRIPTION
What: The `_process_channel_memory` function was fetching message history using `limit=None`, leading to unbounded pagination over channel history.
Where: `cogs/memory/services/message_tracker.py`, lines 200-201.
Why: This is a severe performance bottleneck. It causes excessive latency, uses significant memory overhead to cache all fetched messages, and risks Discord API rate-limiting or blocking if the bot has to catch up on a long period of time or offline messages.
What was done: Replaced `limit=None` with `limit=getattr(self.settings, "message_threshold", 100) * 2`. This guarantees the fetch limit aligns dynamically with the configured summarization threshold with a buffer, without fetching unbounded amounts of history.

---
*PR created automatically by Jules for task [8333301551565409182](https://jules.google.com/task/8333301551565409182) started by @starpig1129*