### PR TITLE
[UX] Fix hanging Thinking... state by using edit_original_response

### DIFF
--- a/cogs/gen_img.py
+++ b/cogs/gen_img.py
@@ -221,7 +221,7 @@ class ImageGenerationCog(commands.Cog, name="ImageGenerationCog"):
 
         # Slash command still uses immediate reply but supports attachments (base64 → discord.File)
         if "error" in result:
-            await interaction.followup.send(result["error"])
+            await interaction.edit_original_response(content=result["error"])
         else:
             files = []
             attachments = result.get("attachments") or []
@@ -236,9 +236,9 @@ class ImageGenerationCog(commands.Cog, name="ImageGenerationCog"):
                     self.logger.error(f"Slash reply conversion failed: {e}")
             content = result.get("content")
             if files:
-                await interaction.followup.send(content=content, files=files)
+                await interaction.edit_original_response(content=content, files=files)
             else:
-                await interaction.followup.send(content=content)
+                await interaction.edit_original_response(content=content)
 
     def _image_to_base64(self, image: Image.Image) -> str:
         """Convert a PIL Image to a base64-encoded string"""

--- a/cogs/schedule.py
+++ b/cogs/schedule.py
@@ -51,13 +51,13 @@ class ScheduleManager(commands.Cog):
             success_msg = self.lang_manager.translate(
                 guild_id, "commands", "upload_schedule", "responses", "success"
             ) if self.lang_manager else "行程表已成功上傳！"
-            await interaction.followup.send(success_msg)
+            await interaction.edit_original_response(content=success_msg)
         except Exception as e:
             await func.report_error(e, "uploading schedule")
             error_msg = self.lang_manager.translate(
                 guild_id, "commands", "upload_schedule", "responses", "error", error=str(e)
             ) if self.lang_manager else f"上傳行程表時發生錯誤：{str(e)}"
-            await interaction.followup.send(error_msg)
+            await interaction.edit_original_response(content=error_msg)
 
     async def _core_upload_schedule(self, user_id: int, channel_id: int, yaml_data: bytes):
         try:
@@ -95,13 +95,13 @@ class ScheduleManager(commands.Cog):
         try:
             target_user_id = target_user.id if target_user else interaction.user.id
             result = await self._core_query_schedule(interaction, query_type.value, target_user_id, time, day.value if day else None)
-            await interaction.followup.send(result)
+            await interaction.edit_original_response(content=result)
         except Exception as e:
             await func.report_error(e, "querying schedule")
             error_msg = self.lang_manager.translate(
                 guild_id, "commands", "query_schedule", "responses", "error", error=str(e)
             ) if self.lang_manager else f"查詢行程表時發生錯誤：{str(e)}"
-            await interaction.followup.send(error_msg)
+            await interaction.edit_original_response(content=error_msg)
 
     async def _core_query_schedule(self, interaction_or_ctx, query_type: str, target_user_id:int, time: str = None, day: str = None):
         guild_id = str(interaction_or_ctx.guild_id) if hasattr(interaction_or_ctx, 'guild_id') and interaction_or_ctx.guild_id else str(interaction_or_ctx.guild.id) if hasattr(interaction_or_ctx, 'guild') else "0"
@@ -307,13 +307,13 @@ class ScheduleManager(commands.Cog):
             success_msg = self.lang_manager.translate(
                 guild_id, "commands", "update_schedule", "responses", "success"
             ) if self.lang_manager else "行程表已成功更新或創建！"
-            await interaction.followup.send(success_msg)
+            await interaction.edit_original_response(content=success_msg)
         except Exception as e:
             await func.report_error(e, "updating schedule")
             error_msg = self.lang_manager.translate(
                 guild_id, "commands", "update_schedule", "responses", "error", error=str(e)
             ) if self.lang_manager else f"更新或創建行程表時發生錯誤：{str(e)}"
-            await interaction.followup.send(error_msg)
+            await interaction.edit_original_response(content=error_msg)
 
     async def _core_update_schedule(self, user_id: int, day: str, time: str, description: str):
         filepath = os.path.join(self.schedule_dir, f"{user_id}.yaml")

--- a/cogs/summarizer.py
+++ b/cogs/summarizer.py
@@ -119,7 +119,7 @@ class SummarizerCog(commands.Cog):
 
             if not dialogue_history or human_msg_count == 0:
                 no_msg_text = self.lang_manager.translate(guild_id, "commands", "summarize", "responses", "no_messages") if self.lang_manager else "No messages to summarize."
-                await interaction.followup.send(no_msg_text, ephemeral=True)
+                await interaction.edit_original_response(content=no_msg_text)
                 return
 
             # Localization for AI prompt
@@ -187,7 +187,7 @@ class SummarizerCog(commands.Cog):
                 footer_text = f"Analyzed {human_msg_count} messages. {current_char_count}/{self.MAX_CHAR_COUNT} chars."
                 
             main_embed.set_footer(text=footer_text)
-            await interaction.followup.send(embed=main_embed)
+            await interaction.edit_original_response(embed=main_embed)
             
             if len(summary_chunks) > 1:
                 log.info(f"Summary long, splitting into {len(summary_chunks)} messages.")
@@ -206,7 +206,7 @@ class SummarizerCog(commands.Cog):
         except Exception as e:
             await func.report_error(e, "summarizing channel")
             error_text = self.lang_manager.translate(guild_id, "commands", "summarize", "responses", "error", error=str(e)) if self.lang_manager else f"Error: {e}"
-            await interaction.followup.send(error_text, ephemeral=True)
+            await interaction.edit_original_response(content=error_text)
 
 
 async def setup(bot: commands.Bot):

--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -741,7 +741,7 @@ class UserDataCog(commands.Cog):
             action='save'
         )
         
-        await interaction.followup.send(result, ephemeral=True)
+        await interaction.edit_original_response(content=result)
 
     @memory_group.command(
         name="clear",
@@ -765,7 +765,7 @@ class UserDataCog(commands.Cog):
             action='clear'
         )
 
-        await interaction.followup.send(result, ephemeral=True)
+        await interaction.edit_original_response(content=result)
 
     @memory_group.command(
         name="show",
@@ -789,7 +789,7 @@ class UserDataCog(commands.Cog):
             action='read'
         )
         
-        await interaction.followup.send(result, ephemeral=True)
+        await interaction.edit_original_response(content=result)
 
     @knowledge_group.command(
         name="show",
@@ -813,22 +813,22 @@ class UserDataCog(commands.Cog):
         target_id = str(interaction.guild_id) if target_type == "guild" else str(interaction.channel_id)
 
         if target_type == "guild" and not interaction.guild_id:
-            await interaction.followup.send("Guild knowledge is only available within a server.", ephemeral=True)
+            await interaction.edit_original_response(content="Guild knowledge is only available within a server.")
             return
 
         if not self.knowledge_storage:
-            await interaction.followup.send("Knowledge storage is not initialized.", ephemeral=True)
+            await interaction.edit_original_response(content="Knowledge storage is not initialized.")
             return
 
         try:
             content = await self.knowledge_storage.get_knowledge(target_type, target_id)
             if content:
-                await interaction.followup.send(f"Current {target_type} knowledge:\n\n{content}", ephemeral=True)
+                await interaction.edit_original_response(content=f"Current {target_type} knowledge:\n\n{content}")
             else:
-                await interaction.followup.send(f"There is no {target_type} knowledge currently stored.", ephemeral=True)
+                await interaction.edit_original_response(content=f"There is no {target_type} knowledge currently stored.")
         except Exception as e:
             self.logger.error(f"Failed to read {target_type} knowledge for {target_id}: {e}")
-            await interaction.followup.send(f"Failed to read knowledge: {e}", ephemeral=True)
+            await interaction.edit_original_response(content=f"Failed to read knowledge: {e}")
 
     @knowledge_group.command(
         name="save",
@@ -861,11 +861,11 @@ class UserDataCog(commands.Cog):
         target_id = str(interaction.guild_id) if target_type == "guild" else str(interaction.channel_id)
 
         if target_type == "guild" and not interaction.guild_id:
-            await interaction.followup.send("Guild knowledge is only available within a server.", ephemeral=True)
+            await interaction.edit_original_response(content="Guild knowledge is only available within a server.")
             return
 
         if not self.knowledge_storage:
-            await interaction.followup.send("Knowledge storage is not initialized.", ephemeral=True)
+            await interaction.edit_original_response(content="Knowledge storage is not initialized.")
             return
 
         try:
@@ -876,10 +876,10 @@ class UserDataCog(commands.Cog):
                 category=category,
                 context=interaction
             )
-            await interaction.followup.send(result_msg, ephemeral=True)
+            await interaction.edit_original_response(content=result_msg)
         except Exception as e:
             self.logger.error(f"Failed to save {target_type} knowledge for {target_id}: {e}")
-            await interaction.followup.send(f"Failed to save knowledge: {e}", ephemeral=True)
+            await interaction.edit_original_response(content=f"Failed to save knowledge: {e}")
 
 
     @knowledge_group.command(
@@ -905,11 +905,11 @@ class UserDataCog(commands.Cog):
         target_id = str(interaction.guild_id) if target_type == "guild" else str(interaction.channel_id)
 
         if target_type == "guild" and not interaction.guild_id:
-            await interaction.followup.send("Guild knowledge is only available within a server.", ephemeral=True)
+            await interaction.edit_original_response(content="Guild knowledge is only available within a server.")
             return
 
         if not self.knowledge_storage:
-            await interaction.followup.send("Knowledge storage is not initialized.", ephemeral=True)
+            await interaction.edit_original_response(content="Knowledge storage is not initialized.")
             return
 
         try:
@@ -929,12 +929,12 @@ class UserDataCog(commands.Cog):
                 except Exception as cache_err:
                     self.logger.warning(f"Failed to invalidate knowledge cache for {target_type} {target_id}: {cache_err}")
 
-                await interaction.followup.send(f"Successfully cleared {target_type} knowledge.", ephemeral=True)
+                await interaction.edit_original_response(content=f"Successfully cleared {target_type} knowledge.")
             else:
-                await interaction.followup.send(f"There was no {target_type} knowledge to clear or an error occurred.", ephemeral=True)
+                await interaction.edit_original_response(content=f"There was no {target_type} knowledge to clear or an error occurred.")
         except Exception as e:
             self.logger.error(f"Failed to clear {target_type} knowledge for {target_id}: {e}")
-            await interaction.followup.send(f"Failed to clear knowledge: {e}", ephemeral=True)
+            await interaction.edit_original_response(content=f"Failed to clear knowledge: {e}")
 
     async def manage_user_data(
         self,


### PR DESCRIPTION
**What:** Several commands (`summarize`, `generate_image`, `schedule` operations, and `userdata`/`knowledge` operations) left a permanent "Thinking..." message hanging in the channel if they took a while to execute.
**Where:** 
- `cogs/summarizer.py`: lines 122, 190, 209
- `cogs/gen_img.py`: lines 224, 239, 241
- `cogs/schedule.py`: lines 54, 60, 98, 104, 310, 316
- `cogs/userdata.py`: lines 744, 768, 792, 816, 820, 826, 828, 831, 864, 868, 879, 882, 908, 912, 932, 934, 937
**Why:** These commands used `await interaction.response.defer(thinking=True)` to indicate background processing, but then followed up with `await interaction.followup.send(...)`. In discord.py, `followup.send` creates a *new* message instead of editing the deferred response, causing the original "Thinking..." message to hang indefinitely, which confuses users and creates visual clutter.
**What was done:** Replaced the initial `await interaction.followup.send(...)` calls with `await interaction.edit_original_response(...)` in the affected code paths. Removed the `ephemeral=True` kwarg from the edited response calls because the ephemeral state is correctly inherited from the initial `defer()` call, preventing any exposure of private configurations.

---
*PR created automatically by Jules for task [16493867214709253652](https://jules.google.com/task/16493867214709253652) started by @starpig1129*