### PR TITLE
[Perf] Resolve N+1 DB queries in ProceduralStorage

### DIFF
--- a/cogs/memory/db/procedural_storage.py
+++ b/cogs/memory/db/procedural_storage.py
@@ -81,6 +81,76 @@ class ProceduralStorage:
             await func.report_error(e, f"get_user_info failed (user: {discord_id})")
             return None
 
+    async def get_users_info(self, discord_ids: List[str]) -> Dict[str, UserInfo]:
+        """Fetch multiple users efficiently using a single SQL query."""
+        if not discord_ids:
+            return {}
+
+        results: Dict[str, UserInfo] = {}
+        missing_ids = []
+
+        for discord_id in discord_ids:
+            if discord_id in self._user_cache:
+                results[discord_id] = self._user_cache[discord_id]
+            else:
+                missing_ids.append(discord_id)
+
+        if not missing_ids:
+            return results
+
+        try:
+            with self.db.get_connection() as conn:
+                placeholders = ",".join("?" * len(missing_ids))
+                cursor = conn.execute(
+                    f"""
+                    SELECT discord_id, discord_name, display_names,
+                           procedural_memory, user_background, created_at
+                    FROM users
+                    WHERE discord_id IN ({placeholders})
+                    """,
+                    tuple(missing_ids),
+                )
+
+                rows = cursor.fetchall()
+                for row in rows:
+                    discord_id = str(row["discord_id"])
+
+                    display_names = []
+                    if row["display_names"]:
+                        try:
+                            display_names = json.loads(row["display_names"])
+                            if not isinstance(display_names, list):
+                                display_names = [str(display_names)]
+                        except Exception:
+                            display_names = [row["display_names"]]
+
+                    created_at = None
+                    if row["created_at"]:
+                        try:
+                            created_at = datetime.fromisoformat(row["created_at"])
+                        except Exception:
+                            try:
+                                created_at = datetime.fromtimestamp(float(row["created_at"]))
+                            except Exception:
+                                created_at = None
+
+                    user_info = UserInfo(
+                        discord_id=discord_id,
+                        discord_name=row["discord_name"] or "",
+                        display_names=display_names,
+                        procedural_memory=row["procedural_memory"],
+                        user_background=row["user_background"],
+                        created_at=created_at,
+                    )
+
+                    self._update_cache(discord_id, user_info)
+                    results[discord_id] = user_info
+
+            return results
+        except Exception as e:
+            await func.report_error(e, f"get_users_info failed for {len(missing_ids)} users")
+            return results
+
     async def update_user_data(
         self,
         discord_id: str,

--- a/cogs/memory/users/manager.py
+++ b/cogs/memory/users/manager.py
@@ -55,16 +55,25 @@ class SQLiteUserManager:
 
         if uncached:
             try:
-                coros = [self.storage.get_user_info(uid) for uid in uncached]
-                rows = await asyncio.gather(*coros, return_exceptions=True)
-                for uid, row in zip(uncached, rows):
-                    if isinstance(row, Exception):
-                        await func.report_error(row, f"get_user_info failed for {uid}")
-                        continue
-                    if isinstance(row, UserInfo):
-                        result[uid] = row
+                if hasattr(self.storage, "get_users_info"):
+                    # Use batched optimized method if available
+                    batch_results = await getattr(self.storage, "get_users_info")(uncached)
+                    for uid, info in batch_results.items():
+                        result[uid] = info
                         if use_cache:
-                            self._update_cache(uid, row)
+                            self._update_cache(uid, info)
+                else:
+                    # Fallback to existing gather approach
+                    coros = [self.storage.get_user_info(uid) for uid in uncached]
+                    rows = await asyncio.gather(*coros, return_exceptions=True)
+                    for uid, row in zip(uncached, rows):
+                        if isinstance(row, Exception):
+                            await func.report_error(row, f"get_user_info failed for {uid}")
+                            continue
+                        if isinstance(row, UserInfo):
+                            result[uid] = row
+                            if use_cache:
+                                self._update_cache(uid, row)
             except Exception as e:
                 await func.report_error(e, "Failed to retrieve multiple users")
         return result


### PR DESCRIPTION
### What was found:
In `cogs/memory/users/manager.py`, fetching multiple uncached users via `get_multiple_users` triggered an N+1 query problem. It executed `asyncio.gather(*[self.storage.get_user_info(uid) for uid in uncached])`. This issued multiple individual SELECT statements, blocking the event loop and dramatically increasing database load.

### Where it is:
1. `cogs/memory/db/procedural_storage.py` (added `get_users_info` method)
2. `cogs/memory/users/manager.py` (lines ~58-66)

### Why it matters:
When fetching memory contexts for large channels or multi-user conversations, launching multiple simultaneous database connections/queries creates extreme latency and blocks the async loop, increasing bot response time significantly. Using a batched query prevents these performance bottlenecks and connection pool exhaustion.

### What was done:
1. Implemented `get_users_info(self, discord_ids: List[str])` in `ProceduralStorage`. It effectively uses the SQL `WHERE discord_id IN (...)` clause to look up all uncached users in a single query.
2. Updated `manager.py` to use Python feature detection `hasattr(self.storage, 'get_users_info')`. It prefers the batched method if available but transparently falls back to `asyncio.gather` for any legacy/unsupported storage providers.
3. Verified existing test cases pass properly.

---
*PR created automatically by Jules for task [10263388373534883398](https://jules.google.com/task/10263388373534883398) started by @starpig1129*