### PR TITLE
[Security] Fix RCE vulnerability in math expression evaluation

### DIFF
--- a/cogs/math.py
+++ b/cogs/math.py
@@ -180,7 +180,7 @@ class MathCalculatorCog(commands.Cog):
                 transformations=transformations,
                 evaluate=True,
                 local_dict=local_dict,
-                global_dict={},  # Disable global_dict for safety
+                global_dict={'__builtins__': {}},  # Disable global_dict for safety
             )
 
             # Check for undefined functions


### PR DESCRIPTION
1. **What was found**: A critical Remote Code Execution (RCE) vulnerability when evaluating mathematical expressions.
2. **Where it is**: `cogs/math.py` (line 183).
3. **Why it matters**: Discord users could execute arbitrary code by passing a crafted string (e.g. `__import__('os').system(...)`) into the math calculator cog, as Python's `eval()` defaults to injecting `__builtins__` if the `global_dict` is empty.
4. **What was done**: Changed `global_dict={}` to `global_dict={'__builtins__': {}}` in the `parse_expr` call to securely sandbox the evaluation.

---
*PR created automatically by Jules for task [15608371529751381920](https://jules.google.com/task/15608371529751381920) started by @starpig1129*