### PR TITLE
[UX] Fix hanging Thinking state in global error handler

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -512,7 +512,10 @@ class PigPig(commands.Bot):
                 if not interaction.response.is_done():
                     await interaction.response.send_message(error_msg, ephemeral=True)
                 else:
-                    await interaction.followup.send(error_msg, ephemeral=True)
+                    try:
+                        await interaction.edit_original_response(content=error_msg, embed=None, view=None)
+                    except discord.NotFound:
+                        await interaction.followup.send(error_msg, ephemeral=True)
             except Exception as send_e:
                 logger.error(f"Failed to send slash command error message: {send_e}")
 


### PR DESCRIPTION
When a Discord slash command is deferred (`interaction.response.defer(thinking=True)`) and an error occurs, the global error handler (`on_tree_error` in `bot.py`) was previously sending a new ephemeral error message using `interaction.followup.send()`. This caused the original "Bot is thinking..." message to remain stuck in the channel indefinitely.

This commit updates `on_tree_error` to attempt `await interaction.edit_original_response()` first, replacing the hanging "thinking" state with the appropriate error message. If the original message is already deleted or expired (`discord.NotFound`), it falls back to the original `interaction.followup.send()` behavior.

---
*PR created automatically by Jules for task [8173991759151536510](https://jules.google.com/task/8173991759151536510) started by @starpig1129*