### PR TITLE
[Perf] Add thundering herd protection to Procedural and Knowledge memory providers

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -33,7 +33,7 @@ class KnowledgeMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: (type, target_id), value: (content, expire_at)
         self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
-        self._lock = asyncio.Lock()
+        self._pending_queries: Dict[Tuple[str, str], asyncio.Event] = {}
 
     async def get(self, guild_id: Optional[str], channel_id: str) -> KnowledgeMemory:
         """Fetch knowledge for the current guild and channel.
@@ -58,36 +58,58 @@ class KnowledgeMemoryProvider:
 
     async def _get_single(self, target_type: str, target_id: str) -> Optional[str]:
         """Internal helper with TTL cache."""
-        now = time.monotonic()
         cache_key = (target_type, target_id)
+        attempted = False
         
-        async with self._lock:
+        while True:
+            now = time.monotonic()
             entry = self._cache.get(cache_key)
             if entry is not None and entry[1] > now:
                 return entry[0]
+
+            if cache_key in self._pending_queries:
+                await self._pending_queries[cache_key].wait()
+                continue
+
+            if attempted:
+                return None
+            break
+
+        event = asyncio.Event()
+        self._pending_queries[cache_key] = event
+        attempted = True
         
-        # Cache miss
         try:
-            content = await self.storage.get_knowledge(target_type, target_id)
-        except Exception as e:
-            await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
-            content = None
+            # Cache miss
+            try:
+                content = await self.storage.get_knowledge(target_type, target_id)
+            except Exception as e:
+                await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
+                content = None
+
+            # Update cache
+            now = time.monotonic()
+            expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
             
-        # Update cache
-        expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
-        async with self._lock:
             self._cache[cache_key] = (content, expire_at)
-            
+
             # Prune cache if needed
             if len(self._cache) > self.max_cache_size:
-                self._cache = {k: v for k, v in self._cache.items() if v[1] > now}
+                now_insert = time.monotonic()
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
                 while len(self._cache) > self.max_cache_size:
                     oldest_key = next(iter(self._cache))
-                    self._cache.pop(oldest_key)
-                    
-        return content
+                    self._cache.pop(oldest_key, None)
+
+            return content
+        finally:
+            self._pending_queries.pop(cache_key, None)
+            event.set()
 
     async def invalidate(self, target_type: str, target_id: str) -> None:
         """Invalidate cache for a specific target."""
-        async with self._lock:
-            self._cache.pop((target_type, target_id), None)
+        cache_key = (target_type, target_id)
+        self._cache.pop(cache_key, None)
+        event = self._pending_queries.pop(cache_key, None)
+        if event:
+            event.set()

--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -32,7 +32,7 @@ class ProceduralMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
         self._cache: Dict[str, Tuple[UserInfo, float]] = {}
-        self._lock = asyncio.Lock()
+        self._pending_queries: Dict[str, asyncio.Event] = {}
 
     async def get(self, user_ids: List[str]) -> ProceduralMemory:
         """Fetch procedural memory with per-user TTL cache.
@@ -49,40 +49,76 @@ class ProceduralMemoryProvider:
         if not user_ids or not self.user_manager:
             return ProceduralMemory(user_info={})
 
-        now = time.monotonic()
+        unique_ids = list(set(user_ids))
         result: Dict[str, UserInfo] = {}
-        missing_ids: List[str] = []
+        attempted_ids = set()
 
-        async with self._lock:
-            for uid in user_ids:
+        while True:
+            missing_ids = []
+            pending_events = []
+            now = time.monotonic()
+
+            for uid in unique_ids:
+                if uid in result:
+                    continue
+
                 entry = self._cache.get(uid)
                 if entry is not None and entry[1] > now:
                     result[uid] = entry[0]
-                else:
+                    continue
+
+                if uid in self._pending_queries:
+                    pending_events.append(self._pending_queries[uid])
+                elif uid not in attempted_ids:
                     missing_ids.append(uid)
 
-        if missing_ids:
-            try:
-                fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
-                    [str(uid) for uid in missing_ids]
-                )
-            except Exception as e:
-                await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
-                fetched = {}
+            if not missing_ids and not pending_events:
+                break
 
-            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
-            async with self._lock:
-                for uid, info in fetched.items():
-                    self._cache[uid] = (info, expire_at)
-                    result[uid] = info
+            for uid in missing_ids:
+                self._pending_queries[uid] = asyncio.Event()
+                attempted_ids.add(uid)
 
-                if len(self._cache) > self.max_cache_size:
-                    now_insert = time.monotonic()
-                    self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+            fetch_task = None
+            if missing_ids:
+                async def _fetch(m_ids: List[str]) -> None:
+                    try:
+                        fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
+                            [str(u) for u in m_ids]
+                        )
+                    except Exception as e:
+                        await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
+                        fetched = {}
 
-                    while len(self._cache) > self.max_cache_size:
-                        oldest_key = next(iter(self._cache))
-                        self._cache.pop(oldest_key)
+                    now_f = time.monotonic()
+                    expire_at = now_f + memory_config.procedural_cache_ttl
+
+                    try:
+                        for u in m_ids:
+                            info = fetched.get(u)
+                            if info is not None:
+                                self._cache[u] = (info, expire_at)
+                                result[u] = info
+
+                        if len(self._cache) > self.max_cache_size:
+                            now_insert = time.monotonic()
+                            self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+                            while len(self._cache) > self.max_cache_size:
+                                oldest_key = next(iter(self._cache))
+                                self._cache.pop(oldest_key, None)
+                    finally:
+                        for u in m_ids:
+                            event = self._pending_queries.pop(u, None)
+                            if event:
+                                event.set()
+
+                fetch_task = asyncio.create_task(_fetch(missing_ids))
+
+            if pending_events:
+                await asyncio.gather(*(e.wait() for e in pending_events))
+
+            if fetch_task:
+                await fetch_task
 
         return ProceduralMemory(user_info=result)
 
@@ -95,5 +131,7 @@ class ProceduralMemoryProvider:
         Args:
             user_id: The user_id string to remove from cache.
         """
-        async with self._lock:
-            self._cache.pop(str(user_id), None)
+        self._cache.pop(str(user_id), None)
+        event = self._pending_queries.pop(str(user_id), None)
+        if event:
+            event.set()

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -11,6 +11,21 @@ async def _noop_report_error(*args, **kwargs):
 # Lightweight stubs for optional external dependencies used by ContextManager
 fake_discord = types.ModuleType("discord")
 fake_discord.Message = object
+class _FakeAllowedMentions:
+    def __init__(self, **kwargs):
+        pass
+fake_discord.AllowedMentions = _FakeAllowedMentions
+fake_discord.Embed = object
+fake_discord.Colour = object
+fake_discord.File = object
+class _FakeDiscordErrors:
+    class NotFound(Exception):
+        pass
+class _FakeDiscordABC:
+    class Messageable:
+        pass
+fake_discord.errors = _FakeDiscordErrors
+fake_discord.abc = _FakeDiscordABC
 sys.modules.setdefault("discord", fake_discord)
 
 fake_langchain_messages = types.ModuleType("langchain_core.messages")


### PR DESCRIPTION
1. What was found:
The ProceduralMemoryProvider and KnowledgeMemoryProvider were lacking robust asyncio.Event-based thundering herd protection and used `asyncio.Lock` to wrap purely synchronous dictionary operations. This resulted in redundant and simultaneous backend DB queries on cache misses under high concurrency.
2. Where it is:
- llm/memory/procedural.py (Lines 34-40 and 52-137)
- llm/memory/knowledge.py (Lines 35-40 and 61-105)
3. Why it matters:
Without proper thundering herd protection, concurrent requests for the same missing cache keys led to multiple redundant database fetches (a "cache stampede"), significantly degrading system performance and increasing DB load. Improper lock usage for sync dict operations provided no real concurrency protection.
4. What was done:
- Removed `_lock` from both providers.
- Added `_pending_queries: Dict[..., asyncio.Event]` to manage concurrent requests.
- Re-implemented the `get` method in `ProceduralMemoryProvider` and `_get_single` in `KnowledgeMemoryProvider` using an `asyncio.Event`-based waiting mechanism with `while True` loops to safely block duplicate requests until the first fetch finishes.
- Updated `invalidate` methods to accurately remove keys and `.set()` events, ensuring safety from deadlocks.

---
*PR created automatically by Jules for task [3942420597474723622](https://jules.google.com/task/3942420597474723622) started by @starpig1129*