### PR TITLE
[UX] Fix hanging 'Thinking...' messages on slash command errors

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -512,7 +512,10 @@ class PigPig(commands.Bot):
                 if not interaction.response.is_done():
                     await interaction.response.send_message(error_msg, ephemeral=True)
                 else:
-                    await interaction.followup.send(error_msg, ephemeral=True)
+                    try:
+                        await interaction.edit_original_response(content=error_msg, embeds=[], view=None)
+                    except discord.NotFound:
+                        await interaction.followup.send(error_msg, ephemeral=True)
             except Exception as send_e:
                 logger.error(f"Failed to send slash command error message: {send_e}")
 


### PR DESCRIPTION
**What was found:** 
When slash commands encounter an error after being deferred (using `defer(thinking=True)`), the global error handler (`on_tree_error` in `bot.py`) would previously send the error as a new ephemeral followup message. Because the original "Thinking..." message was never edited or deleted, it would remain hanging in the channel indefinitely.

**Where it is:** 
`bot.py` lines 511-519 (inside `on_tree_error`).

**Why it matters:** 
Hanging "Thinking..." messages create a very confusing and messy user experience, as it gives the false impression that the bot is still processing long after an error has occurred. This is a high-frequency friction point since any failed long-running operation will trigger it.

**What was done:** 
Updated the `on_tree_error` fallback logic. When `interaction.response.is_done()` is true, it now tries `await interaction.edit_original_response(...)` to overwrite the "Thinking..." state with the error message. A `try/except` block catches `discord.NotFound` to safely fallback to `followup.send` if the original message has already expired or been deleted.

---
*PR created automatically by Jules for task [17705166043921592518](https://jules.google.com/task/17705166043921592518) started by @starpig1129*