### PR TITLE
[Perf] Add thundering herd protection to ProceduralMemoryProvider

### DIFF
--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -32,6 +32,7 @@ class ProceduralMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
         self._cache: Dict[str, Tuple[UserInfo, float]] = {}
+        self._pending_queries: Dict[str, asyncio.Event] = {}
         self._lock = asyncio.Lock()
 
     async def get(self, user_ids: List[str]) -> ProceduralMemory:
@@ -49,40 +50,83 @@ class ProceduralMemoryProvider:
         if not user_ids or not self.user_manager:
             return ProceduralMemory(user_info={})
 
-        now = time.monotonic()
+        unique_uids = list(set(str(uid) for uid in user_ids))
         result: Dict[str, UserInfo] = {}
-        missing_ids: List[str] = []
+        attempted_ids = set()
 
-        async with self._lock:
-            for uid in user_ids:
-                entry = self._cache.get(uid)
-                if entry is not None and entry[1] > now:
-                    result[uid] = entry[0]
-                else:
-                    missing_ids.append(uid)
+        while True:
+            now = time.monotonic()
+            missing_ids: List[str] = []
+            pending_events: List[asyncio.Event] = []
 
-        if missing_ids:
-            try:
-                fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
-                    [str(uid) for uid in missing_ids]
-                )
-            except Exception as e:
-                await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
-                fetched = {}
-
-            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
             async with self._lock:
-                for uid, info in fetched.items():
-                    self._cache[uid] = (info, expire_at)
-                    result[uid] = info
+                for uid in unique_uids:
+                    if uid in result:
+                        continue
+                    entry = self._cache.get(uid)
+                    if entry is not None and entry[1] > now:
+                        result[uid] = entry[0]
+                    elif uid in attempted_ids:
+                        # We tried to fetch it, and it's not in cache, so it genuinely missed.
+                        # Do not keep looping forever trying to fetch it.
+                        continue
+                    elif uid in self._pending_queries:
+                        pending_events.append(self._pending_queries[uid])
+                    else:
+                        missing_ids.append(uid)
+                        self._pending_queries[uid] = asyncio.Event()
 
-                if len(self._cache) > self.max_cache_size:
-                    now_insert = time.monotonic()
-                    self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+            if not pending_events and not missing_ids:
+                break
 
-                    while len(self._cache) > self.max_cache_size:
-                        oldest_key = next(iter(self._cache))
-                        self._cache.pop(oldest_key)
+            tasks = []
+
+            if missing_ids:
+                attempted_ids.update(missing_ids)
+                async def fetch_missing() -> None:
+                    try:
+                        fetched: Dict[str, UserInfo] = {}
+                        try:
+                            fetched = await self.user_manager.get_multiple_users(missing_ids)
+                        except Exception as e:
+                            await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
+
+                        if fetched:
+                            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
+                            async with self._lock:
+                                for uid, info in fetched.items():
+                                    self._cache[uid] = (info, expire_at)
+
+                                if len(self._cache) > self.max_cache_size:
+                                    now_insert = time.monotonic()
+                                    self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+
+                                    while len(self._cache) > self.max_cache_size:
+                                        oldest_key = next(iter(self._cache))
+                                        self._cache.pop(oldest_key)
+                    finally:
+                        # asyncio event loop makes dict operations safe from thread pre-emption.
+                        # Do not use async with self._lock here to prevent deadlocks when task is cancelled.
+                        for uid in missing_ids:
+                            event = self._pending_queries.pop(uid, None)
+                            if event:
+                                event.set()
+
+                tasks.append(asyncio.create_task(fetch_missing()))
+
+            if pending_events:
+                # gather returns a Future, which we can wrap in a task or just await directly.
+                # Since we want to await fetch_missing AND pending_events concurrently,
+                # we can define a small async function or just create tasks for the awaits.
+                async def wait_for_events() -> None:
+                    await asyncio.gather(*(e.wait() for e in pending_events))
+                tasks.append(asyncio.create_task(wait_for_events()))
+
+            if tasks:
+                await asyncio.gather(*tasks)
+
+            # Loop again to read newly fetched or pending items into `result`
+            continue
 
         return ProceduralMemory(user_info=result)
 
@@ -96,4 +140,8 @@ class ProceduralMemoryProvider:
             user_id: The user_id string to remove from cache.
         """
         async with self._lock:
-            self._cache.pop(str(user_id), None)
+            uid = str(user_id)
+            self._cache.pop(uid, None)
+            event = self._pending_queries.pop(uid, None)
+            if event:
+                event.set()


### PR DESCRIPTION
**What was found**: `ProceduralMemoryProvider` lacked `asyncio.Event`-based cache stampede protection. Concurrent requests for missing user profiles triggered multiple simultaneous database queries for the same batch of users, causing a dogpile effect.
**Where**: `llm/memory/procedural.py` (`ProceduralMemoryProvider.__init__` and `get` methods).
**Why it matters**: Under heavy load, concurrent cache misses cause an N+1 scaling issue where the DB is hammered with identical queries. This significantly increases latency and database load.
**What was done**: 
- Added a `self._pending_queries` dictionary using `asyncio.Event`.
- Refactored `get()` to use a `while True` loop to properly wait on concurrent requests.
- Tracked `attempted_ids` in a local set to prevent infinite looping when users genuinely don't exist in the database (avoiding negative caching empty objects which would cause data loss on transient DB errors).
- Safely cleaned up events synchronously in the `finally` block to prevent deadlocks on task cancellation.

---
*PR created automatically by Jules for task [16781167716150722606](https://jules.google.com/task/16781167716150722606) started by @starpig1129*