### PR TITLE
[Perf] Add thundering herd protection and cache invalidation to EpisodicMemoryProvider

### DIFF
--- a/cogs/memory/services/vectorization_service.py
+++ b/cogs/memory/services/vectorization_service.py
@@ -78,6 +78,14 @@ class VectorizationService:
                 logger.info(f"Storing {len(fragments)} memory fragments in vector database")
                 await store.add_memories(fragments)
                 logger.info("Successfully stored memory fragments in vector database")
+
+                # Invalidate episodic provider cache for the affected channels
+                if hasattr(self.bot, "orchestrator") and hasattr(self.bot.orchestrator, "context_manager"):
+                    episodic_provider = self.bot.orchestrator.context_manager.episodic_provider
+                    if episodic_provider and hasattr(episodic_provider, "invalidate"):
+                        affected_channels = {frag.metadata.get("channel_id") for frag in fragments if frag.metadata.get("channel_id")}
+                        for ch_id in affected_channels:
+                            await episodic_provider.invalidate(str(ch_id))
             except Exception as e:
                 await func.report_error(e, "vector_store_add_memories_failed")
                 return

--- a/llm/memory/episodic.py
+++ b/llm/memory/episodic.py
@@ -50,6 +50,8 @@ class EpisodicMemoryProvider:
         self.cache_ttl = cache_ttl
         # key: (channel_id: str, query: str), value: (formatted_str: Optional[str], expire_at: float monotonic)
         self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
+        # Thundering herd protection: blocks identical concurrent queries
+        self._pending_queries: Dict[Tuple[str, str], asyncio.Event] = {}
 
     async def get(self, message: discord.Message) -> Optional[str]:
         """Return formatted episodic context string, or None if nothing relevant.
@@ -83,68 +85,89 @@ class EpisodicMemoryProvider:
         if entry is not None and entry[1] > now:
             return entry[0]
 
+        # Thundering herd protection
+        if cache_key in self._pending_queries:
+            await self._pending_queries[cache_key].wait()
+            entry = self._cache.get(cache_key)
+            if entry is not None and entry[1] > time.monotonic():
+                return entry[0]
+
+        event = asyncio.Event()
+        self._pending_queries[cache_key] = event
+
         try:
-            fragments = await vector_manager.store.search_memories_by_vector(
-                query_text=query,
-                limit=self.top_k,
-                channel_id=channel_id,
-            )
-        except Exception as e:
-            await func.report_error(e, "EpisodicMemoryProvider.get: vector search failed")
-            return None
+            try:
+                fragments = await vector_manager.store.search_memories_by_vector(
+                    query_text=query,
+                    limit=self.top_k,
+                    channel_id=channel_id,
+                )
+            except Exception as e:
+                await func.report_error(e, "EpisodicMemoryProvider.get: vector search failed")
+                return None
 
-        if not fragments:
-            formatted_result = None
-        else:
-            lines = ["--- Relevant Past Memories ---"]
-            total_chars = len(lines[0])
+            if not fragments:
+                formatted_result = None
+            else:
+                lines = ["--- Relevant Past Memories ---"]
+                total_chars = len(lines[0])
 
-            for i, frag in enumerate(fragments, 1):
-                ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
-                jump_url = frag.metadata.get("jump_url")
+                for i, frag in enumerate(fragments, 1):
+                    ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
+                    jump_url = frag.metadata.get("jump_url")
 
-                # Build source label: prefer a Discord message link over plain timestamp
-                if jump_url and ts:
-                    try:
-                        unix_ts = int(float(ts))
-                        source_str = f" [[Source <t:{unix_ts}:R>]({jump_url})]"
-                    except Exception:
+                    # Build source label: prefer a Discord message link over plain timestamp
+                    if jump_url and ts:
+                        try:
+                            unix_ts = int(float(ts))
+                            source_str = f" [[Source <t:{unix_ts}:R>]({jump_url})]"
+                        except Exception:
+                            source_str = f" [[Source]({jump_url})]"
+                    elif jump_url:
                         source_str = f" [[Source]({jump_url})]"
-                elif jump_url:
-                    source_str = f" [[Source]({jump_url})]"
-                elif ts:
-                    try:
-                        unix_ts = int(float(ts))
-                        source_str = f" [<t:{unix_ts}:R>]"
-                    except Exception:
+                    elif ts:
+                        try:
+                            unix_ts = int(float(ts))
+                            source_str = f" [<t:{unix_ts}:R>]"
+                        except Exception:
+                            source_str = ""
+                    else:
                         source_str = ""
-                else:
-                    source_str = ""
 
-                entry_str = f"[memory #{i}] {frag.content}{source_str}"
+                    entry_str = f"[memory #{i}] {frag.content}{source_str}"
 
-                if total_chars + len(entry_str) + 1 > self.max_chars:
-                    break
-                lines.append(entry_str)
-                total_chars += len(entry_str) + 1
+                    if total_chars + len(entry_str) + 1 > self.max_chars:
+                        break
+                    lines.append(entry_str)
+                    total_chars += len(entry_str) + 1
 
-            lines.append("--- End Past Memories ---")
-            _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
-            formatted_result = "\n".join(lines)
+                lines.append("--- End Past Memories ---")
+                _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
+                formatted_result = "\n".join(lines)
 
-        # Update cache
-        expire_at = now + self.cache_ttl
-        self._cache[cache_key] = (formatted_result, expire_at)
+            # Update cache
+            expire_at = time.monotonic() + self.cache_ttl
+            self._cache[cache_key] = (formatted_result, expire_at)
 
-        # Prune expired items if cache is getting large
-        if len(self._cache) > self.max_cache_size:
-            now_insert = time.monotonic()
-            self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+            # Prune expired items if cache is getting large
+            if len(self._cache) > self.max_cache_size:
+                now_insert = time.monotonic()
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
 
-            # If still over size, remove oldest via insertion order
-            while len(self._cache) > self.max_cache_size:
-                oldest_key = next(iter(self._cache))
-                self._cache.pop(oldest_key, None)
+                # If still over size, remove oldest via insertion order
+                while len(self._cache) > self.max_cache_size:
+                    oldest_key = next(iter(self._cache))
+                    self._cache.pop(oldest_key, None)
 
-        return formatted_result
+            return formatted_result
+        finally:
+            event.set()
+            self._pending_queries.pop(cache_key, None)
 
+
+
+    async def invalidate(self, channel_id: str) -> None:
+        """Clear all cached elements for a specific channel."""
+        keys_to_remove = [k for k in self._cache.keys() if k[0] == str(channel_id)]
+        for k in keys_to_remove:
+            self._cache.pop(k, None)


### PR DESCRIPTION
**What was found:**
1. The `EpisodicMemoryProvider` lacked cache invalidation, meaning that when new memories were ingested by `VectorizationService`, agents wouldn't immediately have access to them due to TTL cache staleness.
2. The `EpisodicMemoryProvider` could perform redundant parallel vector searches for identical queries if they arrived simultaneously before the cache was populated (thundering herd problem).

**Where it is:**
- `llm/memory/episodic.py`
- `cogs/memory/services/vectorization_service.py`

**Why it matters:**
- Caching newly ingested memories without immediate invalidation leads to AI agents missing critical new context just after a user provides it.
- Thundering herd protection prevents DB overload and duplicate API calls in a busy server.

**What was done:**
- Added `_pending_queries` in `EpisodicMemoryProvider` using `asyncio.Event` to safely block concurrent identical queries and await the first result.
- Added `invalidate(channel_id: str)` to `EpisodicMemoryProvider` to easily clear out cached data per channel.
- Modified `VectorizationService` to fetch the `episodic_provider` from the orchestrator and call `invalidate()` for the affected channel(s) right after memories are ingested.

---
*PR created automatically by Jules for task [14639554855333254375](https://jules.google.com/task/14639554855333254375) started by @starpig1129*