### PR TITLE
[UX] Add deferral to mode and shuffle music commands

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -51,11 +51,12 @@ class YTMusic(commands.Cog):
     ])
     async def mode(self, interaction: discord.Interaction, mode: app_commands.Choice[str]):
         """播放模式命令"""
+        await interaction.response.defer(thinking=True)
         guild_id = interaction.guild.id
         if not self.lang_manager: # Ensure lang_manager is loaded
              self.lang_manager = self.bot.get_cog("LanguageManager")
              if not self.lang_manager:
-                 await interaction.response.send_message("Language manager not loaded.", ephemeral=True)
+                 await interaction.edit_original_response(content="Language manager not loaded.")
                  return
  
          # Localize choices (name is already localized by decorator, but value needs translation for response)
@@ -66,7 +67,7 @@ class YTMusic(commands.Cog):
 
         title = self.lang_manager.translate(str(guild_id), "commands", "mode", "responses", "success", mode=mode_name)
         embed = discord.Embed(title=f"✅ | {title}", color=discord.Color.blue())
-        await interaction.response.send_message(embed=embed)
+        await interaction.edit_original_response(embed=embed)
         message = await interaction.original_response()
         state = self.state_manager.get_state(interaction.guild.id)
         state.ui_messages.append(message)
@@ -74,11 +75,12 @@ class YTMusic(commands.Cog):
     @app_commands.command(name="shuffle", description="切換隨機播放")
     async def shuffle(self, interaction: discord.Interaction):
         """隨機播放命令"""
+        await interaction.response.defer(thinking=True)
         guild_id = interaction.guild.id
         if not self.lang_manager: # Ensure lang_manager is loaded
              self.lang_manager = self.bot.get_cog("LanguageManager")
              if not self.lang_manager:
-                 await interaction.response.send_message("Language manager not loaded.", ephemeral=True)
+                 await interaction.edit_original_response(content="Language manager not loaded.")
                  return
  
         is_shuffle = self.queue_manager.toggle_shuffle(guild_id)
@@ -86,7 +88,7 @@ class YTMusic(commands.Cog):
         status = self.lang_manager.translate(str(guild_id), "commands", "shuffle", "responses", status_key)
         title = self.lang_manager.translate(str(guild_id), "commands", "shuffle", "responses", "success", status=status)
         embed = discord.Embed(title=f"✅ | {title}", color=discord.Color.blue())
-        await interaction.response.send_message(embed=embed)
+        await interaction.edit_original_response(embed=embed)
         message = await interaction.original_response()
         state = self.state_manager.get_state(interaction.guild.id)
         state.ui_messages.append(message)


### PR DESCRIPTION
1. **What was found**: The `mode` and `shuffle` slash commands in `cogs/music.py` did not acknowledge the interaction via a deferral before processing queue and mode state updates.
2. **Where it is**: `cogs/music.py` lines 50-89 (inside the `mode` and `shuffle` async definitions).
3. **Why it matters**: Discord API requires interactions to be acknowledged within 3 seconds. If the bot takes slightly too long fetching localizations or processing queue updates, the user sees an ugly "The application did not respond" error, degrading the UX.
4. **What was done**: Added `await interaction.response.defer(thinking=True)` at the beginning of both commands and replaced `await interaction.response.send_message(...)` with `await interaction.edit_original_response(...)` to correctly update the loading state to the final embed.

---
*PR created automatically by Jules for task [11537090964060879739](https://jules.google.com/task/11537090964060879739) started by @starpig1129*