### PR TITLE
[Perf] Batch user info queries to resolve N+1 issue

### DIFF
--- a/cogs/memory/db/procedural_storage.py
+++ b/cogs/memory/db/procedural_storage.py
@@ -81,6 +81,72 @@ class ProceduralStorage:
             await func.report_error(e, f"get_user_info failed (user: {discord_id})")
             return None
 
+    async def get_users_info(self, discord_ids: List[str]) -> Dict[str, UserInfo]:
+        if not discord_ids:
+            return {}
+
+        results = {}
+        missing_ids = []
+        for discord_id in discord_ids:
+            if discord_id in self._user_cache:
+                results[discord_id] = self._user_cache[discord_id]
+            else:
+                missing_ids.append(discord_id)
+
+        if not missing_ids:
+            return results
+
+        try:
+            with self.db.get_connection() as conn:
+                placeholders = ",".join(["?"] * len(missing_ids))
+                cursor = conn.execute(
+                    f"""
+                    SELECT discord_id, discord_name, display_names,
+                           procedural_memory, user_background, created_at
+                    FROM users
+                    WHERE discord_id IN ({placeholders})
+                    """,
+                    missing_ids,
+                )
+
+                for row in cursor.fetchall():
+                    discord_id = str(row["discord_id"])
+                    display_names = []
+                    if row["display_names"]:
+                        try:
+                            display_names = json.loads(row["display_names"])
+                            if not isinstance(display_names, list):
+                                display_names = [str(display_names)]
+                        except Exception:
+                            display_names = [row["display_names"]]
+
+                    created_at = None
+                    if row["created_at"]:
+                        try:
+                            created_at = datetime.fromisoformat(row["created_at"])
+                        except Exception:
+                            try:
+                                created_at = datetime.fromtimestamp(float(row["created_at"]))
+                            except Exception:
+                                created_at = None
+
+                    user_info = UserInfo(
+                        discord_id=discord_id,
+                        discord_name=row["discord_name"] or "",
+                        display_names=display_names,
+                        procedural_memory=row["procedural_memory"],
+                        user_background=row["user_background"],
+                        created_at=created_at,
+                    )
+
+                    self._update_cache(discord_id, user_info)
+                    results[discord_id] = user_info
+
+            return results
+        except Exception as e:
+            await func.report_error(e, f"get_users_info failed (users: {missing_ids})")
+            return results
+
     async def update_user_data(
         self,
         discord_id: str,

--- a/cogs/memory/users/manager.py
+++ b/cogs/memory/users/manager.py
@@ -55,16 +55,23 @@ class SQLiteUserManager:
 
         if uncached:
             try:
-                coros = [self.storage.get_user_info(uid) for uid in uncached]
-                rows = await asyncio.gather(*coros, return_exceptions=True)
-                for uid, row in zip(uncached, rows):
-                    if isinstance(row, Exception):
-                        await func.report_error(row, f"get_user_info failed for {uid}")
-                        continue
-                    if isinstance(row, UserInfo):
+                if hasattr(self.storage, "get_users_info"):
+                    fetched = await self.storage.get_users_info(uncached)
+                    for uid, row in fetched.items():
                         result[uid] = row
                         if use_cache:
                             self._update_cache(uid, row)
+                else:
+                    coros = [self.storage.get_user_info(uid) for uid in uncached]
+                    rows = await asyncio.gather(*coros, return_exceptions=True)
+                    for uid, row in zip(uncached, rows):
+                        if isinstance(row, Exception):
+                            await func.report_error(row, f"get_user_info failed for {uid}")
+                            continue
+                        if isinstance(row, UserInfo):
+                            result[uid] = row
+                            if use_cache:
+                                self._update_cache(uid, row)
             except Exception as e:
                 await func.report_error(e, "Failed to retrieve multiple users")
         return result


### PR DESCRIPTION
**What**: The `get_multiple_users` method previously fetched missing cache records by executing individual `SELECT` queries for each user sequentially (or via `asyncio.gather`), leading to an N+1 query problem.
**Where**: 
- `cogs/memory/db/procedural_storage.py` (added `get_users_info` method)
- `cogs/memory/users/manager.py` (updated `get_multiple_users` to utilize the new batched method)
**Why**: Fetching multiple users in parallel database connections or multiple queries increases I/O latency, locks, and consumes unnecessary connection pool resources, slowing down the bot's overall response time in heavily populated channels.
**What was done**: 
1. Added a new `get_users_info` method to `ProceduralStorage` to dynamically build a `WHERE discord_id IN (...)` SQL clause, retrieving all required user profiles in a single query.
2. Updated `SQLiteUserManager.get_multiple_users` to dynamically attempt to use `get_users_info` (falling back to individual queries if unavailable).
3. Verified the changes with passing test suites using pytest.

---
*PR created automatically by Jules for task [11854023974540646687](https://jules.google.com/task/11854023974540646687) started by @starpig1129*