### PR TITLE
[Perf] Add thundering herd protection to memory providers

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -34,6 +34,7 @@ class KnowledgeMemoryProvider:
         # key: (type, target_id), value: (content, expire_at)
         self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
         self._lock = asyncio.Lock()
+        self._pending_queries: Dict[Tuple[str, str], asyncio.Event] = {}
 
     async def get(self, guild_id: Optional[str], channel_id: str) -> KnowledgeMemory:
         """Fetch knowledge for the current guild and channel.
@@ -58,13 +59,24 @@ class KnowledgeMemoryProvider:
 
     async def _get_single(self, target_type: str, target_id: str) -> Optional[str]:
         """Internal helper with TTL cache."""
-        now = time.monotonic()
         cache_key = (target_type, target_id)
-        
-        async with self._lock:
-            entry = self._cache.get(cache_key)
-            if entry is not None and entry[1] > now:
-                return entry[0]
+
+        while True:
+            now = time.monotonic()
+
+            async with self._lock:
+                entry = self._cache.get(cache_key)
+                if entry is not None and entry[1] > now:
+                    return entry[0]
+
+                event = self._pending_queries.get(cache_key)
+                if event is None:
+                    event = asyncio.Event()
+                    self._pending_queries[cache_key] = event
+                    break # Claimed
+
+            # Wait for another task to fetch
+            await event.wait()
         
         # Cache miss
         try:
@@ -74,16 +86,23 @@ class KnowledgeMemoryProvider:
             content = None
             
         # Update cache
-        expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
-        async with self._lock:
-            self._cache[cache_key] = (content, expire_at)
-            
-            # Prune cache if needed
-            if len(self._cache) > self.max_cache_size:
-                self._cache = {k: v for k, v in self._cache.items() if v[1] > now}
-                while len(self._cache) > self.max_cache_size:
-                    oldest_key = next(iter(self._cache))
-                    self._cache.pop(oldest_key)
+        try:
+            now = time.monotonic()
+            expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
+            async with self._lock:
+                self._cache[cache_key] = (content, expire_at)
+
+                # Prune cache if needed
+                if len(self._cache) > self.max_cache_size:
+                    self._cache = {k: v for k, v in self._cache.items() if v[1] > now}
+                    while len(self._cache) > self.max_cache_size:
+                        oldest_key = next(iter(self._cache))
+                        self._cache.pop(oldest_key)
+        finally:
+            async with self._lock:
+                event = self._pending_queries.pop(cache_key, None)
+                if event:
+                    event.set()
                     
         return content
 
@@ -91,3 +110,6 @@ class KnowledgeMemoryProvider:
         """Invalidate cache for a specific target."""
         async with self._lock:
             self._cache.pop((target_type, target_id), None)
+            event = self._pending_queries.pop((target_type, target_id), None)
+            if event:
+                event.set()

--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -33,6 +33,7 @@ class ProceduralMemoryProvider:
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
         self._cache: Dict[str, Tuple[UserInfo, float]] = {}
         self._lock = asyncio.Lock()
+        self._pending_queries: Dict[str, asyncio.Event] = {}
 
     async def get(self, user_ids: List[str]) -> ProceduralMemory:
         """Fetch procedural memory with per-user TTL cache.
@@ -49,17 +50,35 @@ class ProceduralMemoryProvider:
         if not user_ids or not self.user_manager:
             return ProceduralMemory(user_info={})
 
-        now = time.monotonic()
+        unique_ids = list(set(user_ids))
         result: Dict[str, UserInfo] = {}
-        missing_ids: List[str] = []
 
-        async with self._lock:
-            for uid in user_ids:
-                entry = self._cache.get(uid)
-                if entry is not None and entry[1] > now:
-                    result[uid] = entry[0]
-                else:
-                    missing_ids.append(uid)
+        while True:
+            missing_ids: List[str] = []
+            pending_events: List[asyncio.Event] = []
+
+            async with self._lock:
+                now = time.monotonic()
+                for uid in unique_ids:
+                    entry = self._cache.get(uid)
+                    if entry is not None and entry[1] > now:
+                        result[uid] = entry[0]
+                    elif uid in self._pending_queries:
+                        pending_events.append(self._pending_queries[uid])
+                    else:
+                        missing_ids.append(uid)
+
+                if pending_events:
+                    pass
+                elif missing_ids:
+                    for uid in missing_ids:
+                        self._pending_queries[uid] = asyncio.Event()
+
+            if pending_events:
+                await asyncio.gather(*(event.wait() for event in pending_events))
+                continue
+
+            break
 
         if missing_ids:
             try:
@@ -71,18 +90,26 @@ class ProceduralMemoryProvider:
                 fetched = {}
 
             expire_at = time.monotonic() + memory_config.procedural_cache_ttl
-            async with self._lock:
-                for uid, info in fetched.items():
-                    self._cache[uid] = (info, expire_at)
-                    result[uid] = info
 
-                if len(self._cache) > self.max_cache_size:
-                    now_insert = time.monotonic()
-                    self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+            try:
+                async with self._lock:
+                    for uid, info in fetched.items():
+                        self._cache[uid] = (info, expire_at)
+                        result[uid] = info
 
-                    while len(self._cache) > self.max_cache_size:
-                        oldest_key = next(iter(self._cache))
-                        self._cache.pop(oldest_key)
+                    if len(self._cache) > self.max_cache_size:
+                        now_insert = time.monotonic()
+                        self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+
+                        while len(self._cache) > self.max_cache_size:
+                            oldest_key = next(iter(self._cache))
+                            self._cache.pop(oldest_key)
+            finally:
+                async with self._lock:
+                    for uid in missing_ids:
+                        event = self._pending_queries.pop(uid, None)
+                        if event:
+                            event.set()
 
         return ProceduralMemory(user_info=result)
 
@@ -97,3 +124,6 @@ class ProceduralMemoryProvider:
         """
         async with self._lock:
             self._cache.pop(str(user_id), None)
+            event = self._pending_queries.pop(str(user_id), None)
+            if event:
+                event.set()


### PR DESCRIPTION
Implemented request coalescing (thundering herd protection) in `ProceduralMemoryProvider` and `KnowledgeMemoryProvider` caching layers to avoid cache stampedes on concurrent access.

What was found:
When multiple messages triggered concurrent cache misses for the same user IDs or knowledge keys, it would result in duplicated database/network calls before the TTL cache was populated.

Where it is:
- `llm/memory/procedural.py` (lines 36, 54-78, 127)
- `llm/memory/knowledge.py` (lines 37, 63-75, 113)

Why it matters:
High concurrency on Discord channels can trigger an overwhelming number of requests when multiple users trigger the pipeline, potentially starving the database connection pool or overloading external APIs before the cache updates.

What was done:
Added a `_pending_queries` dictionary using `asyncio.Event` to coordinate cache misses. When multiple coroutines attempt to fetch the same data, the first one assumes responsibility, while subsequent requests wait on the corresponding `asyncio.Event` and seamlessly retrieve the cached result once it becomes available. Also properly cleaned up cache evictions in `invalidate`.

---
*PR created automatically by Jules for task [8909375976278644189](https://jules.google.com/task/8909375976278644189) started by @starpig1129*