### PR TITLE
[Perf] Fix N+1 query in get_multiple_users using batched SQL

### DIFF
--- a/cogs/memory/db/procedural_storage.py
+++ b/cogs/memory/db/procedural_storage.py
@@ -28,6 +28,75 @@ class ProceduralStorage:
         self._cache_size_limit = 1000
         self.logger = logger
 
+    async def get_users_info(self, discord_ids: List[str]) -> Dict[str, UserInfo]:
+        """Fetch multiple users using a single batched query to prevent N+1 issues."""
+        if not discord_ids:
+            return {}
+
+        results: Dict[str, UserInfo] = {}
+        missing_ids: List[str] = []
+
+        for did in discord_ids:
+            if did in self._user_cache:
+                results[did] = self._user_cache[did]
+            else:
+                missing_ids.append(did)
+
+        if not missing_ids:
+            return results
+
+        try:
+            placeholders = ",".join(["?"] * len(missing_ids))
+            with self.db.get_connection() as conn:
+                cursor = conn.execute(
+                    f"""
+                    SELECT discord_id, discord_name, display_names,
+                           procedural_memory, user_background, created_at
+                    FROM users
+                    WHERE discord_id IN ({placeholders})
+                    """,
+                    tuple(missing_ids),
+                )
+                rows = cursor.fetchall()
+
+                for row in rows:
+                    did = str(row["discord_id"])
+                    display_names = []
+                    if row["display_names"]:
+                        try:
+                            display_names = json.loads(row["display_names"])
+                            if not isinstance(display_names, list):
+                                display_names = [str(display_names)]
+                        except Exception:
+                            display_names = [row["display_names"]]
+
+                    created_at = None
+                    if row["created_at"]:
+                        try:
+                            created_at = datetime.fromisoformat(row["created_at"])
+                        except Exception:
+                            try:
+                                created_at = datetime.fromtimestamp(float(row["created_at"]))
+                            except Exception:
+                                created_at = None
+
+                    user_info = UserInfo(
+                        discord_id=did,
+                        discord_name=row["discord_name"] or "",
+                        display_names=display_names,
+                        procedural_memory=row["procedural_memory"],
+                        user_background=row["user_background"],
+                        created_at=created_at,
+                    )
+
+                    self._update_cache(did, user_info)
+                    results[did] = user_info
+
+        except Exception as e:
+            await func.report_error(e, "get_users_info failed")
+
+        return results
+
     async def get_user_info(self, discord_id: str) -> Optional[UserInfo]:
         if discord_id in self._user_cache:
             return self._user_cache[discord_id]

--- a/cogs/memory/users/manager.py
+++ b/cogs/memory/users/manager.py
@@ -55,16 +55,24 @@ class SQLiteUserManager:
 
         if uncached:
             try:
-                coros = [self.storage.get_user_info(uid) for uid in uncached]
-                rows = await asyncio.gather(*coros, return_exceptions=True)
-                for uid, row in zip(uncached, rows):
-                    if isinstance(row, Exception):
-                        await func.report_error(row, f"get_user_info failed for {uid}")
-                        continue
-                    if isinstance(row, UserInfo):
-                        result[uid] = row
+                if hasattr(self.storage, "get_users_info"):
+                    fetched = await self.storage.get_users_info(uncached)
+                    for uid, user_info in fetched.items():
+                        result[uid] = user_info
                         if use_cache:
-                            self._update_cache(uid, row)
+                            self._update_cache(uid, user_info)
+                else:
+                    # Fallback for storage implementations without get_users_info
+                    coros = [self.storage.get_user_info(uid) for uid in uncached]
+                    rows = await asyncio.gather(*coros, return_exceptions=True)
+                    for uid, row in zip(uncached, rows):
+                        if isinstance(row, Exception):
+                            await func.report_error(row, f"get_user_info failed for {uid}")
+                            continue
+                        if isinstance(row, UserInfo):
+                            result[uid] = row
+                            if use_cache:
+                                self._update_cache(uid, row)
             except Exception as e:
                 await func.report_error(e, "Failed to retrieve multiple users")
         return result


### PR DESCRIPTION
**What:** 
Found an N+1 query problem in `SQLiteUserManager.get_multiple_users` where it was using `asyncio.gather` with multiple individual `get_user_info` calls.

**Where:**
- `cogs/memory/db/procedural_storage.py` (added `get_users_info` method)
- `cogs/memory/users/manager.py` (updated `get_multiple_users` method)

**Why:**
This issue caused poor performance and high latency during the bot's response processing, specifically when constructing procedural memory context for multiple users in a channel. Since SQLite does not handle true concurrency well, these serial reads slowed down the hot-path context pipeline significantly.

**What was done:**
Implemented `get_users_info` in `ProceduralStorage` to use a batched `SELECT ... WHERE discord_id IN (...)` query. Updated the `manager.py` to use `hasattr` to check if this new batched query exists and call it instead, maintaining a backward-compatible fallback.

---
*PR created automatically by Jules for task [17307369727105486593](https://jules.google.com/task/17307369727105486593) started by @starpig1129*