### PR TITLE
[Perf] Add thundering herd protection to memory providers

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -33,7 +33,7 @@ class KnowledgeMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: (type, target_id), value: (content, expire_at)
         self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
-        self._lock = asyncio.Lock()
+        self._pending_queries: Dict[Tuple[str, str], asyncio.Event] = {}
 
     async def get(self, guild_id: Optional[str], channel_id: str) -> KnowledgeMemory:
         """Fetch knowledge for the current guild and channel.
@@ -45,11 +45,14 @@ class KnowledgeMemoryProvider:
         Returns:
             KnowledgeMemory object containing both levels of knowledge.
         """
-        guild_knowledge = None
         if guild_id:
-            guild_knowledge = await self._get_single("guild", guild_id)
-            
-        channel_knowledge = await self._get_single("channel", channel_id)
+            guild_knowledge, channel_knowledge = await asyncio.gather(
+                self._get_single("guild", guild_id),
+                self._get_single("channel", channel_id)
+            )
+        else:
+            guild_knowledge = None
+            channel_knowledge = await self._get_single("channel", channel_id)
         
         return KnowledgeMemory(
             guild_knowledge=guild_knowledge,
@@ -57,37 +60,53 @@ class KnowledgeMemoryProvider:
         )
 
     async def _get_single(self, target_type: str, target_id: str) -> Optional[str]:
-        """Internal helper with TTL cache."""
-        now = time.monotonic()
+        """Internal helper with TTL cache and thundering herd protection."""
         cache_key = (target_type, target_id)
-        
-        async with self._lock:
+
+        while True:
+            now = time.monotonic()
             entry = self._cache.get(cache_key)
             if entry is not None and entry[1] > now:
                 return entry[0]
+
+            if cache_key in self._pending_queries:
+                await self._pending_queries[cache_key].wait()
+                continue
+
+            break
+
+        event = asyncio.Event()
+        self._pending_queries[cache_key] = event
         
         # Cache miss
         try:
-            content = await self.storage.get_knowledge(target_type, target_id)
-        except Exception as e:
-            await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
-            content = None
-            
-        # Update cache
-        expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
-        async with self._lock:
+            try:
+                content = await self.storage.get_knowledge(target_type, target_id)
+            except Exception as e:
+                await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
+                content = None
+
+            # Update cache
+            now_insert = time.monotonic()
+            expire_at = now_insert + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
             self._cache[cache_key] = (content, expire_at)
-            
+
             # Prune cache if needed
             if len(self._cache) > self.max_cache_size:
-                self._cache = {k: v for k, v in self._cache.items() if v[1] > now}
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
                 while len(self._cache) > self.max_cache_size:
                     oldest_key = next(iter(self._cache))
                     self._cache.pop(oldest_key)
-                    
-        return content
+
+            return content
+        finally:
+            self._pending_queries.pop(cache_key, None)
+            event.set()
 
     async def invalidate(self, target_type: str, target_id: str) -> None:
         """Invalidate cache for a specific target."""
-        async with self._lock:
-            self._cache.pop((target_type, target_id), None)
+        cache_key = (target_type, target_id)
+        self._cache.pop(cache_key, None)
+        event = self._pending_queries.pop(cache_key, None)
+        if event:
+            event.set()

--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -32,7 +32,7 @@ class ProceduralMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
         self._cache: Dict[str, Tuple[UserInfo, float]] = {}
-        self._lock = asyncio.Lock()
+        self._pending_queries: Dict[str, asyncio.Event] = {}
 
     async def get(self, user_ids: List[str]) -> ProceduralMemory:
         """Fetch procedural memory with per-user TTL cache.
@@ -49,40 +49,65 @@ class ProceduralMemoryProvider:
         if not user_ids or not self.user_manager:
             return ProceduralMemory(user_info={})
 
-        now = time.monotonic()
+        # deduplicate
+        user_ids = list(set(str(uid) for uid in user_ids))
         result: Dict[str, UserInfo] = {}
-        missing_ids: List[str] = []
 
-        async with self._lock:
+        while True:
+            now = time.monotonic()
+            missing_ids: List[str] = []
+            pending_events: List[asyncio.Event] = []
+
             for uid in user_ids:
                 entry = self._cache.get(uid)
                 if entry is not None and entry[1] > now:
                     result[uid] = entry[0]
+                elif uid in self._pending_queries:
+                    pending_events.append(self._pending_queries[uid])
                 else:
                     missing_ids.append(uid)
 
-        if missing_ids:
-            try:
-                fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
-                    [str(uid) for uid in missing_ids]
-                )
-            except Exception as e:
-                await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
-                fetched = {}
+            if pending_events:
+                await asyncio.gather(*(event.wait() for event in pending_events))
+                # restart loop to check cache again
+                continue
 
-            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
-            async with self._lock:
-                for uid, info in fetched.items():
+            # if no missing ids and no pending events, we're done
+            if not missing_ids:
+                break
+
+            # Claim missing_ids
+            for uid in missing_ids:
+                self._pending_queries[uid] = asyncio.Event()
+
+            try:
+                try:
+                    fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(missing_ids)
+                except Exception as e:
+                    await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
+                    fetched = {}
+
+                now_insert = time.monotonic()
+                expire_at = now_insert + memory_config.procedural_cache_ttl
+
+                for uid in missing_ids:
+                    info = fetched.get(uid, UserInfo(user_background="", procedural_memory=""))
                     self._cache[uid] = (info, expire_at)
                     result[uid] = info
 
                 if len(self._cache) > self.max_cache_size:
-                    now_insert = time.monotonic()
                     self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
 
                     while len(self._cache) > self.max_cache_size:
                         oldest_key = next(iter(self._cache))
                         self._cache.pop(oldest_key)
+            finally:
+                for uid in missing_ids:
+                    event = self._pending_queries.pop(uid, None)
+                    if event:
+                        event.set()
+
+            break
 
         return ProceduralMemory(user_info=result)
 
@@ -95,5 +120,8 @@ class ProceduralMemoryProvider:
         Args:
             user_id: The user_id string to remove from cache.
         """
-        async with self._lock:
-            self._cache.pop(str(user_id), None)
+        uid_str = str(user_id)
+        self._cache.pop(uid_str, None)
+        event = self._pending_queries.pop(uid_str, None)
+        if event:
+            event.set()


### PR DESCRIPTION
1. **What was found:** `ProceduralMemoryProvider` and `KnowledgeMemoryProvider` used an `asyncio.Lock()` that only wrapped the synchronous dictionary lookups, failing to provide any concurrency protection. As a result, cache misses for the same key occurring concurrently would all trigger independent database/API fetches (a thundering herd). Furthermore, `KnowledgeMemoryProvider.get()` awaited guild and channel knowledge sequentially.
2. **Where it is:** 
   - `llm/memory/procedural.py` lines 34-114
   - `llm/memory/knowledge.py` lines 36-107
3. **Why it matters:** The lack of synchronization meant high traffic could spike database query volume unnecessarily. Furthermore, the sequential knowledge loading directly inflated the critical path latency for user requests, resulting in slower bot response times.
4. **What was done:** 
   - Removed the ineffective locks from both providers.
   - Implemented an `asyncio.Event` based `_pending_queries` dictionary in both providers to safely block concurrent requests for the same key while the first request fetches the data.
   - Refactored `ProceduralMemoryProvider.get` to deduplicate and batch process missing keys safely.
   - Refactored `KnowledgeMemoryProvider.get` to use `asyncio.gather` for fetching guild and channel knowledge concurrently.

---
*PR created automatically by Jules for task [8492711124239131573](https://jules.google.com/task/8492711124239131573) started by @starpig1129*