### PR TITLE
[Perf] Add thundering herd protection to EpisodicMemoryProvider

### DIFF
--- a/llm/memory/episodic.py
+++ b/llm/memory/episodic.py
@@ -50,6 +50,8 @@ class EpisodicMemoryProvider:
         self.cache_ttl = cache_ttl
         # key: (channel_id: str, query: str), value: (formatted_str: Optional[str], expire_at: float monotonic)
         self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
+        # key: (channel_id: str, query: str), value: asyncio.Event
+        self._pending_queries: Dict[Tuple[str, str], asyncio.Event] = {}
 
     async def get(self, message: discord.Message) -> Optional[str]:
         """Return formatted episodic context string, or None if nothing relevant.
@@ -79,72 +81,86 @@ class EpisodicMemoryProvider:
         cache_key = (channel_id, query)
         now = time.monotonic()
 
-        entry = self._cache.get(cache_key)
-        if entry is not None and entry[1] > now:
-            return entry[0]
+        while True:
+            entry = self._cache.get(cache_key)
+            if entry is not None and entry[1] > now:
+                return entry[0]
+
+            if cache_key in self._pending_queries:
+                await self._pending_queries[cache_key].wait()
+                now = time.monotonic()
+                continue
+
+            event = asyncio.Event()
+            self._pending_queries[cache_key] = event
+            break
 
         try:
-            fragments = await vector_manager.store.search_memories_by_vector(
-                query_text=query,
-                limit=self.top_k,
-                channel_id=channel_id,
-            )
-        except Exception as e:
-            await func.report_error(e, "EpisodicMemoryProvider.get: vector search failed")
-            return None
+            try:
+                fragments = await vector_manager.store.search_memories_by_vector(
+                    query_text=query,
+                    limit=self.top_k,
+                    channel_id=channel_id,
+                )
+            except Exception as e:
+                await func.report_error(e, "EpisodicMemoryProvider.get: vector search failed")
+                return None
 
-        if not fragments:
-            formatted_result = None
-        else:
-            lines = ["--- Relevant Past Memories ---"]
-            total_chars = len(lines[0])
+            if not fragments:
+                formatted_result = None
+            else:
+                lines = ["--- Relevant Past Memories ---"]
+                total_chars = len(lines[0])
 
-            for i, frag in enumerate(fragments, 1):
-                ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
-                jump_url = frag.metadata.get("jump_url")
+                for i, frag in enumerate(fragments, 1):
+                    ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
+                    jump_url = frag.metadata.get("jump_url")
 
-                # Build source label: prefer a Discord message link over plain timestamp
-                if jump_url and ts:
-                    try:
-                        unix_ts = int(float(ts))
-                        source_str = f" [[Source <t:{unix_ts}:R>]({jump_url})]"
-                    except Exception:
+                    # Build source label: prefer a Discord message link over plain timestamp
+                    if jump_url and ts:
+                        try:
+                            unix_ts = int(float(ts))
+                            source_str = f" [[Source <t:{unix_ts}:R>]({jump_url})]"
+                        except Exception:
+                            source_str = f" [[Source]({jump_url})]"
+                    elif jump_url:
                         source_str = f" [[Source]({jump_url})]"
-                elif jump_url:
-                    source_str = f" [[Source]({jump_url})]"
-                elif ts:
-                    try:
-                        unix_ts = int(float(ts))
-                        source_str = f" [<t:{unix_ts}:R>]"
-                    except Exception:
+                    elif ts:
+                        try:
+                            unix_ts = int(float(ts))
+                            source_str = f" [<t:{unix_ts}:R>]"
+                        except Exception:
+                            source_str = ""
+                    else:
                         source_str = ""
-                else:
-                    source_str = ""
 
-                entry_str = f"[memory #{i}] {frag.content}{source_str}"
+                    entry_str = f"[memory #{i}] {frag.content}{source_str}"
 
-                if total_chars + len(entry_str) + 1 > self.max_chars:
-                    break
-                lines.append(entry_str)
-                total_chars += len(entry_str) + 1
+                    if total_chars + len(entry_str) + 1 > self.max_chars:
+                        break
+                    lines.append(entry_str)
+                    total_chars += len(entry_str) + 1
 
-            lines.append("--- End Past Memories ---")
-            _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
-            formatted_result = "\n".join(lines)
+                lines.append("--- End Past Memories ---")
+                _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
+                formatted_result = "\n".join(lines)
 
-        # Update cache
-        expire_at = now + self.cache_ttl
-        self._cache[cache_key] = (formatted_result, expire_at)
+            # Update cache
+            expire_at = time.monotonic() + self.cache_ttl
+            self._cache[cache_key] = (formatted_result, expire_at)
 
-        # Prune expired items if cache is getting large
-        if len(self._cache) > self.max_cache_size:
-            now_insert = time.monotonic()
-            self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+            # Prune expired items if cache is getting large
+            if len(self._cache) > self.max_cache_size:
+                now_insert = time.monotonic()
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
 
-            # If still over size, remove oldest via insertion order
-            while len(self._cache) > self.max_cache_size:
-                oldest_key = next(iter(self._cache))
-                self._cache.pop(oldest_key, None)
+                # If still over size, remove oldest via insertion order
+                while len(self._cache) > self.max_cache_size:
+                    oldest_key = next(iter(self._cache))
+                    self._cache.pop(oldest_key, None)
 
-        return formatted_result
+            return formatted_result
+        finally:
+            self._pending_queries.pop(cache_key, None)
+            event.set()
 


### PR DESCRIPTION
**What was found:**
The `EpisodicMemoryProvider.get` caching layer used a standard dictionary lookup to guard against duplicate vector searches. However, it lacked "thundering herd" (or cache stampede) protection. If a high volume of identical queries arrived at the exact same moment (e.g., a burst of messages in the same channel triggering parallel orchestrator calls), they would all bypass the empty cache simultaneously, launching redundant, expensive vector database queries.

**Where it is:**
`llm/memory/episodic.py`, specifically inside `EpisodicMemoryProvider.__init__` and `EpisodicMemoryProvider.get`.

**Why it matters:**
Each query performs semantic similarity search via Qdrant/vector_manager. Redundant parallel calls needlessly consume CPU, database throughput, and memory, directly increasing latency across the entire system during activity spikes. Eliminating these redundant calls ensures the bot scales much better under load without wasting resources.

**What was done:**
Implemented request coalescing using an `asyncio.Event` dictionary (`self._pending_queries`). 
1. When a cache miss occurs, the first task registers an event in `_pending_queries` and proceeds to perform the vector search.
2. Any subsequent concurrent tasks matching the exact same `cache_key` will see the event in `_pending_queries` and immediately `await` it.
3. Once the initial search finishes, it caches the result and calls `.set()` on the event in a `try...finally` block.
4. The waiting tasks wake up, loop back around, and successfully retrieve the result directly from the cache without ever calling the vector store.

---
*PR created automatically by Jules for task [2076966194897591363](https://jules.google.com/task/2076966194897591363) started by @starpig1129*