### PR TITLE
[Perf] Add batched get_users_info to ProceduralStorage

### DIFF
--- a/cogs/memory/db/procedural_storage.py
+++ b/cogs/memory/db/procedural_storage.py
@@ -81,6 +81,75 @@ class ProceduralStorage:
             await func.report_error(e, f"get_user_info failed (user: {discord_id})")
             return None
 
+    async def get_users_info(self, discord_ids: List[str]) -> Dict[str, UserInfo]:
+        """Fetch multiple users using a single batched query to avoid N+1 query issues."""
+        if not discord_ids:
+            return {}
+
+        results: Dict[str, UserInfo] = {}
+        uncached_ids: List[str] = []
+
+        for did in discord_ids:
+            if did in self._user_cache:
+                results[did] = self._user_cache[did]
+            else:
+                uncached_ids.append(did)
+
+        if not uncached_ids:
+            return results
+
+        try:
+            with self.db.get_connection() as conn:
+                placeholders = ",".join("?" * len(uncached_ids))
+                cursor = conn.execute(
+                    f"""
+                    SELECT discord_id, discord_name, display_names,
+                           procedural_memory, user_background, created_at
+                    FROM users
+                    WHERE discord_id IN ({placeholders})
+                    """,
+                    uncached_ids,
+                )
+
+                for row in cursor.fetchall():
+                    discord_id = str(row["discord_id"])
+
+                    display_names = []
+                    if row["display_names"]:
+                        try:
+                            display_names = json.loads(row["display_names"])
+                            if not isinstance(display_names, list):
+                                display_names = [str(display_names)]
+                        except Exception:
+                            display_names = [row["display_names"]]
+
+                    created_at = None
+                    if row["created_at"]:
+                        try:
+                            created_at = datetime.fromisoformat(row["created_at"])
+                        except Exception:
+                            try:
+                                created_at = datetime.fromtimestamp(float(row["created_at"]))
+                            except Exception:
+                                created_at = None
+
+                    user_info = UserInfo(
+                        discord_id=discord_id,
+                        discord_name=row["discord_name"] or "",
+                        display_names=display_names,
+                        procedural_memory=row["procedural_memory"],
+                        user_background=row["user_background"],
+                        created_at=created_at,
+                    )
+
+                    self._update_cache(discord_id, user_info)
+                    results[discord_id] = user_info
+
+        except Exception as e:
+            await func.report_error(e, f"get_users_info failed for ids: {uncached_ids}")
+
+        return results
+
     async def update_user_data(
         self,
         discord_id: str,

--- a/cogs/memory/users/manager.py
+++ b/cogs/memory/users/manager.py
@@ -55,16 +55,23 @@ class SQLiteUserManager:
 
         if uncached:
             try:
-                coros = [self.storage.get_user_info(uid) for uid in uncached]
-                rows = await asyncio.gather(*coros, return_exceptions=True)
-                for uid, row in zip(uncached, rows):
-                    if isinstance(row, Exception):
-                        await func.report_error(row, f"get_user_info failed for {uid}")
-                        continue
-                    if isinstance(row, UserInfo):
+                if hasattr(self.storage, "get_users_info"):
+                    fetched = await self.storage.get_users_info(uncached)
+                    for uid, row in fetched.items():
                         result[uid] = row
                         if use_cache:
                             self._update_cache(uid, row)
+                else:
+                    coros = [self.storage.get_user_info(uid) for uid in uncached]
+                    rows = await asyncio.gather(*coros, return_exceptions=True)
+                    for uid, row in zip(uncached, rows):
+                        if isinstance(row, Exception):
+                            await func.report_error(row, f"get_user_info failed for {uid}")
+                            continue
+                        if isinstance(row, UserInfo):
+                            result[uid] = row
+                            if use_cache:
+                                self._update_cache(uid, row)
             except Exception as e:
                 await func.report_error(e, "Failed to retrieve multiple users")
         return result


### PR DESCRIPTION
This PR adds `get_users_info` to `ProceduralStorage` and updates `SQLiteUserManager.get_multiple_users` to dynamically detect and use it. This prevents severe N+1 query performance issues when multiple uncached users are requested simultaneously within context generation, by allowing a single database round-trip via a batch query. It introduces no schema changes, maintains backward compatibility through feature detection, and is covered by existing test cases.

---
*PR created automatically by Jules for task [18022322968939015522](https://jules.google.com/task/18022322968939015522) started by @starpig1129*