### PR TITLE
[Perf] Add asyncio.Event thundering herd protection to Procedural and Knowledge memory providers

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -33,7 +33,7 @@ class KnowledgeMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: (type, target_id), value: (content, expire_at)
         self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
-        self._lock = asyncio.Lock()
+        self._pending_queries: Dict[Tuple[str, str], asyncio.Event] = {}
 
     async def get(self, guild_id: Optional[str], channel_id: str) -> KnowledgeMemory:
         """Fetch knowledge for the current guild and channel.
@@ -58,36 +58,53 @@ class KnowledgeMemoryProvider:
 
     async def _get_single(self, target_type: str, target_id: str) -> Optional[str]:
         """Internal helper with TTL cache."""
-        now = time.monotonic()
         cache_key = (target_type, target_id)
         
-        async with self._lock:
+        while cache_key in self._pending_queries:
+            await self._pending_queries[cache_key].wait()
+            now = time.monotonic()
             entry = self._cache.get(cache_key)
             if entry is not None and entry[1] > now:
                 return entry[0]
         
-        # Cache miss
+        now = time.monotonic()
+        entry = self._cache.get(cache_key)
+        if entry is not None and entry[1] > now:
+            return entry[0]
+            
+        event = asyncio.Event()
+        self._pending_queries[cache_key] = event
+
         try:
-            content = await self.storage.get_knowledge(target_type, target_id)
-        except Exception as e:
-            await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
-            content = None
-            
-        # Update cache
-        expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
-        async with self._lock:
+            # Cache miss
+            try:
+                content = await self.storage.get_knowledge(target_type, target_id)
+            except Exception as e:
+                await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
+                content = None
+
+            # Update cache
+            expire_at = time.monotonic() + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
             self._cache[cache_key] = (content, expire_at)
-            
+
             # Prune cache if needed
             if len(self._cache) > self.max_cache_size:
-                self._cache = {k: v for k, v in self._cache.items() if v[1] > now}
+                now_insert = time.monotonic()
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
                 while len(self._cache) > self.max_cache_size:
                     oldest_key = next(iter(self._cache))
                     self._cache.pop(oldest_key)
-                    
-        return content
+
+            return content
+        finally:
+            if self._pending_queries.get(cache_key) is event:
+                self._pending_queries.pop(cache_key, None)
+            event.set()
 
     async def invalidate(self, target_type: str, target_id: str) -> None:
         """Invalidate cache for a specific target."""
-        async with self._lock:
-            self._cache.pop((target_type, target_id), None)
+        cache_key = (target_type, target_id)
+        self._cache.pop(cache_key, None)
+        event = self._pending_queries.pop(cache_key, None)
+        if event:
+            event.set()

--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -32,7 +32,53 @@ class ProceduralMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
         self._cache: Dict[str, Tuple[UserInfo, float]] = {}
-        self._lock = asyncio.Lock()
+        self._pending_queries: Dict[str, asyncio.Event] = {}
+
+    async def _fetch_and_cache(self, missing_ids: List[str]) -> None:
+        events = []
+        claimed = []
+        for uid in missing_ids:
+            if uid not in self._pending_queries:
+                ev = asyncio.Event()
+                self._pending_queries[uid] = ev
+                events.append(ev)
+                claimed.append(uid)
+
+        if not claimed:
+            return
+
+        try:
+            fetched = await self.user_manager.get_multiple_users(claimed)
+            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
+
+            for uid, ev in zip(claimed, events):
+                # cache an empty UserInfo if it doesn't exist, this provides negative caching
+                # and stops the get loop from attempting to fetch infinitely
+                info = fetched.get(uid)
+                if not info:
+                    info = UserInfo()
+                self._cache[uid] = (info, expire_at)
+
+                if self._pending_queries.get(uid) is ev:
+                    self._pending_queries.pop(uid, None)
+                ev.set()
+
+            if len(self._cache) > self.max_cache_size:
+                now_insert = time.monotonic()
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+                while len(self._cache) > self.max_cache_size:
+                    oldest_key = next(iter(self._cache))
+                    self._cache.pop(oldest_key, None)
+
+        except Exception as e:
+            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
+            for uid, ev in zip(claimed, events):
+                # cache empty on exception to prevent infinite loop
+                self._cache[uid] = (UserInfo(), expire_at)
+                if self._pending_queries.get(uid) is ev:
+                    self._pending_queries.pop(uid, None)
+                ev.set()
+            await func.report_error(e, "ProceduralMemoryProvider._fetch_and_cache failed")
 
     async def get(self, user_ids: List[str]) -> ProceduralMemory:
         """Fetch procedural memory with per-user TTL cache.
@@ -49,40 +95,44 @@ class ProceduralMemoryProvider:
         if not user_ids or not self.user_manager:
             return ProceduralMemory(user_info={})
 
-        now = time.monotonic()
+        unique_ids = list(set(str(uid) for uid in user_ids))
         result: Dict[str, UserInfo] = {}
-        missing_ids: List[str] = []
 
-        async with self._lock:
-            for uid in user_ids:
+        while True:
+            # 1. Deduplicate and wait for all pending events concurrently before checking cache
+            pending_events = [self._pending_queries[uid] for uid in unique_ids if uid in self._pending_queries]
+
+            if pending_events:
+                # Avoid latency regressions by concurrently fetching missing keys
+                now = time.monotonic()
+                missing_candidates = [
+                    uid for uid in unique_ids
+                    if uid not in self._pending_queries and uid not in result and (uid not in self._cache or self._cache[uid][1] <= now)
+                ]
+                if missing_candidates:
+                    asyncio.create_task(self._fetch_and_cache(missing_candidates))
+
+                # Separate checking for pending events from claiming missing keys in main loop
+                await asyncio.gather(*(e.wait() for e in pending_events))
+                continue
+
+            # 2. Synchronously check the cache
+            now = time.monotonic()
+            missing_ids = []
+            for uid in unique_ids:
+                if uid in result:
+                    continue
                 entry = self._cache.get(uid)
                 if entry is not None and entry[1] > now:
                     result[uid] = entry[0]
                 else:
                     missing_ids.append(uid)
 
-        if missing_ids:
-            try:
-                fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
-                    [str(uid) for uid in missing_ids]
-                )
-            except Exception as e:
-                await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
-                fetched = {}
+            if not missing_ids:
+                break
 
-            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
-            async with self._lock:
-                for uid, info in fetched.items():
-                    self._cache[uid] = (info, expire_at)
-                    result[uid] = info
-
-                if len(self._cache) > self.max_cache_size:
-                    now_insert = time.monotonic()
-                    self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
-
-                    while len(self._cache) > self.max_cache_size:
-                        oldest_key = next(iter(self._cache))
-                        self._cache.pop(oldest_key)
+            # Fetch and cache missing keys directly (will loop again to pick up results)
+            await self._fetch_and_cache(missing_ids)
 
         return ProceduralMemory(user_info=result)
 
@@ -95,5 +145,8 @@ class ProceduralMemoryProvider:
         Args:
             user_id: The user_id string to remove from cache.
         """
-        async with self._lock:
-            self._cache.pop(str(user_id), None)
+        user_id_str = str(user_id)
+        self._cache.pop(user_id_str, None)
+        event = self._pending_queries.pop(user_id_str, None)
+        if event:
+            event.set()


### PR DESCRIPTION
**What was found:** 
`ProceduralMemoryProvider` and `KnowledgeMemoryProvider` suffered from a thundering herd (cache stampede) issue on cache misses. Furthermore, they used global `asyncio.Lock()` instances around purely synchronous dictionary operations, failing to provide actual concurrency control since task switching only occurs across `await` boundaries. This resulted in redundant, dogpiled database queries on cache miss and blocked completely unrelated keys from being read or fetched.

**Where it is:**
* `llm/memory/procedural.py` lines 32-146
* `llm/memory/knowledge.py` lines 33-108

**Why it matters:** 
The lack of per-key synchronization caused sequential bottlenecks in the critical hot-path of the application context manager. When multiple asynchronous requests hit the same missing cache keys concurrently (such as during traffic spikes), it spammed the backend database redundantly and sharply degraded response latency across the system. 

**What was done:**
* Removed the global `self._lock` in both `ProceduralMemoryProvider` and `KnowledgeMemoryProvider`.
* Introduced a per-key `asyncio.Event` mapping (`self._pending_queries`) to provide fine-grained, localized synchronization.
* For `ProceduralMemoryProvider`, implemented a double-pass deduction loop. It concurrently gathers and waits for all pending events before checking the cache, and asynchronously fires missing batch fetches, eliminating sequential blockers.
* Ensured negative caching (e.g., caching empty objects) is applied when exceptions occur to guarantee termination of the `while True` loop and prevent CPU exhaustion. 
* Refined the `finally` event cleanup blocks to pop only if the current active event perfectly matches the dictionary reference, avoiding invalidation race conditions.

---
*PR created automatically by Jules for task [11185275805803921005](https://jules.google.com/task/11185275805803921005) started by @starpig1129*