### PR TITLE
[Perf] Fix thundering herd in memory caches

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -33,7 +33,7 @@ class KnowledgeMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: (type, target_id), value: (content, expire_at)
         self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
-        self._lock = asyncio.Lock()
+        self._pending_queries: Dict[Tuple[str, str], asyncio.Event] = {}
 
     async def get(self, guild_id: Optional[str], channel_id: str) -> KnowledgeMemory:
         """Fetch knowledge for the current guild and channel.
@@ -58,36 +58,52 @@ class KnowledgeMemoryProvider:
 
     async def _get_single(self, target_type: str, target_id: str) -> Optional[str]:
         """Internal helper with TTL cache."""
-        now = time.monotonic()
         cache_key = (target_type, target_id)
         
-        async with self._lock:
+        while cache_key in self._pending_queries:
+            await self._pending_queries[cache_key].wait()
+            now = time.monotonic()
             entry = self._cache.get(cache_key)
             if entry is not None and entry[1] > now:
                 return entry[0]
+
+        now = time.monotonic()
+        entry = self._cache.get(cache_key)
+        if entry is not None and entry[1] > now:
+            return entry[0]
+
+        event = asyncio.Event()
+        self._pending_queries[cache_key] = event
         
-        # Cache miss
         try:
-            content = await self.storage.get_knowledge(target_type, target_id)
-        except Exception as e:
-            await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
-            content = None
-            
-        # Update cache
-        expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
-        async with self._lock:
+            try:
+                content = await self.storage.get_knowledge(target_type, target_id)
+            except Exception as e:
+                await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
+                content = None
+
+            # Update cache
+            now = time.monotonic()
+            expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
             self._cache[cache_key] = (content, expire_at)
-            
+
             # Prune cache if needed
             if len(self._cache) > self.max_cache_size:
-                self._cache = {k: v for k, v in self._cache.items() if v[1] > now}
+                now_insert = time.monotonic()
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
                 while len(self._cache) > self.max_cache_size:
                     oldest_key = next(iter(self._cache))
                     self._cache.pop(oldest_key)
-                    
-        return content
+
+            return content
+        finally:
+            self._pending_queries.pop(cache_key, None)
+            event.set()
 
     async def invalidate(self, target_type: str, target_id: str) -> None:
         """Invalidate cache for a specific target."""
-        async with self._lock:
-            self._cache.pop((target_type, target_id), None)
+        cache_key = (target_type, target_id)
+        self._cache.pop(cache_key, None)
+        event = self._pending_queries.pop(cache_key, None)
+        if event:
+            event.set()

--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -32,7 +32,7 @@ class ProceduralMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
         self._cache: Dict[str, Tuple[UserInfo, float]] = {}
-        self._lock = asyncio.Lock()
+        self._pending_queries: Dict[str, asyncio.Event] = {}
 
     async def get(self, user_ids: List[str]) -> ProceduralMemory:
         """Fetch procedural memory with per-user TTL cache.
@@ -49,32 +49,55 @@ class ProceduralMemoryProvider:
         if not user_ids or not self.user_manager:
             return ProceduralMemory(user_info={})
 
-        now = time.monotonic()
+        unique_ids = list(set(str(uid) for uid in user_ids))
         result: Dict[str, UserInfo] = {}
-        missing_ids: List[str] = []
+        not_found_ids = set()
 
-        async with self._lock:
-            for uid in user_ids:
+        while True:
+            now = time.monotonic()
+            missing_ids: List[str] = []
+            pending_events: List[asyncio.Event] = []
+
+            for uid in unique_ids:
+                if uid in result or uid in not_found_ids:
+                    continue
+
                 entry = self._cache.get(uid)
                 if entry is not None and entry[1] > now:
                     result[uid] = entry[0]
+                elif uid in self._pending_queries:
+                    pending_events.append(self._pending_queries[uid])
                 else:
                     missing_ids.append(uid)
 
-        if missing_ids:
-            try:
-                fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
-                    [str(uid) for uid in missing_ids]
-                )
-            except Exception as e:
-                await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
-                fetched = {}
+            if pending_events:
+                await asyncio.gather(*(event.wait() for event in pending_events))
+                continue
 
-            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
-            async with self._lock:
-                for uid, info in fetched.items():
-                    self._cache[uid] = (info, expire_at)
-                    result[uid] = info
+            if not missing_ids:
+                break
+
+            events_created = []
+            for uid in missing_ids:
+                event = asyncio.Event()
+                self._pending_queries[uid] = event
+                events_created.append((uid, event))
+
+            try:
+                try:
+                    fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(missing_ids)
+                except Exception as e:
+                    await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
+                    fetched = {}
+
+                expire_at = time.monotonic() + memory_config.procedural_cache_ttl
+                for uid in missing_ids:
+                    info = fetched.get(uid)
+                    if info is not None:
+                        self._cache[uid] = (info, expire_at)
+                        result[uid] = info
+                    else:
+                        not_found_ids.add(uid)
 
                 if len(self._cache) > self.max_cache_size:
                     now_insert = time.monotonic()
@@ -83,6 +106,10 @@ class ProceduralMemoryProvider:
                     while len(self._cache) > self.max_cache_size:
                         oldest_key = next(iter(self._cache))
                         self._cache.pop(oldest_key)
+            finally:
+                for uid, event in events_created:
+                    self._pending_queries.pop(uid, None)
+                    event.set()
 
         return ProceduralMemory(user_info=result)
 
@@ -95,5 +122,8 @@ class ProceduralMemoryProvider:
         Args:
             user_id: The user_id string to remove from cache.
         """
-        async with self._lock:
-            self._cache.pop(str(user_id), None)
+        uid = str(user_id)
+        self._cache.pop(uid, None)
+        event = self._pending_queries.pop(uid, None)
+        if event:
+            event.set()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,3 +15,8 @@
 # importable.
 
 import addons.settings  # noqa: F401  — side-effect: caches real module
+import discord
+from unittest.mock import MagicMock
+
+# Create partial discord mock attributes needed during test collection
+discord.AllowedMentions = MagicMock()


### PR DESCRIPTION
**What was found:**
A cache stampede (thundering herd) bottleneck in `llm/memory/procedural.py` and `llm/memory/knowledge.py`. Both providers used an `asyncio.Lock` surrounding synchronous dictionary operations, dropping the lock when awaiting the database fetch. Consequently, if multiple concurrent requests targeted the same missing cache key, all of them would independently trigger simultaneous database queries.

**Where it is:**
- `llm/memory/procedural.py` (lines 35-125)
- `llm/memory/knowledge.py` (lines 36-105)

**Why it matters:**
This creates significant resource impact (excessive SQLite read contention) and increased tail latency during concurrent user interaction spikes or when background batch tasks run, directly slowing down the `context_manager` LLM orchestration hot-path.

**What was done:**
- Replaced the `asyncio.Lock` with an `asyncio.Event` based deduplication map (`self._pending_queries = {}`).
- Implemented a `while True` loop pattern in both `get` methods that deduplicates pending requests and awaits the inflight event using `asyncio.gather`.
- Wrapped database fetches in `try...finally` blocks to guarantee event cleanup and prevent deadlocks if a fetch errors or cancels.
- Fixed `tests/conftest.py` missing `AllowedMentions` mock to restore test suite execution viability in disconnected environments.
- Tested successfully against existing `ProceduralMemoryProvider` and `KnowledgeMemoryProvider` unit tests.

---
*PR created automatically by Jules for task [7319845329842044739](https://jules.google.com/task/7319845329842044739) started by @starpig1129*