### PR TITLE
[Feature] Add tools to clear guild and channel knowledge

### DIFF
--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -529,6 +529,43 @@ class UserDataCog(commands.Cog):
             await func.report_error(e, f"save_knowledge_data failed ({target_type}:{target_id})")
             return f"Error: {str(e)}"
 
+    async def _clear_knowledge_data(self, target_type: str, target_id: str) -> str:
+        """Core logic for clearing guild/channel knowledge."""
+        async with self._knowledge_lock:
+            self.logger.info(f"Initiating sequential knowledge clear for {target_type} {target_id}...")
+
+            try:
+                if not self.knowledge_storage:
+                    return "Knowledge storage not initialized."
+
+                success = await self.knowledge_storage.delete_knowledge(target_type, target_id)
+
+                if success:
+                    # Invalidate KnowledgeMemoryProvider cache
+                    try:
+                        orchestrator = getattr(self.bot, "orchestrator", None)
+                        if orchestrator:
+                            provider = getattr(
+                                getattr(orchestrator, "context_manager", None),
+                                "knowledge_provider",
+                                None,
+                            )
+                            if provider and hasattr(provider, "invalidate"):
+                                await provider.invalidate(target_type, target_id)
+                    except Exception as cache_err:
+                        self.logger.warning(f"Failed to invalidate knowledge cache for {target_type} {target_id}: {cache_err}")
+
+                    self.logger.info(f"Successfully cleared {target_type} knowledge.")
+                    return f"Successfully cleared {target_type} knowledge."
+                else:
+                    self.logger.info(f"No {target_type} knowledge found to clear for {target_id}.")
+                    return f"No {target_type} knowledge found to clear."
+
+            except Exception as e:
+                self.logger.error(f"Failed to clear {target_type} knowledge for {target_id}: {e}")
+                await func.report_error(e, f"clear_knowledge_data failed ({target_type}:{target_id})")
+                return f"Error: {str(e)}"
+
     async def _save_user_data(
         self,
         user_id: str,

--- a/llm/tools/knowledge.py
+++ b/llm/tools/knowledge.py
@@ -96,11 +96,90 @@ class UpdateChannelKnowledgeTool(BaseTool):
             logger.error(f"update_channel_knowledge tool failed: {e}")
             return f"Error updating channel knowledge: {str(e)}"
 
+class ClearKnowledgeInput(BaseModel):
+    """Input for clearing knowledge."""
+    dummy: Optional[str] = Field(default=None, description="Dummy argument, leave empty.")
+
+class ClearGuildKnowledgeTool(BaseTool):
+    """Tool to clear all knowledge shared across the entire server."""
+    name: str = "clear_guild_knowledge"
+    description: str = "Clear all recorded facts, memes, or culture for the ENTIRE SERVER. Use only when explicitly asked to forget server knowledge."
+    args_schema: Type[BaseModel] = ClearKnowledgeInput
+    runtime: Optional[Any] = None
+
+    def _run(self, dummy: Optional[str] = None) -> str:
+        """Synchronous run (not used)."""
+        raise NotImplementedError("Use _arun")
+
+    async def _arun(self, dummy: Optional[str] = None) -> str:
+        """Clear guild-level knowledge."""
+        if not self.runtime or not self.runtime.message:
+            return "Error: Runtime context missing."
+
+        guild = self.runtime.message.guild
+        if not guild:
+            return "Error: This tool can only be used within a Discord Server (Guild)."
+
+        bot = self.runtime.bot
+        cog = bot.get_cog("UserDataCog")
+        if not cog:
+            return "Error: UserDataCog not loaded."
+
+        try:
+            result = await cog._clear_knowledge_data(
+                target_type="guild",
+                target_id=str(guild.id),
+            )
+            return result
+        except Exception as e:
+            from addons.logging import get_logger
+            local_logger = get_logger(server_id=str(guild.id), source="llm.tools.knowledge")
+            local_logger.error(f"clear_guild_knowledge tool failed: {e}")
+            return f"Error clearing guild knowledge: {str(e)}"
+
+class ClearChannelKnowledgeTool(BaseTool):
+    """Tool to clear knowledge specific to the current channel."""
+    name: str = "clear_channel_knowledge"
+    description: str = "Clear all recorded facts, rules, or culture for the CURRENT CHANNEL only. Use only when explicitly asked to forget channel knowledge."
+    args_schema: Type[BaseModel] = ClearKnowledgeInput
+    runtime: Optional[Any] = None
+
+    def _run(self, dummy: Optional[str] = None) -> str:
+        """Synchronous run (not used)."""
+        raise NotImplementedError("Use _arun")
+
+    async def _arun(self, dummy: Optional[str] = None) -> str:
+        """Clear channel-level knowledge."""
+        if not self.runtime or not self.runtime.message:
+            return "Error: Runtime context missing."
+
+        channel = self.runtime.message.channel
+        guild = getattr(self.runtime.message, "guild", None)
+        bot = self.runtime.bot
+        cog = bot.get_cog("UserDataCog")
+        if not cog:
+            return "Error: UserDataCog not loaded."
+
+        try:
+            result = await cog._clear_knowledge_data(
+                target_type="channel",
+                target_id=str(channel.id),
+            )
+            return result
+        except Exception as e:
+            from addons.logging import get_logger
+            guild_id = str(guild.id) if guild else "Bot"
+            local_logger = get_logger(server_id=guild_id, source="llm.tools.knowledge")
+            local_logger.error(f"clear_channel_knowledge tool failed: {e}")
+            return f"Error clearing channel knowledge: {str(e)}"
+
 def get_tools(runtime: Any) -> list:
     """Discovery function for the tools factory."""
     return [
         UpdateGuildKnowledgeTool(runtime=runtime),
         UpdateChannelKnowledgeTool(runtime=runtime),
+        ClearGuildKnowledgeTool(runtime=runtime),
+        ClearChannelKnowledgeTool(runtime=runtime),
     ]
 
 class KnowledgeTools:


### PR DESCRIPTION
**What:**
The agent discovered that while the bot had tools to read and update/add "knowledge" (server and channel shared context), it completely lacked the ability to clear or forget that knowledge. If the bot hallucinated or learned an incorrect fact, the only way to delete it was via manual database intervention.

**Where:**
- `cogs/userdata.py` - Added `_clear_knowledge_data`.
- `llm/tools/knowledge.py` - Added `ClearGuildKnowledgeTool` and `ClearChannelKnowledgeTool`, and registered them in `get_tools`.

**Why:**
To give users and the AI agency over deleting shared information it had learned, achieving feature parity with the procedural user memory tools.

**What was done:**
1. Implemented a backend method `_clear_knowledge_data` inside the `UserDataCog` which calls the database `delete_knowledge` function.
2. Added proper cache invalidation for `KnowledgeMemoryProvider` upon successful deletion.
3. Implemented two LangChain tools (`ClearGuildKnowledgeTool` and `ClearChannelKnowledgeTool`) matching the project's existing tool format, logging rules (`addons.logging`), and error-handling schemes.
4. Used an optional `dummy` parameter scheme for these 0-parameter tools to prevent LangChain parsing issues.

---
*PR created automatically by Jules for task [755397511105090003](https://jules.google.com/task/755397511105090003) started by @starpig1129*