### PR TITLE
[Perf] Add TTL cache invalidation and thundering herd protection to EpisodicMemoryProvider

### DIFF
--- a/cogs/memory/services/vectorization_service.py
+++ b/cogs/memory/services/vectorization_service.py
@@ -78,6 +78,22 @@ class VectorizationService:
                 logger.info(f"Storing {len(fragments)} memory fragments in vector database")
                 await store.add_memories(fragments)
                 logger.info("Successfully stored memory fragments in vector database")
+
+                # Invalidate episodic cache for modified channels
+                unique_channel_ids = {frag.metadata.get("channel_id") for frag in fragments if frag.metadata.get("channel_id")}
+                try:
+                    episodic_provider = getattr(
+                        getattr(getattr(self.bot, "orchestrator", None), "context_manager", None),
+                        "episodic_provider",
+                        None
+                    )
+                    if episodic_provider and hasattr(episodic_provider, "invalidate"):
+                        for cid in unique_channel_ids:
+                            await episodic_provider.invalidate(cid)
+                        logger.info(f"Invalidated episodic cache for {len(unique_channel_ids)} channels")
+                except Exception as cache_err:
+                    logger.warning(f"Failed to invalidate episodic cache: {cache_err}")
+
             except Exception as e:
                 await func.report_error(e, "vector_store_add_memories_failed")
                 return

--- a/llm/memory/episodic.py
+++ b/llm/memory/episodic.py
@@ -50,6 +50,25 @@ class EpisodicMemoryProvider:
         self.cache_ttl = cache_ttl
         # key: (channel_id: str, query: str), value: (formatted_str: Optional[str], expire_at: float monotonic)
         self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
+        # prevents cache stampedes
+        self._pending_queries: Dict[Tuple[str, str], asyncio.Event] = {}
+
+    async def invalidate(self, channel_id: str) -> None:
+        """Invalidate all cached episodic queries for a specific channel.
+
+        Args:
+            channel_id: The Discord channel ID.
+        """
+        keys_to_remove = [k for k in self._cache.keys() if k[0] == channel_id]
+        for k in keys_to_remove:
+            self._cache.pop(k, None)
+
+        # Unblock any pending queries that were waiting on a now-invalidated result
+        pending_to_remove = [k for k in self._pending_queries.keys() if k[0] == channel_id]
+        for k in pending_to_remove:
+            event = self._pending_queries.pop(k, None)
+            if event:
+                event.set()
 
     async def get(self, message: discord.Message) -> Optional[str]:
         """Return formatted episodic context string, or None if nothing relevant.
@@ -77,74 +96,92 @@ class EpisodicMemoryProvider:
 
         channel_id = str(message.channel.id)
         cache_key = (channel_id, query)
-        now = time.monotonic()
 
+        # Thundering herd protection logic
+        while cache_key in self._pending_queries:
+            await self._pending_queries[cache_key].wait()
+            now = time.monotonic()
+            entry = self._cache.get(cache_key)
+            if entry is not None and entry[1] > now:
+                return entry[0]
+            # If wait finished but cache wasn't updated (e.g. error in primary task),
+            # loop again in case another task picked up the query.
+
+        now = time.monotonic()
         entry = self._cache.get(cache_key)
         if entry is not None and entry[1] > now:
             return entry[0]
 
+        event = asyncio.Event()
+        self._pending_queries[cache_key] = event
+
         try:
-            fragments = await vector_manager.store.search_memories_by_vector(
-                query_text=query,
-                limit=self.top_k,
-                channel_id=channel_id,
-            )
-        except Exception as e:
-            await func.report_error(e, "EpisodicMemoryProvider.get: vector search failed")
-            return None
+            try:
+                fragments = await vector_manager.store.search_memories_by_vector(
+                    query_text=query,
+                    limit=self.top_k,
+                    channel_id=channel_id,
+                )
+            except Exception as e:
+                await func.report_error(e, "EpisodicMemoryProvider.get: vector search failed")
+                return None
 
-        if not fragments:
-            formatted_result = None
-        else:
-            lines = ["--- Relevant Past Memories ---"]
-            total_chars = len(lines[0])
+            if not fragments:
+                formatted_result = None
+            else:
+                lines = ["--- Relevant Past Memories ---"]
+                total_chars = len(lines[0])
 
-            for i, frag in enumerate(fragments, 1):
-                ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
-                jump_url = frag.metadata.get("jump_url")
+                for i, frag in enumerate(fragments, 1):
+                    ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
+                    jump_url = frag.metadata.get("jump_url")
 
-                # Build source label: prefer a Discord message link over plain timestamp
-                if jump_url and ts:
-                    try:
-                        unix_ts = int(float(ts))
-                        source_str = f" [[Source <t:{unix_ts}:R>]({jump_url})]"
-                    except Exception:
+                    # Build source label: prefer a Discord message link over plain timestamp
+                    if jump_url and ts:
+                        try:
+                            unix_ts = int(float(ts))
+                            source_str = f" [[Source <t:{unix_ts}:R>]({jump_url})]"
+                        except Exception:
+                            source_str = f" [[Source]({jump_url})]"
+                    elif jump_url:
                         source_str = f" [[Source]({jump_url})]"
-                elif jump_url:
-                    source_str = f" [[Source]({jump_url})]"
-                elif ts:
-                    try:
-                        unix_ts = int(float(ts))
-                        source_str = f" [<t:{unix_ts}:R>]"
-                    except Exception:
+                    elif ts:
+                        try:
+                            unix_ts = int(float(ts))
+                            source_str = f" [<t:{unix_ts}:R>]"
+                        except Exception:
+                            source_str = ""
+                    else:
                         source_str = ""
-                else:
-                    source_str = ""
 
-                entry_str = f"[memory #{i}] {frag.content}{source_str}"
+                    entry_str = f"[memory #{i}] {frag.content}{source_str}"
 
-                if total_chars + len(entry_str) + 1 > self.max_chars:
-                    break
-                lines.append(entry_str)
-                total_chars += len(entry_str) + 1
+                    if total_chars + len(entry_str) + 1 > self.max_chars:
+                        break
+                    lines.append(entry_str)
+                    total_chars += len(entry_str) + 1
 
-            lines.append("--- End Past Memories ---")
-            _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
-            formatted_result = "\n".join(lines)
+                lines.append("--- End Past Memories ---")
+                _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
+                formatted_result = "\n".join(lines)
 
-        # Update cache
-        expire_at = now + self.cache_ttl
-        self._cache[cache_key] = (formatted_result, expire_at)
+            # Update cache
+            expire_at = now + self.cache_ttl
+            self._cache[cache_key] = (formatted_result, expire_at)
 
-        # Prune expired items if cache is getting large
-        if len(self._cache) > self.max_cache_size:
-            now_insert = time.monotonic()
-            self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+            # Prune expired items if cache is getting large
+            if len(self._cache) > self.max_cache_size:
+                now_insert = time.monotonic()
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
 
-            # If still over size, remove oldest via insertion order
-            while len(self._cache) > self.max_cache_size:
-                oldest_key = next(iter(self._cache))
-                self._cache.pop(oldest_key, None)
+                # If still over size, remove oldest via insertion order
+                while len(self._cache) > self.max_cache_size:
+                    oldest_key = next(iter(self._cache))
+                    self._cache.pop(oldest_key, None)
 
-        return formatted_result
+            return formatted_result
+        finally:
+            # Always ensure the event is cleaned up and waiting tasks are notified
+            self._pending_queries.pop(cache_key, None)
+            event.set()
 


### PR DESCRIPTION
**What was found:** `EpisodicMemoryProvider` lacked mechanisms to prevent cache stampedes (thundering herd) and returned stale memories due to missing cache invalidation when new memory fragments were added via the vectorization pipeline.
**Where it is:** `llm/memory/episodic.py` and `cogs/memory/services/vectorization_service.py`.
**Why it matters:** Cache stampedes overload the vector database API with redundant searches, significantly reducing bot scalability and increasing latency. Missing invalidation means the LLM misses critical new context if it queries right after a memory update but before the TTL expires.
**What was done:** 
1. Added `_pending_queries` using `asyncio.Event` to block concurrent duplicate requests in `EpisodicMemoryProvider.get`. Used a `try/finally` block to ensure the event is always set and removed to prevent deadlocks.
2. Implemented `EpisodicMemoryProvider.invalidate(channel_id)` to purge cached memories for a specific channel.
3. Modified `VectorizationService.process_event_summaries` to extract `channel_id`s from uploaded `MemoryFragment` metadata and call the invalidate method, ensuring immediate cache freshness upon memory ingestion.

---
*PR created automatically by Jules for task [3816913018741036409](https://jules.google.com/task/3816913018741036409) started by @starpig1129*