### PR TITLE
[Security] Fix RCE vulnerability in sympy expression parsing

### DIFF
--- a/cogs/math.py
+++ b/cogs/math.py
@@ -180,7 +180,7 @@ class MathCalculatorCog(commands.Cog):
                 transformations=transformations,
                 evaluate=True,
                 local_dict=local_dict,
-                global_dict={},  # Disable global_dict for safety
+                global_dict={'__builtins__': {}},  # Disable global_dict for safety
             )
 
             # Check for undefined functions


### PR DESCRIPTION
What: The `parse_expr` function from `sympy` was being called with `global_dict={}`, which failed to override Python's automatic injection of `__builtins__`. This allowed users to execute arbitrary Python code via malicious math expressions.
Where: `cogs/math.py` around line 180.
Why: This is a critical Remote Code Execution (RCE) vulnerability that allows a malicious user to easily take control of the bot process, access its environment (including API keys), or execute shell commands.
What was done: Changed `global_dict={}` to `global_dict={'__builtins__': {}}` in the `parse_expr` call to completely sandbox the evaluation environment and eliminate the RCE vector.

---
*PR created automatically by Jules for task [6486451843129196490](https://jules.google.com/task/6486451843129196490) started by @starpig1129*