### PR TITLE
[Perf] Resolve N+1 DB query bottleneck in user procedural memory fetches

### DIFF
--- a/cogs/memory/db/procedural_storage.py
+++ b/cogs/memory/db/procedural_storage.py
@@ -81,6 +81,73 @@ class ProceduralStorage:
             await func.report_error(e, f"get_user_info failed (user: {discord_id})")
             return None
 
+    async def get_users_info(self, discord_ids: List[str]) -> Dict[str, UserInfo]:
+        if not discord_ids:
+            return {}
+
+        result: Dict[str, UserInfo] = {}
+        uncached: List[str] = []
+
+        for did in discord_ids:
+            if did in self._user_cache:
+                result[did] = self._user_cache[did]
+            else:
+                uncached.append(did)
+
+        if not uncached:
+            return result
+
+        try:
+            with self.db.get_connection() as conn:
+                placeholders = ",".join("?" for _ in uncached)
+                cursor = conn.execute(
+                    f"""
+                    SELECT discord_id, discord_name, display_names,
+                           procedural_memory, user_background, created_at
+                    FROM users
+                    WHERE discord_id IN ({placeholders})
+                    """,
+                    tuple(uncached),
+                )
+                rows = cursor.fetchall()
+
+                for row in rows:
+                    did = str(row["discord_id"])
+                    display_names = []
+                    if row["display_names"]:
+                        try:
+                            display_names = json.loads(row["display_names"])
+                            if not isinstance(display_names, list):
+                                display_names = [str(display_names)]
+                        except Exception:
+                            display_names = [row["display_names"]]
+
+                    created_at = None
+                    if row["created_at"]:
+                        try:
+                            created_at = datetime.fromisoformat(row["created_at"])
+                        except Exception:
+                            try:
+                                created_at = datetime.fromtimestamp(float(row["created_at"]))
+                            except Exception:
+                                created_at = None
+
+                    user_info = UserInfo(
+                        discord_id=did,
+                        discord_name=row["discord_name"] or "",
+                        display_names=display_names,
+                        procedural_memory=row["procedural_memory"],
+                        user_background=row["user_background"],
+                        created_at=created_at,
+                    )
+                    self._update_cache(did, user_info)
+                    result[did] = user_info
+
+        except Exception as e:
+            await func.report_error(e, f"get_users_info failed for ids: {uncached}")
+
+        return result
+
     async def update_user_data(
         self,
         discord_id: str,

--- a/cogs/memory/users/manager.py
+++ b/cogs/memory/users/manager.py
@@ -55,16 +55,24 @@ class SQLiteUserManager:
 
         if uncached:
             try:
-                coros = [self.storage.get_user_info(uid) for uid in uncached]
-                rows = await asyncio.gather(*coros, return_exceptions=True)
-                for uid, row in zip(uncached, rows):
-                    if isinstance(row, Exception):
-                        await func.report_error(row, f"get_user_info failed for {uid}")
-                        continue
-                    if isinstance(row, UserInfo):
+                if hasattr(self.storage, "get_users_info"):
+                    # Use the batched fetch to avoid N+1 queries blocking the loop
+                    fetched = await self.storage.get_users_info(uncached)
+                    for uid, row in fetched.items():
                         result[uid] = row
                         if use_cache:
                             self._update_cache(uid, row)
+                else:
+                    coros = [self.storage.get_user_info(uid) for uid in uncached]
+                    rows = await asyncio.gather(*coros, return_exceptions=True)
+                    for uid, row in zip(uncached, rows):
+                        if isinstance(row, Exception):
+                            await func.report_error(row, f"get_user_info failed for {uid}")
+                            continue
+                        if isinstance(row, UserInfo):
+                            result[uid] = row
+                            if use_cache:
+                                self._update_cache(uid, row)
             except Exception as e:
                 await func.report_error(e, "Failed to retrieve multiple users")
         return result


### PR DESCRIPTION
### What
An N+1 query performance bottleneck was found in `cogs/memory/users/manager.py` within `get_multiple_users`. Multiple database requests were fired asynchronously via `asyncio.gather`. Since the underlying SQLite method `ProceduralStorage.get_user_info` uses synchronous blocking calls, executing these concurrently sequentially blocks the main event loop `N` times.

### Where
1. `cogs/memory/db/procedural_storage.py` - Implemented `get_users_info`
2. `cogs/memory/users/manager.py` - Lines 56-61 (modified `get_multiple_users`)

### Why
Because PigPig extracts unique user IDs from short-term memory (chat history) in `llm/context_manager.py` and then batches procedural memory fetches, high-traffic channels will frequently trigger `get_multiple_users` with large lists of uncached IDs. Using `asyncio.gather` on blocking queries causes severe latency, lagging the bot's response to users and creating unnecessary CPU/database overhead.

### What was done
1. Added a new method `get_users_info(self, discord_ids: List[str]) -> Dict[str, UserInfo]` to `ProceduralStorage`. This method uses an SQL `IN (?, ?, ...)` clause to batch fetch uncached users in exactly one query, then caches them.
2. Updated `SQLiteUserManager.get_multiple_users` to check for `hasattr(self.storage, "get_users_info")`. If it exists, it passes the list of uncached IDs directly to the new batched fetch, collapsing N SQLite round-trips into a single query and completely resolving the N+1 loop blocking issue. This approach remains backward compatible if an alternative DB implementation does not yet support batching.

---
*PR created automatically by Jules for task [4482683441739565306](https://jules.google.com/task/4482683441739565306) started by @starpig1129*