### PR TITLE
[Perf] Fix thundering herd bottleneck in memory cache providers

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -33,7 +33,8 @@ class KnowledgeMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: (type, target_id), value: (content, expire_at)
         self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
-        self._lock = asyncio.Lock()
+        # key: (type, target_id), value: asyncio.Event
+        self._pending_queries: Dict[Tuple[str, str], asyncio.Event] = {}
 
     async def get(self, guild_id: Optional[str], channel_id: str) -> KnowledgeMemory:
         """Fetch knowledge for the current guild and channel.
@@ -45,11 +46,17 @@ class KnowledgeMemoryProvider:
         Returns:
             KnowledgeMemory object containing both levels of knowledge.
         """
-        guild_knowledge = None
+        # Fetch both levels concurrently
+        tasks = []
         if guild_id:
-            guild_knowledge = await self._get_single("guild", guild_id)
+            tasks.append(self._get_single("guild", guild_id))
+        else:
+            async def null_task(): return None
+            tasks.append(null_task())
             
-        channel_knowledge = await self._get_single("channel", channel_id)
+        tasks.append(self._get_single("channel", channel_id))
+
+        guild_knowledge, channel_knowledge = await asyncio.gather(*tasks)
         
         return KnowledgeMemory(
             guild_knowledge=guild_knowledge,
@@ -57,37 +64,53 @@ class KnowledgeMemoryProvider:
         )
 
     async def _get_single(self, target_type: str, target_id: str) -> Optional[str]:
-        """Internal helper with TTL cache."""
-        now = time.monotonic()
+        """Internal helper with TTL cache and thundering herd protection."""
         cache_key = (target_type, target_id)
         
-        async with self._lock:
+        while True:
+            now = time.monotonic()
+
             entry = self._cache.get(cache_key)
             if entry is not None and entry[1] > now:
                 return entry[0]
-        
-        # Cache miss
-        try:
-            content = await self.storage.get_knowledge(target_type, target_id)
-        except Exception as e:
-            await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
-            content = None
             
-        # Update cache
-        expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
-        async with self._lock:
-            self._cache[cache_key] = (content, expire_at)
+            if cache_key in self._pending_queries:
+                await self._pending_queries[cache_key].wait()
+                continue
             
-            # Prune cache if needed
-            if len(self._cache) > self.max_cache_size:
-                self._cache = {k: v for k, v in self._cache.items() if v[1] > now}
-                while len(self._cache) > self.max_cache_size:
-                    oldest_key = next(iter(self._cache))
-                    self._cache.pop(oldest_key)
+            # Cache miss and no pending query, become the active fetcher
+            event = asyncio.Event()
+            self._pending_queries[cache_key] = event
+
+            try:
+                try:
+                    content = await self.storage.get_knowledge(target_type, target_id)
+                except Exception as e:
+                    await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
+                    content = None
                     
-        return content
+                expire_at = time.monotonic() + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
+
+                self._cache[cache_key] = (content, expire_at)
+
+                # Prune cache if needed
+                if len(self._cache) > self.max_cache_size:
+                    now_insert = time.monotonic()
+                    self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+                    while len(self._cache) > self.max_cache_size:
+                        oldest_key = next(iter(self._cache))
+                        self._cache.pop(oldest_key, None)
+
+                return content
+            finally:
+                self._pending_queries.pop(cache_key, None)
+                event.set()
 
     async def invalidate(self, target_type: str, target_id: str) -> None:
         """Invalidate cache for a specific target."""
-        async with self._lock:
-            self._cache.pop((target_type, target_id), None)
+        cache_key = (target_type, target_id)
+        self._cache.pop(cache_key, None)
+
+        event = self._pending_queries.pop(cache_key, None)
+        if event:
+            event.set()

--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -32,7 +32,8 @@ class ProceduralMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
         self._cache: Dict[str, Tuple[UserInfo, float]] = {}
-        self._lock = asyncio.Lock()
+        # key: user_id (str), value: asyncio.Event
+        self._pending_queries: Dict[str, asyncio.Event] = {}
 
     async def get(self, user_ids: List[str]) -> ProceduralMemory:
         """Fetch procedural memory with per-user TTL cache.
@@ -49,30 +50,47 @@ class ProceduralMemoryProvider:
         if not user_ids or not self.user_manager:
             return ProceduralMemory(user_info={})
 
-        now = time.monotonic()
+        unique_uids = list(set(str(uid) for uid in user_ids))
         result: Dict[str, UserInfo] = {}
-        missing_ids: List[str] = []
 
-        async with self._lock:
-            for uid in user_ids:
+        while True:
+            now = time.monotonic()
+            missing_ids: List[str] = []
+            pending_events: List[asyncio.Event] = []
+
+            for uid in unique_uids:
                 entry = self._cache.get(uid)
                 if entry is not None and entry[1] > now:
                     result[uid] = entry[0]
+                elif uid in self._pending_queries:
+                    pending_events.append(self._pending_queries[uid])
                 else:
                     missing_ids.append(uid)
 
-        if missing_ids:
-            try:
-                fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
-                    [str(uid) for uid in missing_ids]
-                )
-            except Exception as e:
-                await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
-                fetched = {}
+            if not missing_ids and not pending_events:
+                return ProceduralMemory(user_info=result)
 
-            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
-            async with self._lock:
-                for uid, info in fetched.items():
+            if pending_events:
+                await asyncio.gather(*(event.wait() for event in pending_events))
+                # Loop again to verify the cache state after waiting.
+                continue
+
+            # We have missing_ids to fetch, and none of them are pending.
+            # Create events for missing_ids.
+            for uid in missing_ids:
+                self._pending_queries[uid] = asyncio.Event()
+
+            try:
+                try:
+                    fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(missing_ids)
+                except Exception as e:
+                    await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
+                    fetched = {}
+
+                expire_at = time.monotonic() + memory_config.procedural_cache_ttl
+
+                for uid in missing_ids:
+                    info = fetched.get(uid, UserInfo())
                     self._cache[uid] = (info, expire_at)
                     result[uid] = info
 
@@ -84,7 +102,12 @@ class ProceduralMemoryProvider:
                         oldest_key = next(iter(self._cache))
                         self._cache.pop(oldest_key)
 
-        return ProceduralMemory(user_info=result)
+                return ProceduralMemory(user_info=result)
+            finally:
+                for uid in missing_ids:
+                    event = self._pending_queries.pop(uid, None)
+                    if event:
+                        event.set()
 
     async def invalidate(self, user_id: str) -> None:
         """Evict a single user from the cache.
@@ -95,5 +118,9 @@ class ProceduralMemoryProvider:
         Args:
             user_id: The user_id string to remove from cache.
         """
-        async with self._lock:
-            self._cache.pop(str(user_id), None)
+        uid = str(user_id)
+        self._cache.pop(uid, None)
+
+        event = self._pending_queries.pop(uid, None)
+        if event:
+            event.set()


### PR DESCRIPTION
1. **What was found**: `ProceduralMemoryProvider` and `KnowledgeMemoryProvider` were vulnerable to cache stampedes (thundering herd). They used an `asyncio.Lock` around a synchronous dictionary lookup, providing zero concurrency protection. During concurrent cache misses, this caused redundant database/API calls because tasks wouldn't wait for the active fetcher to finish. Furthermore, `KnowledgeMemoryProvider` fetched guild and channel knowledge sequentially.
2. **Where it is**: `llm/memory/procedural.py` (lines ~35-104), `llm/memory/knowledge.py` (lines ~35-86).
3. **Why it matters**: In high-traffic environments or during spikes of messages, concurrent requests mapping to the same user or channel bypass the cache and hit the database redundantly. This spikes latency on the bot's hot path (`context_manager`) and increases SQLite lock contention. Sequential fetching in `knowledge.py` also unnecessarily chained DB latency.
4. **What was done**: 
   - Replaced `asyncio.Lock` with an `asyncio.Event`-based `_pending_queries` dictionary in both providers.
   - Tasks encountering a cache miss now register an `asyncio.Event`. Subsequent concurrent tasks for the same keys wait on this event via `asyncio.gather` instead of initiating their own fetch.
   - Wrapped fetching logic in `try...finally` blocks to guarantee event teardown and unblocking (`event.set()`).
   - Refactored `KnowledgeMemoryProvider.get()` to fetch guild and channel knowledge concurrently using `asyncio.gather`.
   - Updated cache `invalidate()` methods to unblock any pending tasks appropriately.

---
*PR created automatically by Jules for task [2896548487397273642](https://jules.google.com/task/2896548487397273642) started by @starpig1129*