### PR TITLE
[Perf] Implement Thundering Herd Protection for Memory Providers

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -33,7 +33,8 @@ class KnowledgeMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: (type, target_id), value: (content, expire_at)
         self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
-        self._lock = asyncio.Lock()
+        # prevents cache stampedes
+        self._pending_queries: Dict[Tuple[str, str], asyncio.Event] = {}
 
     async def get(self, guild_id: Optional[str], channel_id: str) -> KnowledgeMemory:
         """Fetch knowledge for the current guild and channel.
@@ -58,36 +59,51 @@ class KnowledgeMemoryProvider:
 
     async def _get_single(self, target_type: str, target_id: str) -> Optional[str]:
         """Internal helper with TTL cache."""
-        now = time.monotonic()
         cache_key = (target_type, target_id)
         
-        async with self._lock:
+        while cache_key in self._pending_queries:
+            await self._pending_queries[cache_key].wait()
+            now = time.monotonic()
             entry = self._cache.get(cache_key)
             if entry is not None and entry[1] > now:
                 return entry[0]
+
+        now = time.monotonic()
+        entry = self._cache.get(cache_key)
+        if entry is not None and entry[1] > now:
+            return entry[0]
+
+        event = asyncio.Event()
+        self._pending_queries[cache_key] = event
         
-        # Cache miss
         try:
-            content = await self.storage.get_knowledge(target_type, target_id)
-        except Exception as e:
-            await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
-            content = None
-            
-        # Update cache
-        expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
-        async with self._lock:
+            try:
+                content = await self.storage.get_knowledge(target_type, target_id)
+            except Exception as e:
+                await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
+                content = None
+
+            # Update cache
+            now = time.monotonic()
+            expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
             self._cache[cache_key] = (content, expire_at)
-            
+
             # Prune cache if needed
             if len(self._cache) > self.max_cache_size:
                 self._cache = {k: v for k, v in self._cache.items() if v[1] > now}
                 while len(self._cache) > self.max_cache_size:
                     oldest_key = next(iter(self._cache))
-                    self._cache.pop(oldest_key)
-                    
-        return content
+                    self._cache.pop(oldest_key, None)
+
+            return content
+        finally:
+            self._pending_queries.pop(cache_key, None)
+            event.set()
 
     async def invalidate(self, target_type: str, target_id: str) -> None:
         """Invalidate cache for a specific target."""
-        async with self._lock:
-            self._cache.pop((target_type, target_id), None)
+        cache_key = (target_type, target_id)
+        self._cache.pop(cache_key, None)
+        event = self._pending_queries.pop(cache_key, None)
+        if event:
+            event.set()

--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -32,7 +32,8 @@ class ProceduralMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
         self._cache: Dict[str, Tuple[UserInfo, float]] = {}
-        self._lock = asyncio.Lock()
+        # prevents cache stampedes
+        self._pending_queries: Dict[str, asyncio.Event] = {}
 
     async def get(self, user_ids: List[str]) -> ProceduralMemory:
         """Fetch procedural memory with per-user TTL cache.
@@ -49,40 +50,70 @@ class ProceduralMemoryProvider:
         if not user_ids or not self.user_manager:
             return ProceduralMemory(user_info={})
 
-        now = time.monotonic()
+        # Deduplicate user IDs to prevent redundant fetches
+        unique_uids = list(set(str(uid) for uid in user_ids))
         result: Dict[str, UserInfo] = {}
+
+        # 1. Thundering herd protection phase
+        while True:
+            events_to_wait = []
+            for uid in unique_uids:
+                if uid in self._pending_queries:
+                    events_to_wait.append(self._pending_queries[uid].wait())
+
+            if not events_to_wait:
+                break
+
+            # Wait for all currently pending queries to finish
+            await asyncio.gather(*events_to_wait)
+
+        # 2. Synchronous cache check phase
+        now = time.monotonic()
         missing_ids: List[str] = []
 
-        async with self._lock:
-            for uid in user_ids:
-                entry = self._cache.get(uid)
-                if entry is not None and entry[1] > now:
-                    result[uid] = entry[0]
-                else:
-                    missing_ids.append(uid)
+        for uid in unique_uids:
+            entry = self._cache.get(uid)
+            if entry is not None and entry[1] > now:
+                result[uid] = entry[0]
+            else:
+                missing_ids.append(uid)
+                # Register the query as pending immediately to block other concurrent requests
+                self._pending_queries[uid] = asyncio.Event()
 
+        # 3. Fetch missing entries phase
         if missing_ids:
+            fetched: Dict[str, UserInfo] = {}
             try:
-                fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
-                    [str(uid) for uid in missing_ids]
-                )
+                fetched = await self.user_manager.get_multiple_users(missing_ids)
             except Exception as e:
                 await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
+                # Ensure we don't leave the missing users hanging on error
                 fetched = {}
+            finally:
+                # Always resolve pending events and update cache, even on error (we'll just cache empty or partial)
+                expire_at = time.monotonic() + memory_config.procedural_cache_ttl
 
-            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
-            async with self._lock:
-                for uid, info in fetched.items():
-                    self._cache[uid] = (info, expire_at)
-                    result[uid] = info
+                # We iterate over missing_ids to guarantee every pending event we created is cleared
+                for uid in missing_ids:
+                    # If we failed to fetch a user, we store whatever we got, or nothing (it won't be cached as hit)
+                    if uid in fetched:
+                        info = fetched[uid]
+                        self._cache[uid] = (info, expire_at)
+                        result[uid] = info
 
+                    # Unblock pending requests
+                    event = self._pending_queries.pop(uid, None)
+                    if event:
+                        event.set()
+
+                # Prune cache if it exceeds size
                 if len(self._cache) > self.max_cache_size:
                     now_insert = time.monotonic()
                     self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
 
                     while len(self._cache) > self.max_cache_size:
                         oldest_key = next(iter(self._cache))
-                        self._cache.pop(oldest_key)
+                        self._cache.pop(oldest_key, None)
 
         return ProceduralMemory(user_info=result)
 
@@ -95,5 +126,8 @@ class ProceduralMemoryProvider:
         Args:
             user_id: The user_id string to remove from cache.
         """
-        async with self._lock:
-            self._cache.pop(str(user_id), None)
+        uid = str(user_id)
+        self._cache.pop(uid, None)
+        event = self._pending_queries.pop(uid, None)
+        if event:
+            event.set()

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -11,6 +11,16 @@ async def _noop_report_error(*args, **kwargs):
 # Lightweight stubs for optional external dependencies used by ContextManager
 fake_discord = types.ModuleType("discord")
 fake_discord.Message = object
+fake_discord.abc = types.ModuleType("discord.abc")
+fake_discord.abc.Messageable = object
+sys.modules["discord.abc"] = fake_discord.abc
+fake_discord.errors = types.ModuleType("discord.errors")
+fake_discord.errors.NotFound = Exception
+sys.modules["discord.errors"] = fake_discord.errors
+fake_discord.AllowedMentions = lambda **kwargs: object()
+fake_discord.Embed = object
+fake_discord.Colour = object
+fake_discord.File = object
 sys.modules.setdefault("discord", fake_discord)
 
 fake_langchain_messages = types.ModuleType("langchain_core.messages")


### PR DESCRIPTION
### What was found
The memory providers `ProceduralMemoryProvider` and `KnowledgeMemoryProvider` were using a single `asyncio.Lock()` to protect their cache lookups. This is problematic because while a cache miss blocks to perform a DB fetch, the lock must be released (since the `await db_call()` sits inside an `if cache_miss` block). Concurrent requests for the same exact key missing the cache would subsequently run parallel database queries, causing a "thundering herd" (cache stampede).

### Where it is
- `llm/memory/procedural.py` lines 32-125
- `llm/memory/knowledge.py` lines 33-100

### Why it matters
Under high message load, multiple context injections for the same user or channel trigger duplicate expensive queries against SQLite, degrading performance, stalling orchestration routines, and risking DB lock exceptions.

### What was done
Replaced the broad `asyncio.Lock` with an `asyncio.Event`-based deduplication queue (`_pending_queries`).
Concurrent fetches for the exact same ID will safely block on `.wait()` until the first thread resolves, while fetches for independent IDs flow through smoothly in parallel. Finally, ensured the tests appropriately mock newly required symbols (`discord.abc`, `discord.errors`) to maintain complete coverage.

---
*PR created automatically by Jules for task [13194489524113555710](https://jules.google.com/task/13194489524113555710) started by @starpig1129*