### PR TITLE
[UX] Add specific error messages to global app command handler

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -433,20 +433,26 @@ class PigPig(commands.Bot):
             logger = getattr(self, "system_logger", log)
             guild_id_str = str(interaction.guild_id) if interaction.guild_id else "0"
 
-            logger.error(f"Error in slash command '{interaction.command.name if interaction.command else 'Unknown'}': {error}")
-            logger.error("".join(traceback.format_exception(type(error), error, error.__traceback__)))
-
-            await func.report_error(error, f"on_tree_error: {interaction.command.name if interaction.command else 'Unknown'}")
-
-            # Send a user-friendly error message
-            lang_manager = self.get_cog("LanguageManager")
-            if lang_manager:
-                try:
-                    error_msg = lang_manager.translate(guild_id_str, "system", "general", "errors", "unexpected_error")
-                except Exception:
-                    error_msg = "❌ 抱歉，執行此指令時發生未預期的錯誤。(An unexpected error occurred.)"
+            if isinstance(error, discord.app_commands.CommandOnCooldown):
+                error_msg = f"⏳ 此指令冷卻中，請再等候 {error.retry_after:.1f} 秒。(Command on cooldown. Please wait {error.retry_after:.1f}s.)"
+            elif isinstance(error, discord.app_commands.MissingPermissions):
+                error_msg = "🚫 您沒有足夠的權限執行此指令。(You do not have permission to execute this command.)"
+            elif isinstance(error, discord.app_commands.BotMissingPermissions):
+                error_msg = "🤖 機器人缺少必要的權限來執行此指令。(The bot is missing necessary permissions to execute this command.)"
             else:
-                error_msg = "❌ 抱歉，執行此指令時發生未預期的錯誤。(An unexpected error occurred.)"
+                logger.error(f"Error in slash command '{interaction.command.name if interaction.command else 'Unknown'}': {error}")
+                logger.error("".join(traceback.format_exception(type(error), error, error.__traceback__)))
+                await func.report_error(error, f"on_tree_error: {interaction.command.name if interaction.command else 'Unknown'}")
+
+                # Send a user-friendly error message
+                lang_manager = self.get_cog("LanguageManager")
+                if lang_manager:
+                    try:
+                        error_msg = lang_manager.translate(guild_id_str, "system", "general", "errors", "unexpected_error")
+                    except Exception:
+                        error_msg = "❌ 抱歉，執行此指令時發生未預期的錯誤。(An unexpected error occurred.)"
+                else:
+                    error_msg = "❌ 抱歉，執行此指令時發生未預期的錯誤。(An unexpected error occurred.)"
 
             try:
                 if not interaction.response.is_done():


### PR DESCRIPTION
1. **What was found**: The global slash command error handler (`on_tree_error` in `bot.py`) caught all `discord.app_commands.AppCommandError` exceptions and always replied with a generic "unexpected error" message: `"❌ 抱歉，執行此指令時發生未預期的錯誤。(An unexpected error occurred.)"`. This causes severe user confusion when the error is actually an expected constraint violation, such as being on cooldown or missing required permissions.
2. **Where it is**: `bot.py`, in the `on_tree_error` function, lines ~435.
3. **Why it matters**: A major UX friction point. Users were frequently encountering expected constraints (e.g. cooldown limits, lacking permissions) and receiving generic, unhelpful error messages rather than actionable context.
4. **What was done**: Modified `bot.py`'s `on_tree_error` function to specifically handle `CommandOnCooldown`, `MissingPermissions`, and `BotMissingPermissions` exceptions, replacing the generic error with user-friendly, specific bilingual (Chinese/English) feedback messages. This prevents the system from logging tracebacks for non-bugs and improves the UX.

---
*PR created automatically by Jules for task [16870004965955776482](https://jules.google.com/task/16870004965955776482) started by @starpig1129*