### PR TITLE
[Perf] Add thundering herd protection to ProceduralMemoryProvider

### DIFF
--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -32,7 +32,8 @@ class ProceduralMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
         self._cache: Dict[str, Tuple[UserInfo, float]] = {}
-        self._lock = asyncio.Lock()
+        # prevents cache stampedes
+        self._pending_queries: Dict[str, asyncio.Event] = {}
 
     async def get(self, user_ids: List[str]) -> ProceduralMemory:
         """Fetch procedural memory with per-user TTL cache.
@@ -49,32 +50,61 @@ class ProceduralMemoryProvider:
         if not user_ids or not self.user_manager:
             return ProceduralMemory(user_info={})
 
-        now = time.monotonic()
+        # Deduplicate list to prevent self-deadlocking on same uid
+        unique_uids = list(set(str(uid) for uid in user_ids))
         result: Dict[str, UserInfo] = {}
-        missing_ids: List[str] = []
 
-        async with self._lock:
-            for uid in user_ids:
+        while True:
+            now = time.monotonic()
+            missing_ids: List[str] = []
+            pending_events: List[asyncio.Event] = []
+
+            for uid in unique_uids:
                 entry = self._cache.get(uid)
                 if entry is not None and entry[1] > now:
                     result[uid] = entry[0]
                 else:
-                    missing_ids.append(uid)
+                    event = self._pending_queries.get(uid)
+                    if event:
+                        pending_events.append(event)
+                    else:
+                        missing_ids.append(uid)
+
+            if pending_events:
+                # Wait for all currently pending queries to finish, then loop to check cache again
+                await asyncio.gather(*(event.wait() for event in pending_events))
+                continue
+
+            # If no pending events, we're ready to proceed with missing_ids
+            break
 
         if missing_ids:
-            try:
-                fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
-                    [str(uid) for uid in missing_ids]
-                )
-            except Exception as e:
-                await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
-                fetched = {}
+            # Create events for all missing_ids to block concurrent requests
+            events_created: List[str] = []
+            for uid in missing_ids:
+                event = asyncio.Event()
+                self._pending_queries[uid] = event
+                events_created.append(uid)
 
-            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
-            async with self._lock:
-                for uid, info in fetched.items():
-                    self._cache[uid] = (info, expire_at)
-                    result[uid] = info
+            try:
+                try:
+                    fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(missing_ids)
+                except Exception as e:
+                    await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
+                    fetched = {}
+
+                now_fetched = time.monotonic()
+                expire_at = now_fetched + memory_config.procedural_cache_ttl
+
+                for uid in missing_ids:
+                    # Update result with fetched info (could be missing/empty)
+                    info = fetched.get(uid)
+                    if info is not None:
+                        self._cache[uid] = (info, expire_at)
+                        result[uid] = info
+                    else:
+                        # Optional: Could cache negative hit to prevent constant re-fetching of invalid users
+                        pass
 
                 if len(self._cache) > self.max_cache_size:
                     now_insert = time.monotonic()
@@ -82,7 +112,12 @@ class ProceduralMemoryProvider:
 
                     while len(self._cache) > self.max_cache_size:
                         oldest_key = next(iter(self._cache))
-                        self._cache.pop(oldest_key)
+                        self._cache.pop(oldest_key, None)
+            finally:
+                for uid in events_created:
+                    event = self._pending_queries.pop(uid, None)
+                    if event:
+                        event.set()
 
         return ProceduralMemory(user_info=result)
 
@@ -95,5 +130,10 @@ class ProceduralMemoryProvider:
         Args:
             user_id: The user_id string to remove from cache.
         """
-        async with self._lock:
-            self._cache.pop(str(user_id), None)
+        uid = str(user_id)
+        self._cache.pop(uid, None)
+
+        # Unblock any pending queries that were waiting on a now-invalidated result
+        event = self._pending_queries.pop(uid, None)
+        if event:
+            event.set()


### PR DESCRIPTION
**What** 
Found a thundering herd (cache stampede) vulnerability in `ProceduralMemoryProvider`. When multiple concurrent queries requested a missing `user_id`, the global `asyncio.Lock()` (which did not span the `await` database call) failed to synchronize the requests. This caused all concurrent tasks to simultaneously read a cache miss and blast the database with redundant fetches for the same user.

**Where** 
`llm/memory/procedural.py` inside `ProceduralMemoryProvider.__init__`, `get`, and `invalidate` methods.

**Why** 
In high-traffic servers or during bursts of messages involving the same user, the bot would execute N+1 database queries, slowing down response generation and eating up thread pool resources. This degrades bot latency severely for heavily active users.

**What was done** 
- Replaced the ineffective `self._lock` with `self._pending_queries`, a dictionary of `asyncio.Event` objects.
- Modified the `get` method to deduplicate requested `user_ids` and use a `while True` retry loop.
- If a requested `user_id` is currently being fetched by another task (present in `_pending_queries`), the current task waits concurrently on the corresponding `asyncio.Event` using `asyncio.gather`.
- Once unblocked, it loops back and safely retrieves the data directly from the cache.
- The primary fetching task now properly instantiates `asyncio.Event`s, fetches from the database, updates the cache, and then guarantees `.set()` and cleanup in a `finally` block to prevent self-deadlocking.
- Updated `invalidate` to also unblock any waiting tasks if a manual eviction occurs mid-fetch.

---
*PR created automatically by Jules for task [5757449434429249935](https://jules.google.com/task/5757449434429249935) started by @starpig1129*