### PR TITLE
[UX] Fix hanging "thinking..." states on deferred command errors

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -512,7 +512,10 @@ class PigPig(commands.Bot):
                 if not interaction.response.is_done():
                     await interaction.response.send_message(error_msg, ephemeral=True)
                 else:
-                    await interaction.followup.send(error_msg, ephemeral=True)
+                    try:
+                        await interaction.edit_original_response(content=error_msg)
+                    except discord.NotFound:
+                        await interaction.followup.send(error_msg, ephemeral=True)
             except Exception as send_e:
                 logger.error(f"Failed to send slash command error message: {send_e}")
 


### PR DESCRIPTION
1. **What:** When a slash command is deferred (`thinking=True`) and then encounters an error, the bot replies with an error message using `followup.send()`. This leaves the original "Bot is thinking..." message hanging forever in the user's Discord client UI.
2. **Where:** `bot.py` around line 515 in the `on_tree_error` function.
3. **Why:** It looks broken and creates a poor UX, confusing users as they wait indefinitely for a "thinking" bot that has actually already errored out.
4. **What was done:** Updated the `on_tree_error` global fallback logic to prioritize `interaction.edit_original_response(content=error_msg)`. If the original response is somehow not found (catching `discord.NotFound`), it falls back safely to `interaction.followup.send()`.

---
*PR created automatically by Jules for task [15409389776550717836](https://jules.google.com/task/15409389776550717836) started by @starpig1129*