### PR TITLE
[UX] Fix hanging 'Thinking...' state on slash command error

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -512,7 +512,10 @@ class PigPig(commands.Bot):
                 if not interaction.response.is_done():
                     await interaction.response.send_message(error_msg, ephemeral=True)
                 else:
-                    await interaction.followup.send(error_msg, ephemeral=True)
+                    try:
+                        await interaction.edit_original_response(content=error_msg, view=None)
+                    except discord.NotFound:
+                        await interaction.followup.send(error_msg, ephemeral=True)
             except Exception as send_e:
                 logger.error(f"Failed to send slash command error message: {send_e}")
 


### PR DESCRIPTION
**What was found:** 
When an error occurs during a slash command that was deferred (showing a "Bot is thinking..." state), the `on_tree_error` global handler simply checks if the interaction was acknowledged (`is_done()`) and blindly calls `followup.send()`. Since `followup.send()` creates a new webhook message, the original "Thinking..." message is never updated or deleted, leaving a confusing hanging state in the Discord UI until it times out with "The application did not respond".

**Where it is:** 
`bot.py`, specifically lines 511-518 inside the `on_tree_error` function.

**Why it matters:** 
This is a high-frequency, high-confusion UX issue. Users perceive the bot as broken or still processing something indefinitely, leading to frustration and repeated command usage. A clean error response in the place of the "Thinking..." message provides immediate, clear feedback.

**What was done:** 
Modified the error fallback path to first attempt `await interaction.edit_original_response(content=error_msg, view=None)`. If this fails with `discord.NotFound` (meaning the original message is gone or wasn't sent), it gracefully falls back to the existing `await interaction.followup.send()` logic.

---
*PR created automatically by Jules for task [7568754352695450694](https://jules.google.com/task/7568754352695450694) started by @starpig1129*