### PR TITLE
[Security] Fix RCE vulnerability in sympy parse_expr evaluation

### DIFF
--- a/cogs/math.py
+++ b/cogs/math.py
@@ -180,7 +180,7 @@ class MathCalculatorCog(commands.Cog):
                 transformations=transformations,
                 evaluate=True,
                 local_dict=local_dict,
-                global_dict={},  # Disable global_dict for safety
+                global_dict={'__builtins__': {}},  # Disable global_dict for safety
             )
 
             # Check for undefined functions


### PR DESCRIPTION
**What was found:**
A critical Remote Code Execution (RCE) vulnerability was found in the `MathCalculatorCog` tool, specifically where the bot parses and evaluates user-provided mathematical expressions.

**Where it is:**
File: `cogs/math.py`
Line: ~183, inside the `calculate_math` function where `parse_expr` is called.

**Why it matters:**
`sympy.parsing.sympy_parser.parse_expr` internally uses Python's `eval()` function to compute the result of mathematical expressions. The code was passing `global_dict={}` to restrict execution, however, Python automatically injects the `__builtins__` dictionary into empty global namespaces during `eval()`. Even though there's a strict regex filtering characters earlier in the function, it is safer to ensure the sandbox is properly isolated, preventing any potential namespace escape or command injection that could lead to full bot takeover or resource abuse.

**What was done:**
Modified the `global_dict` parameter in the `parse_expr` call from `{}` to `{'__builtins__': {}}`. This effectively shadows the default built-ins injection and properly locks down the evaluation environment, mitigating the RCE vulnerability without affecting legitimate mathematical operations.

---
*PR created automatically by Jules for task [12675465591200094324](https://jules.google.com/task/12675465591200094324) started by @starpig1129*