### PR TITLE
[Perf] Add thundering herd protection to ProceduralMemoryProvider

### DIFF
--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -32,7 +32,8 @@ class ProceduralMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
         self._cache: Dict[str, Tuple[UserInfo, float]] = {}
-        self._lock = asyncio.Lock()
+        # prevents cache stampedes
+        self._pending_queries: Dict[str, asyncio.Event] = {}
 
     async def get(self, user_ids: List[str]) -> ProceduralMemory:
         """Fetch procedural memory with per-user TTL cache.
@@ -49,40 +50,65 @@ class ProceduralMemoryProvider:
         if not user_ids or not self.user_manager:
             return ProceduralMemory(user_info={})
 
-        now = time.monotonic()
+        unique_ids = list(set(user_ids))
         result: Dict[str, UserInfo] = {}
-        missing_ids: List[str] = []
 
-        async with self._lock:
-            for uid in user_ids:
+        while True:
+            now = time.monotonic()
+            missing_ids: List[str] = []
+            pending_events: List[asyncio.Event] = []
+
+            for uid in unique_ids:
                 entry = self._cache.get(uid)
                 if entry is not None and entry[1] > now:
                     result[uid] = entry[0]
+                elif uid in self._pending_queries:
+                    pending_events.append(self._pending_queries[uid])
                 else:
                     missing_ids.append(uid)
 
-        if missing_ids:
-            try:
-                fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
-                    [str(uid) for uid in missing_ids]
-                )
-            except Exception as e:
-                await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
-                fetched = {}
+            if pending_events:
+                await asyncio.gather(*(event.wait() for event in pending_events))
+                continue
 
-            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
-            async with self._lock:
+            if not missing_ids:
+                break
+
+            # Claim missing_ids
+            events_created: List[str] = []
+            for uid in missing_ids:
+                event = asyncio.Event()
+                self._pending_queries[uid] = event
+                events_created.append(uid)
+
+            try:
+                try:
+                    fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
+                        [str(uid) for uid in missing_ids]
+                    )
+                except Exception as e:
+                    await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
+                    fetched = {}
+
+                now_insert = time.monotonic()
+                expire_at = now_insert + memory_config.procedural_cache_ttl
+
                 for uid, info in fetched.items():
                     self._cache[uid] = (info, expire_at)
                     result[uid] = info
 
                 if len(self._cache) > self.max_cache_size:
-                    now_insert = time.monotonic()
                     self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
 
                     while len(self._cache) > self.max_cache_size:
                         oldest_key = next(iter(self._cache))
-                        self._cache.pop(oldest_key)
+                        self._cache.pop(oldest_key, None)
+                break
+            finally:
+                for uid in events_created:
+                    event = self._pending_queries.pop(uid, None)
+                    if event:
+                        event.set()
 
         return ProceduralMemory(user_info=result)
 
@@ -95,5 +121,8 @@ class ProceduralMemoryProvider:
         Args:
             user_id: The user_id string to remove from cache.
         """
-        async with self._lock:
-            self._cache.pop(str(user_id), None)
+        uid = str(user_id)
+        self._cache.pop(uid, None)
+        event = self._pending_queries.pop(uid, None)
+        if event:
+            event.set()


### PR DESCRIPTION
[Perf] Add thundering herd protection to ProceduralMemoryProvider

What was found:
In `ProceduralMemoryProvider.get`, concurrent fetches for the same missing user IDs triggered parallel database fetches, leading to high redundant database load and increased latency in the context manager pipeline (cache stampede).

Where it is:
`llm/memory/procedural.py` lines 35-95.

Why it matters:
When the bot is active in busy channels or during high traffic, repeated cache misses for the same user block the event loop and degrade SQLite/throughput performance. By coalescing these requests, the bot's response latency remains stable under heavy load.

What was done:
Replaced the coarse-grained `asyncio.Lock` with an `asyncio.Event`-based `_pending_queries` dictionary. This enables concurrent duplicate requests to wait for the primary fetching task rather than executing their own database queries. Cleaned up the lock structure to allow lock-free synchronous dictionary cache reads.

---
*PR created automatically by Jules for task [9678770282072153553](https://jules.google.com/task/9678770282072153553) started by @starpig1129*