### PR TITLE
[Perf] Fix thundering herd in memory providers with request coalescing

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -33,7 +33,7 @@ class KnowledgeMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: (type, target_id), value: (content, expire_at)
         self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
-        self._lock = asyncio.Lock()
+        self._pending_queries: Dict[Tuple[str, str], asyncio.Event] = {}
 
     async def get(self, guild_id: Optional[str], channel_id: str) -> KnowledgeMemory:
         """Fetch knowledge for the current guild and channel.
@@ -58,36 +58,53 @@ class KnowledgeMemoryProvider:
 
     async def _get_single(self, target_type: str, target_id: str) -> Optional[str]:
         """Internal helper with TTL cache."""
-        now = time.monotonic()
         cache_key = (target_type, target_id)
-        
-        async with self._lock:
+
+        while True:
+            now = time.monotonic()
             entry = self._cache.get(cache_key)
             if entry is not None and entry[1] > now:
                 return entry[0]
-        
-        # Cache miss
+
+            if cache_key in self._pending_queries:
+                await self._pending_queries[cache_key].wait()
+                continue
+
+            event = asyncio.Event()
+            self._pending_queries[cache_key] = event
+            break
+
         try:
-            content = await self.storage.get_knowledge(target_type, target_id)
-        except Exception as e:
-            await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
-            content = None
-            
-        # Update cache
-        expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
-        async with self._lock:
+            # Cache miss
+            try:
+                content = await self.storage.get_knowledge(target_type, target_id)
+            except Exception as e:
+                await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
+                content = None
+
+            # Update cache
+            now = time.monotonic()
+            expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
             self._cache[cache_key] = (content, expire_at)
-            
+
             # Prune cache if needed
             if len(self._cache) > self.max_cache_size:
-                self._cache = {k: v for k, v in self._cache.items() if v[1] > now}
+                now_insert = time.monotonic()
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
                 while len(self._cache) > self.max_cache_size:
                     oldest_key = next(iter(self._cache))
-                    self._cache.pop(oldest_key)
-                    
-        return content
+                    self._cache.pop(oldest_key, None)
+
+            return content
+        finally:
+            event = self._pending_queries.pop(cache_key, None)
+            if event:
+                event.set()
 
     async def invalidate(self, target_type: str, target_id: str) -> None:
         """Invalidate cache for a specific target."""
-        async with self._lock:
-            self._cache.pop((target_type, target_id), None)
+        cache_key = (target_type, target_id)
+        self._cache.pop(cache_key, None)
+        event = self._pending_queries.pop(cache_key, None)
+        if event:
+            event.set()

--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -32,7 +32,7 @@ class ProceduralMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
         self._cache: Dict[str, Tuple[UserInfo, float]] = {}
-        self._lock = asyncio.Lock()
+        self._pending_queries: Dict[str, asyncio.Event] = {}
 
     async def get(self, user_ids: List[str]) -> ProceduralMemory:
         """Fetch procedural memory with per-user TTL cache.
@@ -49,40 +49,69 @@ class ProceduralMemoryProvider:
         if not user_ids or not self.user_manager:
             return ProceduralMemory(user_info={})
 
-        now = time.monotonic()
+        user_ids = list(set(str(uid) for uid in user_ids))
         result: Dict[str, UserInfo] = {}
-        missing_ids: List[str] = []
+        processed_ids = set()
 
-        async with self._lock:
+        while True:
+            now = time.monotonic()
+            to_fetch: List[str] = []
+            pending_events: List[asyncio.Event] = []
+
             for uid in user_ids:
+                if uid in processed_ids or uid in result:
+                    continue
+
                 entry = self._cache.get(uid)
                 if entry is not None and entry[1] > now:
                     result[uid] = entry[0]
+                    processed_ids.add(uid)
+                elif uid in self._pending_queries:
+                    pending_events.append(self._pending_queries[uid])
                 else:
-                    missing_ids.append(uid)
+                    to_fetch.append(uid)
 
-        if missing_ids:
+            if not to_fetch and not pending_events:
+                break
+
+            if pending_events and not to_fetch:
+                unique_events = list(set(pending_events))
+                await asyncio.gather(*(event.wait() for event in unique_events))
+                continue
+
+            for uid in to_fetch:
+                event = asyncio.Event()
+                self._pending_queries[uid] = event
+
             try:
-                fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
-                    [str(uid) for uid in missing_ids]
-                )
-            except Exception as e:
-                await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
-                fetched = {}
+                try:
+                    fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(to_fetch)
+                except Exception as e:
+                    await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
+                    fetched = {}
 
-            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
-            async with self._lock:
-                for uid, info in fetched.items():
-                    self._cache[uid] = (info, expire_at)
-                    result[uid] = info
+                expire_at = time.monotonic() + memory_config.procedural_cache_ttl
+                now_insert = time.monotonic()
+
+                for uid in to_fetch:
+                    processed_ids.add(uid)
+                    info = fetched.get(uid)
+                    if info is not None:
+                        self._cache[uid] = (info, expire_at)
+                        result[uid] = info
 
                 if len(self._cache) > self.max_cache_size:
-                    now_insert = time.monotonic()
                     self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
 
                     while len(self._cache) > self.max_cache_size:
                         oldest_key = next(iter(self._cache))
-                        self._cache.pop(oldest_key)
+                        self._cache.pop(oldest_key, None)
+
+            finally:
+                for uid in to_fetch:
+                    event = self._pending_queries.pop(uid, None)
+                    if event:
+                        event.set()
 
         return ProceduralMemory(user_info=result)
 
@@ -95,5 +124,8 @@ class ProceduralMemoryProvider:
         Args:
             user_id: The user_id string to remove from cache.
         """
-        async with self._lock:
-            self._cache.pop(str(user_id), None)
+        user_id_str = str(user_id)
+        self._cache.pop(user_id_str, None)
+        event = self._pending_queries.pop(user_id_str, None)
+        if event:
+            event.set()


### PR DESCRIPTION
**What**: We discovered a cache stampede (thundering herd) vulnerability in the LLM memory providers. `ProceduralMemoryProvider` and `KnowledgeMemoryProvider` were incorrectly using `asyncio.Lock()` over purely synchronous dictionary checks. As a result, when a cache miss occurred for concurrent queries, multiple tasks would immediately fire redundant, heavy requests to the backend (e.g., SQLite or upstream services).

**Where**: 
- `llm/memory/procedural.py` lines 35, 52-132
- `llm/memory/knowledge.py` lines 36, 61-109

**Why**: This matters because redundant backend queries block the event loop, increase SQLite contention, exhaust rate limits, and introduce significant latency in the user-facing LLM processing hot-path. 

**What was done**: We implemented Request Coalescing (Singleflight pattern). We replaced `asyncio.Lock()` with a `_pending_queries` dictionary of `asyncio.Event` flags. Now, the first request establishes an `Event` and fires the backend query, while any subsequent requests for the same key `await event.wait()` concurrently. `try...finally` blocks were added to strictly prevent async deadlocks by guaranteeing the event is always cleared and set. Tests were run and verify the functionality remains intact.

---
*PR created automatically by Jules for task [10774524294909427945](https://jules.google.com/task/10774524294909427945) started by @starpig1129*