### PR TITLE
[Perf] Implement thundering herd protection in Memory Providers

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -33,7 +33,7 @@ class KnowledgeMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: (type, target_id), value: (content, expire_at)
         self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
-        self._lock = asyncio.Lock()
+        self._pending_queries: Dict[Tuple[str, str], asyncio.Event] = {}
 
     async def get(self, guild_id: Optional[str], channel_id: str) -> KnowledgeMemory:
         """Fetch knowledge for the current guild and channel.
@@ -58,36 +58,54 @@ class KnowledgeMemoryProvider:
 
     async def _get_single(self, target_type: str, target_id: str) -> Optional[str]:
         """Internal helper with TTL cache."""
-        now = time.monotonic()
         cache_key = (target_type, target_id)
         
-        async with self._lock:
+        while True:
+            now = time.monotonic()
+
+            if cache_key in self._pending_queries:
+                await self._pending_queries[cache_key].wait()
+                continue
+
             entry = self._cache.get(cache_key)
             if entry is not None and entry[1] > now:
                 return entry[0]
+
+            # Claim the cache key
+            event = asyncio.Event()
+            self._pending_queries[cache_key] = event
+            break
         
         # Cache miss
         try:
-            content = await self.storage.get_knowledge(target_type, target_id)
-        except Exception as e:
-            await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
-            content = None
-            
-        # Update cache
-        expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
-        async with self._lock:
+            try:
+                content = await self.storage.get_knowledge(target_type, target_id)
+            except Exception as e:
+                await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
+                content = None
+
+            # Update cache
+            now = time.monotonic()
+            expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
             self._cache[cache_key] = (content, expire_at)
-            
+
             # Prune cache if needed
             if len(self._cache) > self.max_cache_size:
                 self._cache = {k: v for k, v in self._cache.items() if v[1] > now}
                 while len(self._cache) > self.max_cache_size:
                     oldest_key = next(iter(self._cache))
                     self._cache.pop(oldest_key)
-                    
-        return content
+
+            return content
+        finally:
+            event = self._pending_queries.pop(cache_key, None)
+            if event:
+                event.set()
 
     async def invalidate(self, target_type: str, target_id: str) -> None:
         """Invalidate cache for a specific target."""
-        async with self._lock:
-            self._cache.pop((target_type, target_id), None)
+        cache_key = (target_type, target_id)
+        self._cache.pop(cache_key, None)
+        event = self._pending_queries.pop(cache_key, None)
+        if event:
+            event.set()

--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -32,7 +32,7 @@ class ProceduralMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
         self._cache: Dict[str, Tuple[UserInfo, float]] = {}
-        self._lock = asyncio.Lock()
+        self._pending_queries: Dict[str, asyncio.Event] = {}
 
     async def get(self, user_ids: List[str]) -> ProceduralMemory:
         """Fetch procedural memory with per-user TTL cache.
@@ -49,42 +49,70 @@ class ProceduralMemoryProvider:
         if not user_ids or not self.user_manager:
             return ProceduralMemory(user_info={})
 
-        now = time.monotonic()
+        unique_ids = list(set(str(uid) for uid in user_ids))
         result: Dict[str, UserInfo] = {}
-        missing_ids: List[str] = []
 
-        async with self._lock:
-            for uid in user_ids:
+        while True:
+            now = time.monotonic()
+            missing_ids: List[str] = []
+            pending_events: List[asyncio.Event] = []
+
+            # Pass 1: Check cache and collect pending events without claiming
+            for uid in unique_ids:
+                if uid in self._pending_queries:
+                    pending_events.append(self._pending_queries[uid])
+                    continue
+
                 entry = self._cache.get(uid)
                 if entry is not None and entry[1] > now:
                     result[uid] = entry[0]
                 else:
                     missing_ids.append(uid)
 
-        if missing_ids:
+            if pending_events:
+                # Wait for all pending events concurrently and restart loop
+                await asyncio.gather(*(event.wait() for event in pending_events))
+                # Reset result to rebuild correctly
+                result = {}
+                continue
+
+            # Pass 2: Claim missing IDs
+            if missing_ids:
+                events = {uid: asyncio.Event() for uid in missing_ids}
+                for uid, event in events.items():
+                    self._pending_queries[uid] = event
+                break
+            else:
+                return ProceduralMemory(user_info=result)
+
+        try:
             try:
-                fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
-                    [str(uid) for uid in missing_ids]
-                )
+                fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(missing_ids)
             except Exception as e:
                 await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
                 fetched = {}
 
             expire_at = time.monotonic() + memory_config.procedural_cache_ttl
-            async with self._lock:
-                for uid, info in fetched.items():
-                    self._cache[uid] = (info, expire_at)
-                    result[uid] = info
 
-                if len(self._cache) > self.max_cache_size:
-                    now_insert = time.monotonic()
-                    self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+            for uid, info in fetched.items():
+                self._cache[uid] = (info, expire_at)
+                result[uid] = info
 
-                    while len(self._cache) > self.max_cache_size:
-                        oldest_key = next(iter(self._cache))
-                        self._cache.pop(oldest_key)
+            if len(self._cache) > self.max_cache_size:
+                now_insert = time.monotonic()
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
 
-        return ProceduralMemory(user_info=result)
+                while len(self._cache) > self.max_cache_size:
+                    oldest_key = next(iter(self._cache))
+                    self._cache.pop(oldest_key)
+
+            return ProceduralMemory(user_info=result)
+
+        finally:
+            for uid in missing_ids:
+                event = self._pending_queries.pop(uid, None)
+                if event:
+                    event.set()
 
     async def invalidate(self, user_id: str) -> None:
         """Evict a single user from the cache.
@@ -95,5 +123,8 @@ class ProceduralMemoryProvider:
         Args:
             user_id: The user_id string to remove from cache.
         """
-        async with self._lock:
-            self._cache.pop(str(user_id), None)
+        uid = str(user_id)
+        self._cache.pop(uid, None)
+        event = self._pending_queries.pop(uid, None)
+        if event:
+            event.set()


### PR DESCRIPTION
**What:**
The `ProceduralMemoryProvider` (`llm/memory/procedural.py`) and `KnowledgeMemoryProvider` (`llm/memory/knowledge.py`) were suffering from cache stampede vulnerabilities. While they implemented an `asyncio.Lock()`, the actual expensive I/O operations (fetching user profiles and channel knowledge from the database) were executed *outside* the lock. 

**Where:**
1. `llm/memory/procedural.py` lines ~45-125
2. `llm/memory/knowledge.py` lines ~60-110

**Why:**
When multiple Discord messages are processed concurrently from the same channel or involving the same users (which happens frequently due to orchestration parallelization), the cache TTL check happens simultaneously. All concurrent tasks miss the cache, resulting in N redundant backend queries to the `StorageInterface`, causing database contention and blocking the event loop.

**What was done:**
I implemented an `asyncio.Event`-based thundering herd protection mechanism for both providers. 
1. Replaced `self._lock` with a dictionary mapping keys to `asyncio.Event` objects (`self._pending_queries`).
2. When a cache miss occurs, the first task creates an event and stores it in the dictionary.
3. Subsequent concurrent tasks asking for the same key detect the event and `await` it, suspending execution until the first task completes the DB fetch and updates the cache.
4. For batch fetching (`ProceduralMemoryProvider`), implemented a double-pass system with `asyncio.gather` to wait for all partially pending subsets safely before initiating bulk fetching for missing IDs.
5. Added strict `try...finally` boundaries around DB calls to guarantee `event.set()` is executed and waiting tasks are freed, even under `CancelledError` conditions.

---
*PR created automatically by Jules for task [3297440288585316450](https://jules.google.com/task/3297440288585316450) started by @starpig1129*