### PR TITLE
[Security] Fix RCE vulnerability in math expression evaluation

### DIFF
--- a/cogs/math.py
+++ b/cogs/math.py
@@ -180,7 +180,7 @@ class MathCalculatorCog(commands.Cog):
                 transformations=transformations,
                 evaluate=True,
                 local_dict=local_dict,
-                global_dict={},  # Disable global_dict for safety
+                global_dict={'__builtins__': {}},  # Disable global_dict for safety
             )
 
             # Check for undefined functions


### PR DESCRIPTION
**What was found:** A critical Remote Code Execution (RCE) vulnerability in the math calculation feature.
**Where it is:** `cogs/math.py`, specifically the `global_dict` argument within the `parse_expr` call (around line 183).
**Why it matters:** Passing an empty dictionary `global_dict={}` to `parse_expr` does not disable Python's built-ins, because Python automatically injects `__builtins__` into an empty globals dict. This allowed malicious users to execute arbitrary code (e.g., using `__import__('os').system(...)`).
**What was done:** Explicitly passed `{'__builtins__': {}}` to the `global_dict` parameter in `parse_expr` to completely disable access to built-in functions and mitigate the RCE vector.

---
*PR created automatically by Jules for task [3891506837931074701](https://jules.google.com/task/3891506837931074701) started by @starpig1129*