### PR TITLE
[Perf] Fix thundering herd cache stampede in ProceduralMemoryProvider

### DIFF
--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -32,10 +32,10 @@ class ProceduralMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
         self._cache: Dict[str, Tuple[UserInfo, float]] = {}
-        self._lock = asyncio.Lock()
+        self._pending_queries: Dict[str, asyncio.Event] = {}
 
     async def get(self, user_ids: List[str]) -> ProceduralMemory:
-        """Fetch procedural memory with per-user TTL cache.
+        """Fetch procedural memory with per-user TTL cache and stampede protection.
 
         Cache hit: return cached UserInfo without DB call.
         Cache miss: fetch from DB and store in cache.
@@ -49,32 +49,56 @@ class ProceduralMemoryProvider:
         if not user_ids or not self.user_manager:
             return ProceduralMemory(user_info={})
 
-        now = time.monotonic()
+        # Deduplicate user IDs
+        user_ids = list(set(user_ids))
         result: Dict[str, UserInfo] = {}
+
+        now = time.monotonic()
         missing_ids: List[str] = []
+        pending_events: List[asyncio.Event] = []
+        pending_uids: List[str] = []
 
-        async with self._lock:
-            for uid in user_ids:
-                entry = self._cache.get(uid)
-                if entry is not None and entry[1] > now:
-                    result[uid] = entry[0]
-                else:
-                    missing_ids.append(uid)
+        # Pass 1: check cache and active fetches
+        for uid in user_ids:
+            if uid in self._pending_queries:
+                pending_events.append(self._pending_queries[uid])
+                pending_uids.append(uid)
+                continue
 
-        if missing_ids:
+            entry = self._cache.get(uid)
+            if entry is not None and entry[1] > now:
+                result[uid] = entry[0]
+            else:
+                missing_ids.append(uid)
+
+        # Pass 2: Claim missing ids immediately so other tasks don't fetch them
+        events: List[asyncio.Event] = []
+        for uid in missing_ids:
+            event = asyncio.Event()
+            events.append(event)
+            self._pending_queries[uid] = event
+
+        # Pass 3: Fetch missing and wait for pending concurrently
+        async def fetch_missing():
+            if not missing_ids:
+                return {}
             try:
-                fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
-                    [str(uid) for uid in missing_ids]
-                )
-            except Exception as e:
-                await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
-                fetched = {}
+                try:
+                    fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
+                        [str(uid) for uid in missing_ids]
+                    )
+                except Exception as e:
+                    await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
+                    fetched = {}
 
-            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
-            async with self._lock:
-                for uid, info in fetched.items():
-                    self._cache[uid] = (info, expire_at)
-                    result[uid] = info
+                now_after_fetch = time.monotonic()
+                expire_at = now_after_fetch + memory_config.procedural_cache_ttl
+
+                # Only cache users that actually exist in the DB response
+                # to prevent positive caching of empty records and logic changes.
+                for uid in missing_ids:
+                    if uid in fetched:
+                        self._cache[uid] = (fetched[uid], expire_at)
 
                 if len(self._cache) > self.max_cache_size:
                     now_insert = time.monotonic()
@@ -83,6 +107,34 @@ class ProceduralMemoryProvider:
                     while len(self._cache) > self.max_cache_size:
                         oldest_key = next(iter(self._cache))
                         self._cache.pop(oldest_key)
+
+                return fetched
+            finally:
+                for uid, event in zip(missing_ids, events):
+                    self._pending_queries.pop(uid, None)
+                    event.set()
+
+        async def wait_for_pending():
+            if not pending_events:
+                return
+            await asyncio.gather(*(event.wait() for event in pending_events))
+
+        fetch_task = asyncio.create_task(fetch_missing())
+        wait_task = asyncio.create_task(wait_for_pending())
+
+        await asyncio.gather(fetch_task, wait_task)
+
+        fetched = fetch_task.result()
+        for uid in missing_ids:
+            if uid in fetched:
+                result[uid] = fetched[uid]
+
+        # For pending ids, they should now be in the cache, but let's double check
+        now_after_wait = time.monotonic()
+        for uid in pending_uids:
+            entry = self._cache.get(uid)
+            if entry is not None and entry[1] > now_after_wait:
+                result[uid] = entry[0]
 
         return ProceduralMemory(user_info=result)
 
@@ -95,5 +147,8 @@ class ProceduralMemoryProvider:
         Args:
             user_id: The user_id string to remove from cache.
         """
-        async with self._lock:
-            self._cache.pop(str(user_id), None)
+        uid = str(user_id)
+        self._cache.pop(uid, None)
+        event = self._pending_queries.pop(uid, None)
+        if event:
+            event.set()


### PR DESCRIPTION
1. **What was found**: `ProceduralMemoryProvider` had a vulnerability where an `asyncio.Lock()` was used over a `_cache` mapping, causing it to block incorrectly or allow multiple identical DB queries to hit SQLite for identical IDs simultaneously (cache stampede).
2. **Where it is**: `llm/memory/procedural.py` lines ~35-120.
3. **Why it matters**: In a busy server, many concurrent messages from/to the same users can bypass the cache simultaneously, leading to high latency and redundant SQLite batch queries.
4. **What was done**: Replaced `self._lock` with an `asyncio.Event`-based `_pending_queries` dictionary. Implemented a lock-free loop that claims missing user IDs, awaits database queries, caches the output correctly (without unsafe negative caching), and unlocks parallel waiting tasks using `asyncio.gather` for thundering herd safety.

---
*PR created automatically by Jules for task [6632930996006690823](https://jules.google.com/task/6632930996006690823) started by @starpig1129*