### PR TITLE
[Perf] Add bounded limit to channel history fetch

### DIFF
--- a/cogs/memory/services/message_tracker.py
+++ b/cogs/memory/services/message_tracker.py
@@ -197,7 +197,10 @@ class MessageTracker:
             
             # Get messages after the calculated/found timestamp
             messages = []
-            async for message in channel.history(after=start_timestamp, limit=None):
+            # Use a bounded limit based on message threshold to prevent memory exhaustion
+            # Multiple of 2 provides a safety margin while preventing unbounded fetches
+            fetch_limit = getattr(self.settings, "message_threshold", 100) * 2
+            async for message in channel.history(after=start_timestamp, limit=fetch_limit):
                 messages.append(message)
             
             all_messages.extend(messages)


### PR DESCRIPTION
**What:** Unbounded fetch in channel history was used.
**Where:** `cogs/memory/services/message_tracker.py`, lines 197-204.
**Why:** Calling `channel.history(limit=None)` tries to fetch all messages after a specific timestamp, potentially thousands if the bot was offline or in a highly active channel. This can result in excessive API calls, rate-limiting, event loop blocking, and high memory utilization (OOM). 
**What was done:** Swapped `limit=None` for a bounded limit derived from `self.settings.message_threshold * 2`. This guarantees the fetch stays well within reasonable limits while catching up on processing.

---
*PR created automatically by Jules for task [12369088707543091673](https://jules.google.com/task/12369088707543091673) started by @starpig1129*