### PR TITLE
[Security] Prevent RCE in math calculation by clearing builtins

### DIFF
--- a/cogs/math.py
+++ b/cogs/math.py
@@ -180,7 +180,7 @@ class MathCalculatorCog(commands.Cog):
                 transformations=transformations,
                 evaluate=True,
                 local_dict=local_dict,
-                global_dict={},  # Disable global_dict for safety
+                global_dict={'__builtins__': {}},  # Disable global_dict for safety
             )
 
             # Check for undefined functions


### PR DESCRIPTION
Fixes a critical RCE vulnerability in the math evaluation tool where users could execute arbitrary Python code by leveraging the `__builtins__` module automatically injected into `eval()` contexts.

---
*PR created automatically by Jules for task [14393787900313859097](https://jules.google.com/task/14393787900313859097) started by @starpig1129*