### PR TITLE
[UX] Fix dangling "Thinking..." states on deferred slash commands

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -512,7 +512,10 @@ class PigPig(commands.Bot):
                 if not interaction.response.is_done():
                     await interaction.response.send_message(error_msg, ephemeral=True)
                 else:
-                    await interaction.followup.send(error_msg, ephemeral=True)
+                    try:
+                        await interaction.edit_original_response(content=error_msg)
+                    except discord.NotFound:
+                        await interaction.followup.send(error_msg, ephemeral=True)
             except Exception as send_e:
                 logger.error(f"Failed to send slash command error message: {send_e}")
 

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -145,12 +145,15 @@ class HelpCog(commands.Cog):
                     "no_commands",
                     default="目前沒有可用的指令。"
                 )
-                await interaction.followup.send(fallback, ephemeral=True)
+                await interaction.edit_original_response(content=fallback)
                 return
 
             # Discord allows up to 10 embeds per message; send in batches if needed
             for start in range(0, len(embeds), 10):
-                await interaction.followup.send(embeds=embeds[start:start + 10])
+                if start == 0:
+                    await interaction.edit_original_response(embeds=embeds[start:start + 10])
+                else:
+                    await interaction.followup.send(embeds=embeds[start:start + 10])
 
         except Exception as e:
             log.exception("Error building help response")
@@ -162,7 +165,10 @@ class HelpCog(commands.Cog):
                 "error_message",
                 default="生成指令列表時發生錯誤，請稍後再試。"
             )
-            await interaction.followup.send(fallback_error, ephemeral=True)
+            try:
+                await interaction.edit_original_response(content=fallback_error)
+            except discord.NotFound:
+                await interaction.followup.send(fallback_error, ephemeral=True)
 
 async def setup(bot):
     await bot.add_cog(HelpCog(bot))

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -120,7 +120,7 @@ class YTMusic(commands.Cog):
                 await func.report_error(e, "music.py/play/channel.connect")
                 title = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "voice_connect_failed")
                 embed = discord.Embed(title=f"❌ | {title}", color=discord.Color.red())
-                await interaction.followup.send(embed=embed, ephemeral=True)
+                await interaction.edit_original_response(embed=embed)
                 return
 
         # 如果沒有提供查詢，刷新UI
@@ -139,10 +139,10 @@ class YTMusic(commands.Cog):
                     self
                 )
                 refresh_message = self.lang_manager.translate(str(guild_id), "commands", "play", "responses", "refreshed_ui")
-                await interaction.followup.send(refresh_message, ephemeral=True)
+                await interaction.edit_original_response(content=refresh_message)
             else:
                 no_song_message = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "nothing_playing")
-                await interaction.followup.send(no_song_message, ephemeral=True)
+                await interaction.edit_original_response(content=no_song_message)
             return
 
         # 如果有提供查詢，將音樂加入播放清單
@@ -175,7 +175,7 @@ class YTMusic(commands.Cog):
         if error:
             title = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "playlist_download_failed", error=error)
             embed = discord.Embed(title=f"❌ | {title}", color=discord.Color.red())
-            await interaction.followup.send(embed=embed, ephemeral=True)
+            await interaction.edit_original_response(embed=embed)
             return
             
         # Add initial songs to queue
@@ -200,7 +200,7 @@ class YTMusic(commands.Cog):
             description=description,
             color=discord.Color.blue()
         )
-        await interaction.followup.send(embed=embed, ephemeral=True)
+        await interaction.edit_original_response(embed=embed)
 
     async def _handle_single_video(self, interaction: discord.Interaction, url: str) -> bool:
         """Handle single video URL"""
@@ -219,7 +219,7 @@ class YTMusic(commands.Cog):
         if error:
             title = self.lang_manager.translate(guild_id_str, "commands", "play", "errors", "video_info_failed", error=error)
             embed = discord.Embed(title=f"❌ | {title}", color=discord.Color.red())
-            await interaction.followup.send(embed=embed, ephemeral=True)
+            await interaction.edit_original_response(embed=embed)
             return False
             
         video_info['added_by'] = interaction.user.id
@@ -230,7 +230,7 @@ class YTMusic(commands.Cog):
         if success:
             title = self.lang_manager.translate(guild_id_str, "commands", "play", "responses", "song_added", title=video_info['title'])
             embed = discord.Embed(title=f"✅ | {title}", color=discord.Color.blue())
-            await interaction.followup.send(embed=embed, ephemeral=True)
+            await interaction.edit_original_response(embed=embed)
             return True
         else:
             title = self.lang_manager.translate(guild_id_str, "commands", "play", "errors", "queue_full_title")
@@ -240,7 +240,7 @@ class YTMusic(commands.Cog):
                 description=desc,
                 color=discord.Color.red()
             )
-            await interaction.followup.send(embed=embed, ephemeral=True)
+            await interaction.edit_original_response(embed=embed)
             return False
 
     async def _handle_search(self, interaction: discord.Interaction, query: str):
@@ -250,7 +250,7 @@ class YTMusic(commands.Cog):
         if not results:
             title = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "no_results")
             embed = discord.Embed(title=f"❌ | {title}", color=discord.Color.red())
-            await interaction.followup.send(embed=embed, ephemeral=True)
+            await interaction.edit_original_response(embed=embed)
             return
         
         # Format durations properly
@@ -271,7 +271,7 @@ class YTMusic(commands.Cog):
             color=discord.Color.blue()
         )
         
-        await interaction.followup.send(embed=embed, view=view, ephemeral=True)
+        await interaction.edit_original_response(embed=embed, view=view)
 
     async def play_next(self, interaction: discord.Interaction, force_new: bool = False):
         """Play the next song in queue"""


### PR DESCRIPTION
### What was found
A significant UX friction point exists across the bot's slash command handlers. Many commands defer their response using `await interaction.response.defer(thinking=True)` to gain time for processing. However, they subsequently use `await interaction.followup.send(...)` to send the result instead of `await interaction.edit_original_response(...)`. 

### Where it is
This anti-pattern is prevalent in over 60 locations across multiple files. This PR provides a proof-of-concept fix targeting the most critical areas:
* `bot.py` (lines ~515): The global `on_tree_error` handler.
* `cogs/help.py` (lines ~148, 154, 168): The `/help` command logic.
* `cogs/music.py` (lines ~123, 142, 145, 178, 203, 222, 233, 243, 253, 274): The `/play` command and its internal handlers (`_handle_playlist`, `_handle_single_video`, `_handle_search`).

### Why it matters
Using `followup.send()` after deferring creates a *new* message webhook, leaving the original "Bot is thinking..." message hanging permanently in the user's Discord UI. This provides extremely poor feedback, making users think the bot has crashed or is stuck in an infinite loop, even when the command succeeded.

### What was done
As a focused proof-of-concept (keeping the PR <100 lines and manageable), I have updated the initial response mechanism for the most visible commands:
1. **`bot.py`**: Updated the global error handler to attempt `await interaction.edit_original_response(content=...)`, catching `discord.NotFound` to safely fallback to `followup.send()` if the interaction expired.
2. **`cogs/help.py`**: Updated the embed pagination loop to use `edit_original_response` for the first batch of 10 embeds, and `followup.send` for subsequent batches.
3. **`cogs/music.py`**: Updated the success and error execution paths in `/play` to use `edit_original_response`. Also removed `ephemeral=True` from these calls, as `edit_original_response` natively inherits the visibility state from the initial `defer()`.

### Proposed Next Steps
To fully resolve this UX issue, a larger refactoring should be planned to apply this pattern across the remaining cogs, specifically: `cogs/userdata.py`, `cogs/schedule.py`, `cogs/internet_search.py`, `cogs/story/ui/modals.py`, `cogs/system_prompt/views.py`, and `cogs/gen_img.py`.

---
*PR created automatically by Jules for task [2178261745633199004](https://jules.google.com/task/2178261745633199004) started by @starpig1129*