### PR TITLE
[Perf] Add TTL cache invalidation and thundering herd protection to EpisodicMemoryProvider

### DIFF
--- a/cogs/memory/services/vectorization_service.py
+++ b/cogs/memory/services/vectorization_service.py
@@ -78,6 +78,26 @@ class VectorizationService:
                 logger.info(f"Storing {len(fragments)} memory fragments in vector database")
                 await store.add_memories(fragments)
                 logger.info("Successfully stored memory fragments in vector database")
+
+                # Collect unique channel IDs from the processed summaries
+                channel_ids = {str(frag.metadata.get('channel_id')) for frag in fragments if frag.metadata and frag.metadata.get('channel_id')}
+
+                # Invalidate episodic cache for those channels
+                if channel_ids:
+                    orchestrator = getattr(self.bot, "orchestrator", None)
+                    if orchestrator:
+                        episodic_provider = getattr(
+                            getattr(orchestrator, "context_manager", None),
+                            "episodic_provider",
+                            None,
+                        )
+                        if episodic_provider and hasattr(episodic_provider, "invalidate"):
+                            for cid in channel_ids:
+                                try:
+                                    await episodic_provider.invalidate(cid)
+                                    logger.debug(f"Invalidated episodic cache for channel {cid}")
+                                except Exception as e:
+                                    logger.warning(f"Failed to invalidate cache for channel {cid}: {e}")
             except Exception as e:
                 await func.report_error(e, "vector_store_add_memories_failed")
                 return

--- a/llm/memory/episodic.py
+++ b/llm/memory/episodic.py
@@ -50,6 +50,8 @@ class EpisodicMemoryProvider:
         self.cache_ttl = cache_ttl
         # key: (channel_id: str, query: str), value: (formatted_str: Optional[str], expire_at: float monotonic)
         self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
+        self._lock = asyncio.Lock()
+        self._pending_queries: Dict[Tuple[str, str], asyncio.Event] = {}
 
     async def get(self, message: discord.Message) -> Optional[str]:
         """Return formatted episodic context string, or None if nothing relevant.
@@ -79,72 +81,114 @@ class EpisodicMemoryProvider:
         cache_key = (channel_id, query)
         now = time.monotonic()
 
-        entry = self._cache.get(cache_key)
-        if entry is not None and entry[1] > now:
-            return entry[0]
+        async with self._lock:
+            entry = self._cache.get(cache_key)
+            if entry is not None and entry[1] > now:
+                return entry[0]
+
+            # Cache miss, check for thundering herd
+            event = self._pending_queries.get(cache_key)
+            if event is not None:
+                wait_for_event = True
+            else:
+                wait_for_event = False
+                event = asyncio.Event()
+                self._pending_queries[cache_key] = event
+
+        if wait_for_event:
+            await event.wait()
+            async with self._lock:
+                entry = self._cache.get(cache_key)
+                if entry is not None and entry[1] > time.monotonic():
+                    return entry[0]
+                # If cache is STILL missing or expired after waiting, just proceed to fetch
 
         try:
-            fragments = await vector_manager.store.search_memories_by_vector(
-                query_text=query,
-                limit=self.top_k,
-                channel_id=channel_id,
-            )
-        except Exception as e:
-            await func.report_error(e, "EpisodicMemoryProvider.get: vector search failed")
-            return None
+            try:
+                fragments = await vector_manager.store.search_memories_by_vector(
+                    query_text=query,
+                    limit=self.top_k,
+                    channel_id=channel_id,
+                )
+            except Exception as e:
+                await func.report_error(e, "EpisodicMemoryProvider.get: vector search failed")
+                return None
 
-        if not fragments:
-            formatted_result = None
-        else:
-            lines = ["--- Relevant Past Memories ---"]
-            total_chars = len(lines[0])
+            if not fragments:
+                formatted_result = None
+            else:
+                lines = ["--- Relevant Past Memories ---"]
+                total_chars = len(lines[0])
 
-            for i, frag in enumerate(fragments, 1):
-                ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
-                jump_url = frag.metadata.get("jump_url")
+                for i, frag in enumerate(fragments, 1):
+                    ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
+                    jump_url = frag.metadata.get("jump_url")
 
-                # Build source label: prefer a Discord message link over plain timestamp
-                if jump_url and ts:
-                    try:
-                        unix_ts = int(float(ts))
-                        source_str = f" [[Source <t:{unix_ts}:R>]({jump_url})]"
-                    except Exception:
+                    # Build source label: prefer a Discord message link over plain timestamp
+                    if jump_url and ts:
+                        try:
+                            unix_ts = int(float(ts))
+                            source_str = f" [[Source <t:{unix_ts}:R>]({jump_url})]"
+                        except Exception:
+                            source_str = f" [[Source]({jump_url})]"
+                    elif jump_url:
                         source_str = f" [[Source]({jump_url})]"
-                elif jump_url:
-                    source_str = f" [[Source]({jump_url})]"
-                elif ts:
-                    try:
-                        unix_ts = int(float(ts))
-                        source_str = f" [<t:{unix_ts}:R>]"
-                    except Exception:
+                    elif ts:
+                        try:
+                            unix_ts = int(float(ts))
+                            source_str = f" [<t:{unix_ts}:R>]"
+                        except Exception:
+                            source_str = ""
+                    else:
                         source_str = ""
-                else:
-                    source_str = ""
 
-                entry_str = f"[memory #{i}] {frag.content}{source_str}"
+                    entry_str = f"[memory #{i}] {frag.content}{source_str}"
 
-                if total_chars + len(entry_str) + 1 > self.max_chars:
-                    break
-                lines.append(entry_str)
-                total_chars += len(entry_str) + 1
+                    if total_chars + len(entry_str) + 1 > self.max_chars:
+                        break
+                    lines.append(entry_str)
+                    total_chars += len(entry_str) + 1
 
-            lines.append("--- End Past Memories ---")
-            _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
-            formatted_result = "\n".join(lines)
+                lines.append("--- End Past Memories ---")
+                _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
+                formatted_result = "\n".join(lines)
 
-        # Update cache
-        expire_at = now + self.cache_ttl
-        self._cache[cache_key] = (formatted_result, expire_at)
+            # Update cache
+            now = time.monotonic()
+            expire_at = now + self.cache_ttl
 
-        # Prune expired items if cache is getting large
-        if len(self._cache) > self.max_cache_size:
-            now_insert = time.monotonic()
-            self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+            async with self._lock:
+                self._cache[cache_key] = (formatted_result, expire_at)
 
-            # If still over size, remove oldest via insertion order
-            while len(self._cache) > self.max_cache_size:
-                oldest_key = next(iter(self._cache))
-                self._cache.pop(oldest_key, None)
+                # Prune expired items if cache is getting large
+                if len(self._cache) > self.max_cache_size:
+                    now_insert = time.monotonic()
+                    self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
 
-        return formatted_result
+                    # If still over size, remove oldest via insertion order
+                    while len(self._cache) > self.max_cache_size:
+                        oldest_key = next(iter(self._cache))
+                        self._cache.pop(oldest_key, None)
 
+            return formatted_result
+        finally:
+            if not wait_for_event:
+                async with self._lock:
+                    event.set()
+                    self._pending_queries.pop(cache_key, None)
+
+
+    async def invalidate(self, channel_id: str) -> None:
+        """Evict all cache entries belonging to a specific channel.
+
+        Call this after new episodic memories are generated to ensure subsequent
+        requests fetch the updated data instead of stale cache.
+
+        Args:
+            channel_id: The channel_id string whose memories need eviction.
+        """
+        async with self._lock:
+            # Gather keys to remove
+            keys_to_remove = [k for k in self._cache.keys() if k[0] == channel_id]
+            for k in keys_to_remove:
+                self._cache.pop(k, None)


### PR DESCRIPTION
**What was found:** 
The `EpisodicMemoryProvider` lacked concurrency control for cache misses and relied solely on TTL for memory freshness. This caused "thundering herd" behavior where multiple simultaneous messages in a busy channel could trigger duplicate, heavy vector database searches. Furthermore, when new memories were generated by the background summarization service, the bot would continue to use stale cached episodic context until the TTL expired.

**Where it is:**
- `llm/memory/episodic.py` (lines 48-181)
- `cogs/memory/services/vectorization_service.py` (lines 80-99)

**Why it matters:** 
Without thundering herd protection, sudden bursts of chat activity can exhaust database connections or API limits for remote vector stores. Without proactive cache invalidation, users experience a confusing delay where the bot "forgets" things that were just successfully vectorized and stored moments prior.

**What was done:**
- Added an `asyncio.Event` based `_pending_queries` dictionary and `asyncio.Lock` to `EpisodicMemoryProvider` to block identical concurrent requests while the first request fetches from the vector DB.
- Created `EpisodicMemoryProvider.invalidate(channel_id)` to selectively purge cache.
- Wired the `VectorizationService` to invoke `invalidate()` immediately after successfully calling `store.add_memories()`, ensuring immediate context injection of newly processed events.

---
*PR created automatically by Jules for task [6883572420221573079](https://jules.google.com/task/6883572420221573079) started by @starpig1129*