### PR TITLE
[Perf] Add TTL cache invalidation and thundering herd protection to EpisodicMemoryProvider

### DIFF
--- a/cogs/memory/services/vectorization_service.py
+++ b/cogs/memory/services/vectorization_service.py
@@ -78,6 +78,25 @@ class VectorizationService:
                 logger.info(f"Storing {len(fragments)} memory fragments in vector database")
                 await store.add_memories(fragments)
                 logger.info("Successfully stored memory fragments in vector database")
+
+                # Invalidate episodic memory cache for affected channels
+                orchestrator = getattr(self.bot, "orchestrator", None)
+                if orchestrator:
+                    context_manager = getattr(orchestrator, "context_manager", None)
+                    if context_manager:
+                        episodic_provider = getattr(context_manager, "episodic_provider", None)
+                        if episodic_provider and hasattr(episodic_provider, "invalidate"):
+                            affected_channels = set()
+                            for frag in fragments:
+                                cid = frag.metadata.get("channel_id")
+                                if cid:
+                                    affected_channels.add(str(cid))
+                            for cid in affected_channels:
+                                try:
+                                    episodic_provider.invalidate(cid)
+                                except Exception as e:
+                                    logger.warning(f"Failed to invalidate episodic cache for channel {cid}: {e}")
+
             except Exception as e:
                 await func.report_error(e, "vector_store_add_memories_failed")
                 return

--- a/llm/memory/episodic.py
+++ b/llm/memory/episodic.py
@@ -50,6 +50,17 @@ class EpisodicMemoryProvider:
         self.cache_ttl = cache_ttl
         # key: (channel_id: str, query: str), value: (formatted_str: Optional[str], expire_at: float monotonic)
         self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
+        self._pending_queries: Dict[Tuple[str, str], asyncio.Event] = {}
+
+    def invalidate(self, channel_id: str) -> None:
+        """Invalidate all cache entries for a specific channel.
+
+        Args:
+            channel_id: The Discord channel ID as a string.
+        """
+        keys_to_remove = [k for k in self._cache.keys() if k[0] == str(channel_id)]
+        for k in keys_to_remove:
+            self._cache.pop(k, None)
 
     async def get(self, message: discord.Message) -> Optional[str]:
         """Return formatted episodic context string, or None if nothing relevant.
@@ -83,68 +94,85 @@ class EpisodicMemoryProvider:
         if entry is not None and entry[1] > now:
             return entry[0]
 
+        # Check if another task is already fetching this exact query
+        if cache_key in self._pending_queries:
+            event = self._pending_queries[cache_key]
+            await event.wait()
+            # After waiting, the result should be in the cache
+            entry = self._cache.get(cache_key)
+            if entry is not None and entry[1] > time.monotonic():
+                return entry[0]
+
+        # We are the first to request this query, set up the event
+        event = asyncio.Event()
+        self._pending_queries[cache_key] = event
+
         try:
-            fragments = await vector_manager.store.search_memories_by_vector(
-                query_text=query,
-                limit=self.top_k,
-                channel_id=channel_id,
-            )
-        except Exception as e:
-            await func.report_error(e, "EpisodicMemoryProvider.get: vector search failed")
-            return None
+            try:
+                fragments = await vector_manager.store.search_memories_by_vector(
+                    query_text=query,
+                    limit=self.top_k,
+                    channel_id=channel_id,
+                )
+            except Exception as e:
+                await func.report_error(e, "EpisodicMemoryProvider.get: vector search failed")
+                return None
 
-        if not fragments:
-            formatted_result = None
-        else:
-            lines = ["--- Relevant Past Memories ---"]
-            total_chars = len(lines[0])
+            if not fragments:
+                formatted_result = None
+            else:
+                lines = ["--- Relevant Past Memories ---"]
+                total_chars = len(lines[0])
 
-            for i, frag in enumerate(fragments, 1):
-                ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
-                jump_url = frag.metadata.get("jump_url")
+                for i, frag in enumerate(fragments, 1):
+                    ts = frag.metadata.get("start_timestamp") or frag.metadata.get("timestamp")
+                    jump_url = frag.metadata.get("jump_url")
 
-                # Build source label: prefer a Discord message link over plain timestamp
-                if jump_url and ts:
-                    try:
-                        unix_ts = int(float(ts))
-                        source_str = f" [[Source <t:{unix_ts}:R>]({jump_url})]"
-                    except Exception:
+                    # Build source label: prefer a Discord message link over plain timestamp
+                    if jump_url and ts:
+                        try:
+                            unix_ts = int(float(ts))
+                            source_str = f" [[Source <t:{unix_ts}:R>]({jump_url})]"
+                        except Exception:
+                            source_str = f" [[Source]({jump_url})]"
+                    elif jump_url:
                         source_str = f" [[Source]({jump_url})]"
-                elif jump_url:
-                    source_str = f" [[Source]({jump_url})]"
-                elif ts:
-                    try:
-                        unix_ts = int(float(ts))
-                        source_str = f" [<t:{unix_ts}:R>]"
-                    except Exception:
+                    elif ts:
+                        try:
+                            unix_ts = int(float(ts))
+                            source_str = f" [<t:{unix_ts}:R>]"
+                        except Exception:
+                            source_str = ""
+                    else:
                         source_str = ""
-                else:
-                    source_str = ""
 
-                entry_str = f"[memory #{i}] {frag.content}{source_str}"
+                    entry_str = f"[memory #{i}] {frag.content}{source_str}"
 
-                if total_chars + len(entry_str) + 1 > self.max_chars:
-                    break
-                lines.append(entry_str)
-                total_chars += len(entry_str) + 1
+                    if total_chars + len(entry_str) + 1 > self.max_chars:
+                        break
+                    lines.append(entry_str)
+                    total_chars += len(entry_str) + 1
 
-            lines.append("--- End Past Memories ---")
-            _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
-            formatted_result = "\n".join(lines)
+                lines.append("--- End Past Memories ---")
+                _LOGGER.debug(f"Injecting {len(lines) - 2} episodic fragments into context.")
+                formatted_result = "\n".join(lines)
 
-        # Update cache
-        expire_at = now + self.cache_ttl
-        self._cache[cache_key] = (formatted_result, expire_at)
+            # Update cache
+            expire_at = time.monotonic() + self.cache_ttl
+            self._cache[cache_key] = (formatted_result, expire_at)
 
-        # Prune expired items if cache is getting large
-        if len(self._cache) > self.max_cache_size:
-            now_insert = time.monotonic()
-            self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+            # Prune expired items if cache is getting large
+            if len(self._cache) > self.max_cache_size:
+                now_insert = time.monotonic()
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
 
-            # If still over size, remove oldest via insertion order
-            while len(self._cache) > self.max_cache_size:
-                oldest_key = next(iter(self._cache))
-                self._cache.pop(oldest_key, None)
+                # If still over size, remove oldest via insertion order
+                while len(self._cache) > self.max_cache_size:
+                    oldest_key = next(iter(self._cache))
+                    self._cache.pop(oldest_key, None)
 
-        return formatted_result
+            return formatted_result
+        finally:
+            self._pending_queries.pop(cache_key, None)
+            event.set()
 


### PR DESCRIPTION
**What was found:**
1. Stale Cache / Eventual Consistency Issue: When new memory fragments are added to the vector store (`VectorizationService`), the `EpisodicMemoryProvider` retains stale results until the TTL expires, leading to the bot failing to recall newly formed memories in the same channel.
2. Thundering Herd (Cache Stampede) Issue: Multiple concurrent messages in the same channel triggering the same background fetch could cause duplicate, expensive vector database queries.

**Where it is:**
1. `llm/memory/episodic.py` (around line 90-190).
2. `cogs/memory/services/vectorization_service.py` (around line 78-95).

**Why it matters:**
1. **Accuracy**: Explicit cache invalidation ensures the bot's memory is immediately consistent with the vector store after a new memory is committed.
2. **Performance/Cost**: Request coalescing prevents spikes in vector database operations when a burst of similar requests arrives simultaneously.

**What was done:**
1. Added `_pending_queries: Dict[Tuple[str, str], asyncio.Event]` to `EpisodicMemoryProvider`.
2. Wrapped vector search logic in `EpisodicMemoryProvider.get()` using `try...finally` with `asyncio.Event` to wait for in-flight requests before checking the cache again.
3. Added an `invalidate(channel_id)` method to `EpisodicMemoryProvider` to clear the cache for a specific channel.
4. Updated `VectorizationService.process_event_summaries` to resolve `bot.orchestrator.context_manager.episodic_provider` and call `invalidate` on all affected channels after successfully saving new fragments to the vector store.

---
*PR created automatically by Jules for task [14303117678071509552](https://jules.google.com/task/14303117678071509552) started by @starpig1129*