### PR TITLE
[Perf] Limit message history fetch to prevent memory exhaustion

### DIFF
--- a/cogs/memory/services/message_tracker.py
+++ b/cogs/memory/services/message_tracker.py
@@ -197,7 +197,7 @@ class MessageTracker:
             
             # Get messages after the calculated/found timestamp
             messages = []
-            async for message in channel.history(after=start_timestamp, limit=None):
+            async for message in channel.history(after=start_timestamp, limit=self.settings.message_threshold * 2):
                 messages.append(message)
             
             all_messages.extend(messages)


### PR DESCRIPTION
**What was found:** In `cogs/memory/services/message_tracker.py`, the `_process_channel_memory` method was querying Discord channel history with `limit=None` (unbounded fetch).
**Where it is:** `cogs/memory/services/message_tracker.py`, near line 200 in the `_process_channel_memory` method.
**Why it matters:** Fetching an unbounded number of messages at once can lead to extreme memory consumption, exhaustion, and Discord API rate-limiting blocks, completely freezing or crashing the bot when processing channels with large backlogs of unprocessed messages.
**What was done:** Replaced the `limit=None` parameter with a bounded limit based on the configured message processing thresholds: `limit=self.settings.message_threshold * 2`. This guarantees that background operations remain stable and performant by processing massive backlogs iteratively across cycles.

---
*PR created automatically by Jules for task [1046489127040099688](https://jules.google.com/task/1046489127040099688) started by @starpig1129*