### PR TITLE
[Perf] Add thundering herd protection to ProceduralMemoryProvider

### DIFF
--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -33,6 +33,8 @@ class ProceduralMemoryProvider:
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
         self._cache: Dict[str, Tuple[UserInfo, float]] = {}
         self._lock = asyncio.Lock()
+        # prevents cache stampedes
+        self._pending_queries: Dict[str, asyncio.Event] = {}
 
     async def get(self, user_ids: List[str]) -> ProceduralMemory:
         """Fetch procedural memory with per-user TTL cache.
@@ -49,40 +51,67 @@ class ProceduralMemoryProvider:
         if not user_ids or not self.user_manager:
             return ProceduralMemory(user_info={})
 
-        now = time.monotonic()
+        unique_ids = list(set(str(uid) for uid in user_ids))
         result: Dict[str, UserInfo] = {}
-        missing_ids: List[str] = []
 
-        async with self._lock:
-            for uid in user_ids:
-                entry = self._cache.get(uid)
-                if entry is not None and entry[1] > now:
-                    result[uid] = entry[0]
-                else:
-                    missing_ids.append(uid)
+        while True:
+            now = time.monotonic()
+            missing_ids: List[str] = []
+            pending_events: List[asyncio.Event] = []
+
+            async with self._lock:
+                for uid in unique_ids:
+                    if uid in result:
+                        continue
+                    entry = self._cache.get(uid)
+                    if entry is not None and entry[1] > now:
+                        result[uid] = entry[0]
+                    else:
+                        event = self._pending_queries.get(uid)
+                        if event:
+                            pending_events.append(event)
+                        else:
+                            missing_ids.append(uid)
+
+                if not pending_events and missing_ids:
+                    # we are the primary task for missing_ids
+                    for uid in missing_ids:
+                        self._pending_queries[uid] = asyncio.Event()
+
+            if pending_events:
+                await asyncio.gather(*(event.wait() for event in pending_events))
+                continue
+
+            break
 
         if missing_ids:
             try:
-                fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
-                    [str(uid) for uid in missing_ids]
-                )
-            except Exception as e:
-                await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
-                fetched = {}
+                try:
+                    fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
+                        missing_ids
+                    )
+                except Exception as e:
+                    await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
+                    fetched = {}
 
-            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
-            async with self._lock:
-                for uid, info in fetched.items():
-                    self._cache[uid] = (info, expire_at)
-                    result[uid] = info
+                expire_at = time.monotonic() + memory_config.procedural_cache_ttl
+                async with self._lock:
+                    for uid, info in fetched.items():
+                        self._cache[uid] = (info, expire_at)
+                        result[uid] = info
 
-                if len(self._cache) > self.max_cache_size:
-                    now_insert = time.monotonic()
-                    self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+                    if len(self._cache) > self.max_cache_size:
+                        now_insert = time.monotonic()
+                        self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
 
-                    while len(self._cache) > self.max_cache_size:
-                        oldest_key = next(iter(self._cache))
-                        self._cache.pop(oldest_key)
+                        while len(self._cache) > self.max_cache_size:
+                            oldest_key = next(iter(self._cache))
+                            self._cache.pop(oldest_key)
+            finally:
+                for uid in missing_ids:
+                    event = self._pending_queries.pop(uid, None)
+                    if event:
+                        event.set()
 
         return ProceduralMemory(user_info=result)
 
@@ -95,5 +124,9 @@ class ProceduralMemoryProvider:
         Args:
             user_id: The user_id string to remove from cache.
         """
+        user_id_str = str(user_id)
         async with self._lock:
-            self._cache.pop(str(user_id), None)
+            self._cache.pop(user_id_str, None)
+            event = self._pending_queries.pop(user_id_str, None)
+            if event:
+                event.set()


### PR DESCRIPTION
What:
The `ProceduralMemoryProvider` was susceptible to cache stampedes (thundering herd). During cache misses, multiple concurrent requests for the same missing `user_id`s caused redundant, overlapping batched queries to the database.

Where:
- `llm/memory/procedural.py` lines 36-37 (`__init__`)
- `llm/memory/procedural.py` lines 54-106 (`get`)
- `llm/memory/procedural.py` lines 127-132 (`invalidate`)

Why:
Because `asyncio.Lock()` only synchronized dictionary access, it did not block other tasks from starting new database fetch loops if they observed the cache to be empty before the first fetch resolved. This degraded performance under load for hot-path user requests.

What was done:
- Introduced `self._pending_queries: Dict[str, asyncio.Event]` to track pending fetches per user ID.
- Upgraded the cache checking logic to use a `while True` loop that detects pending fetches and waits using `asyncio.gather(*events.wait())`.
- Wrapped database calls in a `try...finally` block to guarantee event clearance and unblock any waiting task seamlessly.
- Updated `invalidate` to appropriately unset pending query events.

---
*PR created automatically by Jules for task [17562904179909665125](https://jules.google.com/task/17562904179909665125) started by @starpig1129*