### PR TITLE
[UX] Fix hanging 'Thinking...' state on slash command errors

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -512,7 +512,10 @@ class PigPig(commands.Bot):
                 if not interaction.response.is_done():
                     await interaction.response.send_message(error_msg, ephemeral=True)
                 else:
-                    await interaction.followup.send(error_msg, ephemeral=True)
+                    try:
+                        await interaction.edit_original_response(content=error_msg)
+                    except discord.NotFound:
+                        await interaction.followup.send(error_msg, ephemeral=True)
             except Exception as send_e:
                 logger.error(f"Failed to send slash command error message: {send_e}")
 


### PR DESCRIPTION
1. **What was found**: When a user executes a slash command that defers its response (`await interaction.response.defer(thinking=True)`) but encounters an unexpected error, the bot's global error handler sends the error message using `await interaction.followup.send()`. This leaves the original "Bot is thinking..." message hanging in the channel indefinitely.
2. **Where it is**: `bot.py` around line 515 (in the `on_tree_error` function).
3. **Why it matters**: This causes significant UX friction and confusion. Users see two states—a pending "Thinking..." message that never resolves, and a separate error message—which makes the bot appear broken or unresponsive.
4. **What was done**: Modified the error handler to check if the interaction is done. If so, it attempts to use `await interaction.edit_original_response(content=error_msg)` to replace the pending state with the error message. It wraps this in a `try...except discord.NotFound` block to safely fallback to `interaction.followup.send()` if the original message was already deleted or doesn't exist.

---
*PR created automatically by Jules for task [6637683190436122859](https://jules.google.com/task/6637683190436122859) started by @starpig1129*