### PR TITLE
[Feature] Make memory context limits configurable

### DIFF
--- a/addons/settings.py
+++ b/addons/settings.py
@@ -321,6 +321,11 @@ class MemoryConfig:
         # Generic provider options bag for future extensions
         self.provider_options: dict = data.get("provider_options", {})
 
+        # Limits for retrieving memories during conversation context injection
+        self.short_term_limit: int = data.get("short_term_limit", 15)
+        self.episodic_top_k: int = data.get("episodic_top_k", 3)
+        self.episodic_max_chars: int = data.get("episodic_max_chars", 1500)
+
         # Message threshold for triggering memory processing
         self.message_threshold: int = data.get("message_threshold", 100)
         # Time threshold for triggering memory processing (in seconds)

--- a/llm/orchestrator.py
+++ b/llm/orchestrator.py
@@ -75,7 +75,8 @@ class Orchestrator:
                 )
             )
 
-        short_term_provider = ShortTermMemoryProvider(bot=bot, limit=15)
+        from addons.settings import memory_config
+        short_term_provider = ShortTermMemoryProvider(bot=bot, limit=memory_config.short_term_limit)
         procedural_provider = ProceduralMemoryProvider(user_manager=user_manager)
 
         # Episodic provider: only when memory is enabled and vector store is available
@@ -92,9 +93,12 @@ class Orchestrator:
                 knowledge_storage = KnowledgeStorage(conn)
                 knowledge_provider = KnowledgeMemoryProvider(knowledge_storage)
 
-        from addons.settings import memory_config
         if memory_enabled and getattr(bot, "vector_manager", None) is not None:
-            episodic_provider = EpisodicMemoryProvider(bot=bot, top_k=3, max_chars=1500)
+            episodic_provider = EpisodicMemoryProvider(
+                bot=bot,
+                top_k=memory_config.episodic_top_k,
+                max_chars=memory_config.episodic_max_chars
+            )
 
         self.context_manager = ContextManager(
             short_term_provider=short_term_provider,


### PR DESCRIPTION
### What
The bounds for retrieving context memory (short term memory limit, episodic memory top-k, and episodic max characters) were previously hardcoded as magic numbers inside the orchestrator instantiation.

### Where
- `addons/settings.py` (`MemoryConfig` class)
- `llm/orchestrator.py` (`Orchestrator.__init__`)

### Why
Hardcoded limits prevent users from customizing the bot's behavior. Users running expensive proprietary LLMs might want to reduce the short-term context window to save tokens, while those running cheap local models might want to expand episodic memory boundaries. This improves flexibility and user control while aligning with the project's config architecture. 

### What was done
1. Modified `MemoryConfig` in `addons/settings.py` to parse `short_term_limit` (default: 15), `episodic_top_k` (default: 3), and `episodic_max_chars` (default: 1500).
2. Refactored `llm/orchestrator.py` to pass these configured limits to `ShortTermMemoryProvider` and `EpisodicMemoryProvider`.
3. Validated changes to ensure no breaking configurations occur.

---
*PR created automatically by Jules for task [18083250296162858821](https://jules.google.com/task/18083250296162858821) started by @starpig1129*