### PR TITLE
[Perf] Add thundering herd protection to memory providers

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -33,7 +33,8 @@ class KnowledgeMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: (type, target_id), value: (content, expire_at)
         self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
-        self._lock = asyncio.Lock()
+        # prevents cache stampedes
+        self._pending_queries: Dict[Tuple[str, str], asyncio.Event] = {}
 
     async def get(self, guild_id: Optional[str], channel_id: str) -> KnowledgeMemory:
         """Fetch knowledge for the current guild and channel.
@@ -58,36 +59,59 @@ class KnowledgeMemoryProvider:
 
     async def _get_single(self, target_type: str, target_id: str) -> Optional[str]:
         """Internal helper with TTL cache."""
-        now = time.monotonic()
         cache_key = (target_type, target_id)
         
-        async with self._lock:
+        while True:
+            now = time.monotonic()
+
+            # 1. Check cache first
             entry = self._cache.get(cache_key)
             if entry is not None and entry[1] > now:
                 return entry[0]
+
+            # 2. Check if another task is fetching this key
+            event = self._pending_queries.get(cache_key)
+            if event:
+                await event.wait()
+                continue
+
+            # 3. Not in cache, not pending. Claim it.
+            event = asyncio.Event()
+            self._pending_queries[cache_key] = event
+            break
         
-        # Cache miss
         try:
-            content = await self.storage.get_knowledge(target_type, target_id)
-        except Exception as e:
-            await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
-            content = None
-            
-        # Update cache
-        expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
-        async with self._lock:
+            # Cache miss
+            try:
+                content = await self.storage.get_knowledge(target_type, target_id)
+            except Exception as e:
+                await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
+                content = None
+
+            # Update cache
+            now = time.monotonic()
+            expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
             self._cache[cache_key] = (content, expire_at)
-            
+
             # Prune cache if needed
             if len(self._cache) > self.max_cache_size:
-                self._cache = {k: v for k, v in self._cache.items() if v[1] > now}
+                now_insert = time.monotonic()
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
                 while len(self._cache) > self.max_cache_size:
                     oldest_key = next(iter(self._cache))
-                    self._cache.pop(oldest_key)
-                    
-        return content
+                    self._cache.pop(oldest_key, None)
+
+            return content
+        finally:
+            event = self._pending_queries.pop(cache_key, None)
+            if event:
+                event.set()
 
     async def invalidate(self, target_type: str, target_id: str) -> None:
         """Invalidate cache for a specific target."""
-        async with self._lock:
-            self._cache.pop((target_type, target_id), None)
+        cache_key = (target_type, target_id)
+        self._cache.pop(cache_key, None)
+
+        event = self._pending_queries.pop(cache_key, None)
+        if event:
+            event.set()

--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -32,7 +32,8 @@ class ProceduralMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
         self._cache: Dict[str, Tuple[UserInfo, float]] = {}
-        self._lock = asyncio.Lock()
+        # prevents cache stampedes
+        self._pending_queries: Dict[str, asyncio.Event] = {}
 
     async def get(self, user_ids: List[str]) -> ProceduralMemory:
         """Fetch procedural memory with per-user TTL cache.
@@ -49,42 +50,74 @@ class ProceduralMemoryProvider:
         if not user_ids or not self.user_manager:
             return ProceduralMemory(user_info={})
 
-        now = time.monotonic()
+        unique_ids = list(set(str(uid) for uid in user_ids))
         result: Dict[str, UserInfo] = {}
-        missing_ids: List[str] = []
 
-        async with self._lock:
-            for uid in user_ids:
+        while True:
+            missing_ids: List[str] = []
+            pending_events: List[asyncio.Event] = []
+            now = time.monotonic()
+
+            for uid in unique_ids:
+                if uid in result:
+                    continue
                 entry = self._cache.get(uid)
                 if entry is not None and entry[1] > now:
                     result[uid] = entry[0]
+                elif uid in self._pending_queries:
+                    pending_events.append(self._pending_queries[uid])
                 else:
                     missing_ids.append(uid)
 
-        if missing_ids:
+            if pending_events:
+                await asyncio.gather(*(event.wait() for event in pending_events))
+                continue
+
+            if not missing_ids:
+                break
+
+            events_created: List[str] = []
+            for uid in missing_ids:
+                event = asyncio.Event()
+                self._pending_queries[uid] = event
+                events_created.append(uid)
+            break
+
+        if not missing_ids:
+            return ProceduralMemory(user_info=result)
+
+        try:
             try:
                 fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
-                    [str(uid) for uid in missing_ids]
+                    missing_ids
                 )
             except Exception as e:
                 await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
                 fetched = {}
 
-            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
-            async with self._lock:
-                for uid, info in fetched.items():
+            now = time.monotonic()
+            expire_at = now + memory_config.procedural_cache_ttl
+
+            for uid in missing_ids:
+                info = fetched.get(uid)
+                if info is not None:
                     self._cache[uid] = (info, expire_at)
                     result[uid] = info
 
-                if len(self._cache) > self.max_cache_size:
-                    now_insert = time.monotonic()
-                    self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+            if len(self._cache) > self.max_cache_size:
+                now_insert = time.monotonic()
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
 
-                    while len(self._cache) > self.max_cache_size:
-                        oldest_key = next(iter(self._cache))
-                        self._cache.pop(oldest_key)
+                while len(self._cache) > self.max_cache_size:
+                    oldest_key = next(iter(self._cache))
+                    self._cache.pop(oldest_key, None)
 
-        return ProceduralMemory(user_info=result)
+            return ProceduralMemory(user_info=result)
+        finally:
+            for uid in events_created:
+                event = self._pending_queries.pop(uid, None)
+                if event:
+                    event.set()
 
     async def invalidate(self, user_id: str) -> None:
         """Evict a single user from the cache.
@@ -95,5 +128,9 @@ class ProceduralMemoryProvider:
         Args:
             user_id: The user_id string to remove from cache.
         """
-        async with self._lock:
-            self._cache.pop(str(user_id), None)
+        uid_str = str(user_id)
+        self._cache.pop(uid_str, None)
+
+        event = self._pending_queries.pop(uid_str, None)
+        if event:
+            event.set()


### PR DESCRIPTION
**What was found**: The `ProceduralMemoryProvider` and `KnowledgeMemoryProvider` used an `asyncio.Lock()` strictly around dictionary accesses, leaving the external API/DB fetch unprotected. Multiple concurrent requests for the same cache-missed key caused parallel duplicate DB requests.

**Where it is**: `llm/memory/procedural.py` lines 55-90 and `llm/memory/knowledge.py` lines 65-100.

**Why it matters**: These providers are invoked on the hot path via parallel execution in `llm/context_manager.py`. With highly active servers generating bursts of messages, cache stampedes directly overload SQLite locks and the discord.py event loop, introducing large latency spikes.

**What was done**: Replaced the synchronous dictionary lock with an `asyncio.Event`-backed `_pending_queries` dictionary. Missing keys are temporarily tracked via events so subsequent tasks yield via `await event.wait()` rather than re-triggering the fetch. The solution natively supports multi-key fetches without deadlocks.

---
*PR created automatically by Jules for task [404217266428916579](https://jules.google.com/task/404217266428916579) started by @starpig1129*