### PR TITLE
[Perf] Add thundering herd cache stampede protection to Memory Providers

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -33,7 +33,8 @@ class KnowledgeMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: (type, target_id), value: (content, expire_at)
         self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
-        self._lock = asyncio.Lock()
+        # prevents cache stampedes
+        self._pending_queries: Dict[Tuple[str, str], asyncio.Event] = {}
 
     async def get(self, guild_id: Optional[str], channel_id: str) -> KnowledgeMemory:
         """Fetch knowledge for the current guild and channel.
@@ -58,36 +59,54 @@ class KnowledgeMemoryProvider:
 
     async def _get_single(self, target_type: str, target_id: str) -> Optional[str]:
         """Internal helper with TTL cache."""
-        now = time.monotonic()
         cache_key = (target_type, target_id)
         
-        async with self._lock:
+        # Thundering herd protection logic
+        while cache_key in self._pending_queries:
+            await self._pending_queries[cache_key].wait()
+            now = time.monotonic()
             entry = self._cache.get(cache_key)
             if entry is not None and entry[1] > now:
                 return entry[0]
+
+        now = time.monotonic()
+        entry = self._cache.get(cache_key)
+        if entry is not None and entry[1] > now:
+            return entry[0]
+
+        event = asyncio.Event()
+        self._pending_queries[cache_key] = event
         
-        # Cache miss
         try:
-            content = await self.storage.get_knowledge(target_type, target_id)
-        except Exception as e:
-            await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
-            content = None
+            # Cache miss
+            try:
+                content = await self.storage.get_knowledge(target_type, target_id)
+            except Exception as e:
+                await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
+                content = None
+
+            # Update cache
+            now_insert = time.monotonic()
+            expire_at = now_insert + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
             
-        # Update cache
-        expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
-        async with self._lock:
             self._cache[cache_key] = (content, expire_at)
             
             # Prune cache if needed
             if len(self._cache) > self.max_cache_size:
-                self._cache = {k: v for k, v in self._cache.items() if v[1] > now}
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
                 while len(self._cache) > self.max_cache_size:
                     oldest_key = next(iter(self._cache))
-                    self._cache.pop(oldest_key)
+                    self._cache.pop(oldest_key, None)
                     
-        return content
+            return content
+        finally:
+            self._pending_queries.pop(cache_key, None)
+            event.set()
 
     async def invalidate(self, target_type: str, target_id: str) -> None:
         """Invalidate cache for a specific target."""
-        async with self._lock:
-            self._cache.pop((target_type, target_id), None)
+        cache_key = (target_type, target_id)
+        self._cache.pop(cache_key, None)
+        event = self._pending_queries.pop(cache_key, None)
+        if event:
+            event.set()

--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -32,7 +32,8 @@ class ProceduralMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
         self._cache: Dict[str, Tuple[UserInfo, float]] = {}
-        self._lock = asyncio.Lock()
+        # prevents cache stampedes
+        self._pending_queries: Dict[str, asyncio.Event] = {}
 
     async def get(self, user_ids: List[str]) -> ProceduralMemory:
         """Fetch procedural memory with per-user TTL cache.
@@ -49,40 +50,59 @@ class ProceduralMemoryProvider:
         if not user_ids or not self.user_manager:
             return ProceduralMemory(user_info={})
 
-        now = time.monotonic()
         result: Dict[str, UserInfo] = {}
         missing_ids: List[str] = []
 
-        async with self._lock:
-            for uid in user_ids:
+        # Thundering herd protection logic
+        for uid in set(user_ids):
+            # Wait if another query is already fetching this user
+            while uid in self._pending_queries:
+                await self._pending_queries[uid].wait()
+                now = time.monotonic()
+                entry = self._cache.get(uid)
+                if entry is not None and entry[1] > now:
+                    result[uid] = entry[0]
+                    break
+            else:
+                now = time.monotonic()
                 entry = self._cache.get(uid)
                 if entry is not None and entry[1] > now:
                     result[uid] = entry[0]
                 else:
                     missing_ids.append(uid)
+                    self._pending_queries[uid] = asyncio.Event()
 
         if missing_ids:
             try:
-                fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
-                    [str(uid) for uid in missing_ids]
-                )
-            except Exception as e:
-                await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
-                fetched = {}
+                try:
+                    fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
+                        [str(uid) for uid in missing_ids]
+                    )
+                except Exception as e:
+                    await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
+                    fetched = {}
 
-            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
-            async with self._lock:
-                for uid, info in fetched.items():
-                    self._cache[uid] = (info, expire_at)
-                    result[uid] = info
+                expire_at = time.monotonic() + memory_config.procedural_cache_ttl
+                now_insert = time.monotonic()
+
+                for uid in missing_ids:
+                    info = fetched.get(uid)
+                    if info is not None:
+                        self._cache[uid] = (info, expire_at)
+                        result[uid] = info
 
                 if len(self._cache) > self.max_cache_size:
-                    now_insert = time.monotonic()
                     self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
 
                     while len(self._cache) > self.max_cache_size:
                         oldest_key = next(iter(self._cache))
-                        self._cache.pop(oldest_key)
+                        self._cache.pop(oldest_key, None)
+            finally:
+                # Always clean up events and unblock waiting tasks
+                for uid in missing_ids:
+                    event = self._pending_queries.pop(uid, None)
+                    if event:
+                        event.set()
 
         return ProceduralMemory(user_info=result)
 
@@ -95,5 +115,8 @@ class ProceduralMemoryProvider:
         Args:
             user_id: The user_id string to remove from cache.
         """
-        async with self._lock:
-            self._cache.pop(str(user_id), None)
+        uid_str = str(user_id)
+        self._cache.pop(uid_str, None)
+        event = self._pending_queries.pop(uid_str, None)
+        if event:
+            event.set()


### PR DESCRIPTION
1. What was found:
The memory providers (`ProceduralMemoryProvider` and `KnowledgeMemoryProvider`) were using `asyncio.Lock()` to wrap purely synchronous dictionary operations. Since there were no `await` statements inside the lock blocks, task switching didn't happen, making the lock useless for concurrency protection. More importantly, concurrent identical requests on cache misses bypassed the cache concurrently, causing duplicate identical database and API queries (cache stampedes/thundering herds).

2. Where it is:
`llm/memory/procedural.py` (lines 53-122)
`llm/memory/knowledge.py` (lines 60-108)

3. Why it matters:
The lack of a thundering herd protection in these high-traffic paths caused an N+1 scaling problem: if 5 concurrent messages arrived in a channel missing procedural or knowledge caches, 5 identical expensive DB/Vector queries were executed simultaneously. Fixing this significantly improves the bot's scalability and latency under load and prevents database thrashing.

4. What was done:
- Replaced `asyncio.Lock` with an `asyncio.Event`-based `_pending_queries` dictionary for fine-grained synchronization.
- When a cache miss occurs, the first task places an `Event` into `_pending_queries` and executes the database fetch.
- Subsequent requests for the same ID hit the `_pending_queries` block and `await` the event to resolve, successfully short-circuiting database fetches and immediately leveraging the newly populated cache.
- Guaranteed safety against deadlocks with `try...finally` to always pop and `.set()` the events even if network/database fetches fail.
- Updated `.invalidate()` to appropriately pop elements from both the cache and `_pending_queries`.

---
*PR created automatically by Jules for task [11447231161678963879](https://jules.google.com/task/11447231161678963879) started by @starpig1129*