### PR TITLE
[Perf] Add thundering herd protection to memory providers

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -33,7 +33,7 @@ class KnowledgeMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: (type, target_id), value: (content, expire_at)
         self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
-        self._lock = asyncio.Lock()
+        self._pending_queries: Dict[Tuple[str, str], asyncio.Event] = {}
 
     async def get(self, guild_id: Optional[str], channel_id: str) -> KnowledgeMemory:
         """Fetch knowledge for the current guild and channel.
@@ -58,36 +58,51 @@ class KnowledgeMemoryProvider:
 
     async def _get_single(self, target_type: str, target_id: str) -> Optional[str]:
         """Internal helper with TTL cache."""
-        now = time.monotonic()
         cache_key = (target_type, target_id)
         
-        async with self._lock:
-            entry = self._cache.get(cache_key)
-            if entry is not None and entry[1] > now:
-                return entry[0]
+        # Thundering herd protection logic
+        while cache_key in self._pending_queries:
+            await self._pending_queries[cache_key].wait()
+
+        now = time.monotonic()
+        entry = self._cache.get(cache_key)
+        if entry is not None and entry[1] > now:
+            return entry[0]
+
+        event = asyncio.Event()
+        self._pending_queries[cache_key] = event
         
         # Cache miss
         try:
-            content = await self.storage.get_knowledge(target_type, target_id)
-        except Exception as e:
-            await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
-            content = None
-            
-        # Update cache
-        expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
-        async with self._lock:
+            try:
+                content = await self.storage.get_knowledge(target_type, target_id)
+            except Exception as e:
+                await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
+                content = None
+
+            # Update cache
+            expire_at = time.monotonic() + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
             self._cache[cache_key] = (content, expire_at)
             
             # Prune cache if needed
             if len(self._cache) > self.max_cache_size:
-                self._cache = {k: v for k, v in self._cache.items() if v[1] > now}
+                now_insert = time.monotonic()
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
                 while len(self._cache) > self.max_cache_size:
                     oldest_key = next(iter(self._cache))
                     self._cache.pop(oldest_key)
-                    
-        return content
+
+            return content
+        finally:
+            event = self._pending_queries.pop(cache_key, None)
+            if event:
+                event.set()
 
     async def invalidate(self, target_type: str, target_id: str) -> None:
         """Invalidate cache for a specific target."""
-        async with self._lock:
-            self._cache.pop((target_type, target_id), None)
+        cache_key = (target_type, target_id)
+        self._cache.pop(cache_key, None)
+
+        event = self._pending_queries.pop(cache_key, None)
+        if event:
+            event.set()

--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -32,7 +32,7 @@ class ProceduralMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
         self._cache: Dict[str, Tuple[UserInfo, float]] = {}
-        self._lock = asyncio.Lock()
+        self._pending_queries: Dict[str, asyncio.Event] = {}
 
     async def get(self, user_ids: List[str]) -> ProceduralMemory:
         """Fetch procedural memory with per-user TTL cache.
@@ -49,32 +49,47 @@ class ProceduralMemoryProvider:
         if not user_ids or not self.user_manager:
             return ProceduralMemory(user_info={})
 
+        unique_uids = list(set(str(uid) for uid in user_ids))
+
+        # Thundering herd protection logic
+        # Wait until none of the requested uids are pending
+        while True:
+            pending_events = [self._pending_queries[uid] for uid in unique_uids if uid in self._pending_queries]
+            if not pending_events:
+                break
+            # Wait for all currently pending events to complete
+            await asyncio.gather(*(event.wait() for event in pending_events))
+
+        # Now synchronously check the cache and register our own events for missing IDs atomically
         now = time.monotonic()
         result: Dict[str, UserInfo] = {}
         missing_ids: List[str] = []
+        events_created: List[str] = []
 
-        async with self._lock:
-            for uid in user_ids:
-                entry = self._cache.get(uid)
-                if entry is not None and entry[1] > now:
-                    result[uid] = entry[0]
-                else:
-                    missing_ids.append(uid)
+        for uid in unique_uids:
+            entry = self._cache.get(uid)
+            if entry is not None and entry[1] > now:
+                result[uid] = entry[0]
+            else:
+                missing_ids.append(uid)
+                event = asyncio.Event()
+                self._pending_queries[uid] = event
+                events_created.append(uid)
 
         if missing_ids:
             try:
-                fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
-                    [str(uid) for uid in missing_ids]
-                )
-            except Exception as e:
-                await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
-                fetched = {}
+                try:
+                    fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(missing_ids)
+                except Exception as e:
+                    await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
+                    fetched = {}
 
-            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
-            async with self._lock:
-                for uid, info in fetched.items():
-                    self._cache[uid] = (info, expire_at)
-                    result[uid] = info
+                expire_at = time.monotonic() + memory_config.procedural_cache_ttl
+                for uid in missing_ids:
+                    info = fetched.get(uid)
+                    if info:
+                        self._cache[uid] = (info, expire_at)
+                        result[uid] = info
 
                 if len(self._cache) > self.max_cache_size:
                     now_insert = time.monotonic()
@@ -83,6 +98,11 @@ class ProceduralMemoryProvider:
                     while len(self._cache) > self.max_cache_size:
                         oldest_key = next(iter(self._cache))
                         self._cache.pop(oldest_key)
+            finally:
+                for uid in events_created:
+                    event = self._pending_queries.pop(uid, None)
+                    if event:
+                        event.set()
 
         return ProceduralMemory(user_info=result)
 
@@ -95,5 +115,9 @@ class ProceduralMemoryProvider:
         Args:
             user_id: The user_id string to remove from cache.
         """
-        async with self._lock:
-            self._cache.pop(str(user_id), None)
+        uid = str(user_id)
+        self._cache.pop(uid, None)
+
+        event = self._pending_queries.pop(uid, None)
+        if event:
+            event.set()


### PR DESCRIPTION
1. **What was found (problem or opportunity):** Both `ProceduralMemoryProvider` and `KnowledgeMemoryProvider` used an `asyncio.Lock()` to wrap simple cache dictionary access, which offered no thundering herd protection. When concurrent tasks requested the same user ID or knowledge data that was not yet in the cache, the system would issue duplicate backend database queries instead of coordinating to share a single DB fetch. 
2. **Where it is:**
    - `llm/memory/procedural.py` (`ProceduralMemoryProvider.get`, lines ~50-80).
    - `llm/memory/knowledge.py` (`KnowledgeMemoryProvider._get_single`, lines ~58-90).
3. **Why it matters:** This causes a substantial performance bottleneck in the LLM chat orchestration hot path (called on every user message). When the bot spins up under load, duplicate DB queries spike latency, increase database load, and negate the benefits of the caching layer.
4. **What was done:** 
    - Replaced `asyncio.Lock()` with `_pending_queries: Dict[str, asyncio.Event]`.
    - Wrapped cache miss processing in event synchronization logic. If a request is already pending for a key, subsequent requests wait on the corresponding `asyncio.Event` until the DB returns data. 
    - In `ProceduralMemoryProvider` specifically, which handles multiple IDs, the logic was refactored to wait for all pending events in the request batch synchronously before inspecting the cache to avoid deadlocking between tasks awaiting overlapping sets of IDs.

---
*PR created automatically by Jules for task [5600618336294207388](https://jules.google.com/task/5600618336294207388) started by @starpig1129*