### PR TITLE
[Perf] Add thundering herd protection to memory providers

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -33,7 +33,7 @@ class KnowledgeMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: (type, target_id), value: (content, expire_at)
         self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
-        self._lock = asyncio.Lock()
+        self._pending_queries: Dict[Tuple[str, str], asyncio.Event] = {}
 
     async def get(self, guild_id: Optional[str], channel_id: str) -> KnowledgeMemory:
         """Fetch knowledge for the current guild and channel.
@@ -58,36 +58,51 @@ class KnowledgeMemoryProvider:
 
     async def _get_single(self, target_type: str, target_id: str) -> Optional[str]:
         """Internal helper with TTL cache."""
-        now = time.monotonic()
         cache_key = (target_type, target_id)
         
-        async with self._lock:
+        while True:
+            now = time.monotonic()
             entry = self._cache.get(cache_key)
             if entry is not None and entry[1] > now:
                 return entry[0]
-        
-        # Cache miss
-        try:
-            content = await self.storage.get_knowledge(target_type, target_id)
-        except Exception as e:
-            await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
-            content = None
+            elif cache_key in self._pending_queries:
+                await self._pending_queries[cache_key].wait()
+                continue
             
-        # Update cache
-        expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
-        async with self._lock:
-            self._cache[cache_key] = (content, expire_at)
+            event = asyncio.Event()
+            self._pending_queries[cache_key] = event
             
-            # Prune cache if needed
-            if len(self._cache) > self.max_cache_size:
-                self._cache = {k: v for k, v in self._cache.items() if v[1] > now}
-                while len(self._cache) > self.max_cache_size:
-                    oldest_key = next(iter(self._cache))
-                    self._cache.pop(oldest_key)
+            try:
+                try:
+                    content = await self.storage.get_knowledge(target_type, target_id)
+                except Exception as e:
+                    await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
+                    content = None
                     
-        return content
+                # Update cache
+                now = time.monotonic()
+                expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
+
+                self._cache[cache_key] = (content, expire_at)
+
+                # Prune cache if needed
+                if len(self._cache) > self.max_cache_size:
+                    now_insert = time.monotonic()
+                    self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+                    while len(self._cache) > self.max_cache_size:
+                        oldest_key = next(iter(self._cache))
+                        self._cache.pop(oldest_key, None)
+            finally:
+                event = self._pending_queries.pop(cache_key, None)
+                if event:
+                    event.set()
+
+            return content
 
     async def invalidate(self, target_type: str, target_id: str) -> None:
         """Invalidate cache for a specific target."""
-        async with self._lock:
-            self._cache.pop((target_type, target_id), None)
+        cache_key = (target_type, target_id)
+        self._cache.pop(cache_key, None)
+        event = self._pending_queries.pop(cache_key, None)
+        if event:
+            event.set()

--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -32,7 +32,7 @@ class ProceduralMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
         self._cache: Dict[str, Tuple[UserInfo, float]] = {}
-        self._lock = asyncio.Lock()
+        self._pending_queries: Dict[str, asyncio.Event] = {}
 
     async def get(self, user_ids: List[str]) -> ProceduralMemory:
         """Fetch procedural memory with per-user TTL cache.
@@ -49,40 +49,73 @@ class ProceduralMemoryProvider:
         if not user_ids or not self.user_manager:
             return ProceduralMemory(user_info={})
 
-        now = time.monotonic()
+        unique_uids = list(set(user_ids))
         result: Dict[str, UserInfo] = {}
-        missing_ids: List[str] = []
 
-        async with self._lock:
-            for uid in user_ids:
+        while True:
+            now = time.monotonic()
+            missing_ids: List[str] = []
+            pending_events: List[asyncio.Event] = []
+
+            for uid in unique_uids:
                 entry = self._cache.get(uid)
                 if entry is not None and entry[1] > now:
                     result[uid] = entry[0]
+                elif uid in self._pending_queries:
+                    pending_events.append(self._pending_queries[uid])
                 else:
                     missing_ids.append(uid)
 
-        if missing_ids:
-            try:
-                fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
-                    [str(uid) for uid in missing_ids]
-                )
-            except Exception as e:
-                await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
-                fetched = {}
+            if not pending_events and not missing_ids:
+                break
 
-            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
-            async with self._lock:
-                for uid, info in fetched.items():
-                    self._cache[uid] = (info, expire_at)
-                    result[uid] = info
+            if pending_events:
+                await asyncio.gather(*(event.wait() for event in pending_events))
+                continue
 
-                if len(self._cache) > self.max_cache_size:
-                    now_insert = time.monotonic()
-                    self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+            if missing_ids:
+                events_created: List[str] = []
+                for uid in missing_ids:
+                    event = asyncio.Event()
+                    self._pending_queries[uid] = event
+                    events_created.append(uid)
 
-                    while len(self._cache) > self.max_cache_size:
-                        oldest_key = next(iter(self._cache))
-                        self._cache.pop(oldest_key)
+                try:
+                    try:
+                        fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
+                            [str(uid) for uid in missing_ids]
+                        )
+                    except Exception as e:
+                        await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
+                        fetched = {}
+
+                    now = time.monotonic()
+                    expire_at = now + memory_config.procedural_cache_ttl
+
+                    for uid in missing_ids:
+                        info = fetched.get(uid)
+                        if info is not None:
+                            self._cache[uid] = (info, expire_at)
+                            result[uid] = info
+                        else:
+                            # Cache an empty result to avoid DB spam on misses if needed,
+                            # or just skip. We will skip and let it miss next time.
+                            pass
+
+                    if len(self._cache) > self.max_cache_size:
+                        now_insert = time.monotonic()
+                        self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+
+                        while len(self._cache) > self.max_cache_size:
+                            oldest_key = next(iter(self._cache))
+                            self._cache.pop(oldest_key, None)
+                finally:
+                    for uid in events_created:
+                        event = self._pending_queries.pop(uid, None)
+                        if event:
+                            event.set()
+
+                break
 
         return ProceduralMemory(user_info=result)
 
@@ -95,5 +128,8 @@ class ProceduralMemoryProvider:
         Args:
             user_id: The user_id string to remove from cache.
         """
-        async with self._lock:
-            self._cache.pop(str(user_id), None)
+        uid = str(user_id)
+        self._cache.pop(uid, None)
+        event = self._pending_queries.pop(uid, None)
+        if event:
+            event.set()


### PR DESCRIPTION
**What was found:**
A thundering herd (cache stampede) vulnerability existed in `ProceduralMemoryProvider` and `KnowledgeMemoryProvider`. The use of `asyncio.Lock()` in these classes only wrapped synchronous dictionary operations. Because `await` was not used within the lock blocks when a cache miss occurred, there was no concurrency protection. Multiple concurrent requests for the same missing cache key would independently trigger duplicate database queries.

**Where it is:**
* `llm/memory/procedural.py` (lines ~35, ~50, ~130)
* `llm/memory/knowledge.py` (lines ~36, ~60, ~95)

**Why it matters:**
This bottleneck severely impacts performance when multiple users interact simultaneously or when batch fetching context. It leads to duplicate database reads and resource exhaustion, ultimately slowing down the bot's response time to users.

**What was done:**
* Removed the ineffectual `_lock` from both providers.
* Introduced an `asyncio.Event`-based `_pending_queries` dictionary to block concurrent duplicate requests until the first fetch completes.
* In `ProceduralMemoryProvider.get`, deduplicated incoming user IDs and introduced a `while True` loop to safely `await` pending queries and initiate new ones.
* In `KnowledgeMemoryProvider._get_single`, introduced a `while True` loop to safely `await` pending queries.
* Handled the cache miss scenarios using `try...finally` blocks to guarantee `asyncio.Event` objects are removed and `event.set()` is called, preventing self-deadlocking or stuck background tasks.
* Updated `invalidate` methods to cleanly pop and unblock pending queries.

---
*PR created automatically by Jules for task [9524582827072231307](https://jules.google.com/task/9524582827072231307) started by @starpig1129*