### PR TITLE
[Perf] Implement asyncio.Event for memory cache stampede protection

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -33,7 +33,7 @@ class KnowledgeMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: (type, target_id), value: (content, expire_at)
         self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
-        self._lock = asyncio.Lock()
+        self._pending_queries: Dict[Tuple[str, str], asyncio.Event] = {}
 
     async def get(self, guild_id: Optional[str], channel_id: str) -> KnowledgeMemory:
         """Fetch knowledge for the current guild and channel.
@@ -58,36 +58,54 @@ class KnowledgeMemoryProvider:
 
     async def _get_single(self, target_type: str, target_id: str) -> Optional[str]:
         """Internal helper with TTL cache."""
-        now = time.monotonic()
         cache_key = (target_type, target_id)
         
-        async with self._lock:
+        while True:
+            now = time.monotonic()
+
+            if cache_key in self._pending_queries:
+                await self._pending_queries[cache_key].wait()
+                continue
+
             entry = self._cache.get(cache_key)
             if entry is not None and entry[1] > now:
                 return entry[0]
+
+            event = asyncio.Event()
+            self._pending_queries[cache_key] = event
+            break
         
-        # Cache miss
         try:
-            content = await self.storage.get_knowledge(target_type, target_id)
-        except Exception as e:
-            await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
-            content = None
-            
-        # Update cache
-        expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
-        async with self._lock:
+            # Cache miss
+            try:
+                content = await self.storage.get_knowledge(target_type, target_id)
+            except Exception as e:
+                await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
+                content = None
+
+            # Update cache
+            now = time.monotonic()
+            expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
             self._cache[cache_key] = (content, expire_at)
-            
+
             # Prune cache if needed
             if len(self._cache) > self.max_cache_size:
-                self._cache = {k: v for k, v in self._cache.items() if v[1] > now}
+                now_insert = time.monotonic()
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
                 while len(self._cache) > self.max_cache_size:
                     oldest_key = next(iter(self._cache))
-                    self._cache.pop(oldest_key)
-                    
-        return content
+                    self._cache.pop(oldest_key, None)
+
+            return content
+        finally:
+            event = self._pending_queries.pop(cache_key, None)
+            if event:
+                event.set()
 
     async def invalidate(self, target_type: str, target_id: str) -> None:
         """Invalidate cache for a specific target."""
-        async with self._lock:
-            self._cache.pop((target_type, target_id), None)
+        cache_key = (target_type, target_id)
+        self._cache.pop(cache_key, None)
+        event = self._pending_queries.pop(cache_key, None)
+        if event:
+            event.set()

--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -32,7 +32,8 @@ class ProceduralMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
         self._cache: Dict[str, Tuple[UserInfo, float]] = {}
-        self._lock = asyncio.Lock()
+        # prevents cache stampedes
+        self._pending_queries: Dict[str, asyncio.Event] = {}
 
     async def get(self, user_ids: List[str]) -> ProceduralMemory:
         """Fetch procedural memory with per-user TTL cache.
@@ -49,32 +50,53 @@ class ProceduralMemoryProvider:
         if not user_ids or not self.user_manager:
             return ProceduralMemory(user_info={})
 
-        now = time.monotonic()
+        unique_ids = list(set(str(uid) for uid in user_ids))
         result: Dict[str, UserInfo] = {}
-        missing_ids: List[str] = []
 
-        async with self._lock:
-            for uid in user_ids:
+        while True:
+            now = time.monotonic()
+            pending_events = []
+
+            # Check for existing events first
+            for uid in unique_ids:
+                if uid in self._pending_queries:
+                    pending_events.append(self._pending_queries[uid])
+
+            if pending_events:
+                await asyncio.gather(*(event.wait() for event in pending_events))
+                continue # Re-evaluate after waiting
+
+            # No pending events, evaluate cache and find missing
+            missing_ids: List[str] = []
+            for uid in unique_ids:
                 entry = self._cache.get(uid)
                 if entry is not None and entry[1] > now:
                     result[uid] = entry[0]
                 else:
                     missing_ids.append(uid)
+                    event = asyncio.Event()
+                    self._pending_queries[uid] = event
+
+            if not missing_ids:
+                break # All keys found in cache
+            else:
+                # We have claimed the missing keys
+                break
 
         if missing_ids:
             try:
-                fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
-                    [str(uid) for uid in missing_ids]
-                )
-            except Exception as e:
-                await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
-                fetched = {}
+                try:
+                    fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(missing_ids)
+                except Exception as e:
+                    await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
+                    fetched = {}
 
-            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
-            async with self._lock:
-                for uid, info in fetched.items():
-                    self._cache[uid] = (info, expire_at)
-                    result[uid] = info
+                expire_at = time.monotonic() + memory_config.procedural_cache_ttl
+                for uid in missing_ids:
+                    info = fetched.get(uid)
+                    if info:
+                        self._cache[uid] = (info, expire_at)
+                        result[uid] = info
 
                 if len(self._cache) > self.max_cache_size:
                     now_insert = time.monotonic()
@@ -82,7 +104,12 @@ class ProceduralMemoryProvider:
 
                     while len(self._cache) > self.max_cache_size:
                         oldest_key = next(iter(self._cache))
-                        self._cache.pop(oldest_key)
+                        self._cache.pop(oldest_key, None)
+            finally:
+                for uid in missing_ids:
+                    event = self._pending_queries.pop(uid, None)
+                    if event:
+                        event.set()
 
         return ProceduralMemory(user_info=result)
 
@@ -95,5 +122,8 @@ class ProceduralMemoryProvider:
         Args:
             user_id: The user_id string to remove from cache.
         """
-        async with self._lock:
-            self._cache.pop(str(user_id), None)
+        uid = str(user_id)
+        self._cache.pop(uid, None)
+        event = self._pending_queries.pop(uid, None)
+        if event:
+            event.set()


### PR DESCRIPTION
**What was found:**
`ProceduralMemoryProvider` (in `llm/memory/procedural.py`) and `KnowledgeMemoryProvider` (in `llm/memory/knowledge.py`) were using `asyncio.Lock()` to wrap their dictionary read/write operations. Because dictionary operations in Python are atomic with respect to the `asyncio` event loop and the lock did not span across `await` boundaries (the actual database fetches occurred outside the lock), this provided no actual concurrency protection against cache stampedes (the "thundering herd" problem). If multiple concurrent requests arrived for the same uncached keys, they would all perform redundant database queries simultaneously.

**Where it is:**
- `llm/memory/procedural.py` lines 35, 47-111
- `llm/memory/knowledge.py` lines 36, 61-97

**Why it matters:**
In a high-traffic environment, concurrent cache misses for identical data (like fetching context for rapid messages from the same user or channel) will overwhelm the underlying database or APIs with redundant queries. This degrades performance, increases latency, and unnecessarily consumes resources.

**What was done:**
Refactored both providers to use an `asyncio.Event`-based deduplication mechanism instead of `asyncio.Lock`:
- In both files, replaced `self._lock` with `self._pending_queries`, a dictionary mapping keys to `asyncio.Event` objects.
- In `procedural.py`, implemented a two-pass `while True` loop that first collects and waits on any existing events for requested user IDs. Once all events resolve, it attempts to fulfill the batch from the cache again. Any remaining uncached IDs are then "claimed" by creating new `Event` objects in `_pending_queries`, the loop breaks, and a single database query is performed for those IDs.
- In `knowledge.py`, similarly implemented a `while True` loop to wait on an existing event or create a new one before executing the cache miss fallback logic.
- Both implementations now use a strict `try...finally` block to guarantee that the `Event` is popped from `_pending_queries` and `.set()` is called, ensuring that waiting tasks are never deadlocked even if the underlying fetch fails or the task is cancelled.
- Invalidations were updated to safely clear both the cache and any pending events.

---
*PR created automatically by Jules for task [369752925504278214](https://jules.google.com/task/369752925504278214) started by @starpig1129*