### PR TITLE
[UX] Fix hanging 'Thinking...' states in deferred slash commands

### DIFF
--- a/cogs/botinfo.py
+++ b/cogs/botinfo.py
@@ -198,7 +198,7 @@ class BotInfo(commands.Cog):
                 icon_url=avatar_url
             )
 
-            await interaction.followup.send(embed=main_embed)
+            await interaction.edit_original_response(embed=main_embed)
         except Exception as e:
             await func.report_error(e, "getting bot info")
 

--- a/cogs/gen_img.py
+++ b/cogs/gen_img.py
@@ -221,7 +221,7 @@ class ImageGenerationCog(commands.Cog, name="ImageGenerationCog"):
 
         # Slash command still uses immediate reply but supports attachments (base64 → discord.File)
         if "error" in result:
-            await interaction.followup.send(result["error"])
+            await interaction.edit_original_response(content=result["error"])
         else:
             files = []
             attachments = result.get("attachments") or []
@@ -236,9 +236,9 @@ class ImageGenerationCog(commands.Cog, name="ImageGenerationCog"):
                     self.logger.error(f"Slash reply conversion failed: {e}")
             content = result.get("content")
             if files:
-                await interaction.followup.send(content=content, files=files)
+                await interaction.edit_original_response(content=content, attachments=files)
             else:
-                await interaction.followup.send(content=content)
+                await interaction.edit_original_response(content=content)
 
     def _image_to_base64(self, image: Image.Image) -> str:
         """Convert a PIL Image to a base64-encoded string"""

--- a/cogs/schedule.py
+++ b/cogs/schedule.py
@@ -51,13 +51,13 @@ class ScheduleManager(commands.Cog):
             success_msg = self.lang_manager.translate(
                 guild_id, "commands", "upload_schedule", "responses", "success"
             ) if self.lang_manager else "行程表已成功上傳！"
-            await interaction.followup.send(success_msg)
+            await interaction.edit_original_response(content=success_msg)
         except Exception as e:
             await func.report_error(e, "uploading schedule")
             error_msg = self.lang_manager.translate(
                 guild_id, "commands", "upload_schedule", "responses", "error", error=str(e)
             ) if self.lang_manager else f"上傳行程表時發生錯誤：{str(e)}"
-            await interaction.followup.send(error_msg)
+            await interaction.edit_original_response(content=error_msg)
 
     async def _core_upload_schedule(self, user_id: int, channel_id: int, yaml_data: bytes):
         try:
@@ -95,13 +95,13 @@ class ScheduleManager(commands.Cog):
         try:
             target_user_id = target_user.id if target_user else interaction.user.id
             result = await self._core_query_schedule(interaction, query_type.value, target_user_id, time, day.value if day else None)
-            await interaction.followup.send(result)
+            await interaction.edit_original_response(content=result)
         except Exception as e:
             await func.report_error(e, "querying schedule")
             error_msg = self.lang_manager.translate(
                 guild_id, "commands", "query_schedule", "responses", "error", error=str(e)
             ) if self.lang_manager else f"查詢行程表時發生錯誤：{str(e)}"
-            await interaction.followup.send(error_msg)
+            await interaction.edit_original_response(content=error_msg)
 
     async def _core_query_schedule(self, interaction_or_ctx, query_type: str, target_user_id:int, time: str = None, day: str = None):
         guild_id = str(interaction_or_ctx.guild_id) if hasattr(interaction_or_ctx, 'guild_id') and interaction_or_ctx.guild_id else str(interaction_or_ctx.guild.id) if hasattr(interaction_or_ctx, 'guild') else "0"
@@ -307,13 +307,13 @@ class ScheduleManager(commands.Cog):
             success_msg = self.lang_manager.translate(
                 guild_id, "commands", "update_schedule", "responses", "success"
             ) if self.lang_manager else "行程表已成功更新或創建！"
-            await interaction.followup.send(success_msg)
+            await interaction.edit_original_response(content=success_msg)
         except Exception as e:
             await func.report_error(e, "updating schedule")
             error_msg = self.lang_manager.translate(
                 guild_id, "commands", "update_schedule", "responses", "error", error=str(e)
             ) if self.lang_manager else f"更新或創建行程表時發生錯誤：{str(e)}"
-            await interaction.followup.send(error_msg)
+            await interaction.edit_original_response(content=error_msg)
 
     async def _core_update_schedule(self, user_id: int, day: str, time: str, description: str):
         filepath = os.path.join(self.schedule_dir, f"{user_id}.yaml")

--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -741,7 +741,7 @@ class UserDataCog(commands.Cog):
             action='save'
         )
         
-        await interaction.followup.send(result, ephemeral=True)
+        await interaction.edit_original_response(content=result)
 
     @memory_group.command(
         name="clear",
@@ -765,7 +765,7 @@ class UserDataCog(commands.Cog):
             action='clear'
         )
 
-        await interaction.followup.send(result, ephemeral=True)
+        await interaction.edit_original_response(content=result)
 
     @memory_group.command(
         name="show",
@@ -789,7 +789,7 @@ class UserDataCog(commands.Cog):
             action='read'
         )
         
-        await interaction.followup.send(result, ephemeral=True)
+        await interaction.edit_original_response(content=result)
 
     @knowledge_group.command(
         name="show",
@@ -813,22 +813,22 @@ class UserDataCog(commands.Cog):
         target_id = str(interaction.guild_id) if target_type == "guild" else str(interaction.channel_id)
 
         if target_type == "guild" and not interaction.guild_id:
-            await interaction.followup.send("Guild knowledge is only available within a server.", ephemeral=True)
+            await interaction.edit_original_response(content="Guild knowledge is only available within a server.")
             return
 
         if not self.knowledge_storage:
-            await interaction.followup.send("Knowledge storage is not initialized.", ephemeral=True)
+            await interaction.edit_original_response(content="Knowledge storage is not initialized.")
             return
 
         try:
             content = await self.knowledge_storage.get_knowledge(target_type, target_id)
             if content:
-                await interaction.followup.send(f"Current {target_type} knowledge:\n\n{content}", ephemeral=True)
+                await interaction.edit_original_response(content=f"Current {target_type} knowledge:\n\n{content}")
             else:
-                await interaction.followup.send(f"There is no {target_type} knowledge currently stored.", ephemeral=True)
+                await interaction.edit_original_response(content=f"There is no {target_type} knowledge currently stored.")
         except Exception as e:
             self.logger.error(f"Failed to read {target_type} knowledge for {target_id}: {e}")
-            await interaction.followup.send(f"Failed to read knowledge: {e}", ephemeral=True)
+            await interaction.edit_original_response(content=f"Failed to read knowledge: {e}")
 
     @knowledge_group.command(
         name="save",
@@ -861,11 +861,11 @@ class UserDataCog(commands.Cog):
         target_id = str(interaction.guild_id) if target_type == "guild" else str(interaction.channel_id)
 
         if target_type == "guild" and not interaction.guild_id:
-            await interaction.followup.send("Guild knowledge is only available within a server.", ephemeral=True)
+            await interaction.edit_original_response(content="Guild knowledge is only available within a server.")
             return
 
         if not self.knowledge_storage:
-            await interaction.followup.send("Knowledge storage is not initialized.", ephemeral=True)
+            await interaction.edit_original_response(content="Knowledge storage is not initialized.")
             return
 
         try:
@@ -876,10 +876,10 @@ class UserDataCog(commands.Cog):
                 category=category,
                 context=interaction
             )
-            await interaction.followup.send(result_msg, ephemeral=True)
+            await interaction.edit_original_response(content=result_msg)
         except Exception as e:
             self.logger.error(f"Failed to save {target_type} knowledge for {target_id}: {e}")
-            await interaction.followup.send(f"Failed to save knowledge: {e}", ephemeral=True)
+            await interaction.edit_original_response(content=f"Failed to save knowledge: {e}")
 
 
     @knowledge_group.command(
@@ -905,11 +905,11 @@ class UserDataCog(commands.Cog):
         target_id = str(interaction.guild_id) if target_type == "guild" else str(interaction.channel_id)
 
         if target_type == "guild" and not interaction.guild_id:
-            await interaction.followup.send("Guild knowledge is only available within a server.", ephemeral=True)
+            await interaction.edit_original_response(content="Guild knowledge is only available within a server.")
             return
 
         if not self.knowledge_storage:
-            await interaction.followup.send("Knowledge storage is not initialized.", ephemeral=True)
+            await interaction.edit_original_response(content="Knowledge storage is not initialized.")
             return
 
         try:
@@ -929,12 +929,12 @@ class UserDataCog(commands.Cog):
                 except Exception as cache_err:
                     self.logger.warning(f"Failed to invalidate knowledge cache for {target_type} {target_id}: {cache_err}")
 
-                await interaction.followup.send(f"Successfully cleared {target_type} knowledge.", ephemeral=True)
+                await interaction.edit_original_response(content=f"Successfully cleared {target_type} knowledge.")
             else:
-                await interaction.followup.send(f"There was no {target_type} knowledge to clear or an error occurred.", ephemeral=True)
+                await interaction.edit_original_response(content=f"There was no {target_type} knowledge to clear or an error occurred.")
         except Exception as e:
             self.logger.error(f"Failed to clear {target_type} knowledge for {target_id}: {e}")
-            await interaction.followup.send(f"Failed to clear knowledge: {e}", ephemeral=True)
+            await interaction.edit_original_response(content=f"Failed to clear knowledge: {e}")
 
     async def manage_user_data(
         self,


### PR DESCRIPTION
**What:**
Deferred slash commands (using `await interaction.response.defer(thinking=True)`) were incorrectly being answered using `await interaction.followup.send(...)`. This caused Discord to leave the original "Thinking..." message hanging perpetually in the channel, while sending the actual response as a separate new message.

**Where:**
- `cogs/botinfo.py`
- `cogs/gen_img.py`
- `cogs/schedule.py`
- `cogs/userdata.py`

**Why:**
This is a highly visible UX issue. Users would see the bot "Thinking..." indefinitely, causing confusion and making them believe the command either hung, failed, or was still running in the background.

**What was done:**
Replaced the initial `await interaction.followup.send(...)` call in these affected cogs with `await interaction.edit_original_response(content=...)` (and adjusting parameters like `attachments` and `embeds` accordingly). For `userdata.py`, removed the unsupported `ephemeral=True` flag from `edit_original_response` because the ephemeral state is already locked in by the initial `defer(ephemeral=True)` call.

---
*PR created automatically by Jules for task [1592872788860544354](https://jules.google.com/task/1592872788860544354) started by @starpig1129*