### PR TITLE
[Security] Prevent RCE in math command by safely isolating eval

### DIFF
--- a/cogs/math.py
+++ b/cogs/math.py
@@ -180,7 +180,7 @@ class MathCalculatorCog(commands.Cog):
                 transformations=transformations,
                 evaluate=True,
                 local_dict=local_dict,
-                global_dict={},  # Disable global_dict for safety
+                global_dict={'__builtins__': {}},  # Disable builtins for RCE prevention
             )
 
             # Check for undefined functions

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import discord
 # tests/conftest.py
 #
 # This conftest pre-loads the real addons.settings module before any test


### PR DESCRIPTION
1. **What**: Identified a Remote Code Execution (RCE) vulnerability in the math calculation feature.
2. **Where**: In `cogs/math.py`, around line 183 inside `parse_expr`.
3. **Why**: The `sympy` parser uses `eval()` under the hood. While it passed `global_dict={}` to restrict variables, Python automatically populates `__builtins__` if they are not explicitly defined in the dictionary. This allows a malicious Discord user to pass expressions like `__import__('os').system('...')` and execute arbitrary system commands, leading to complete bot and host takeover.
4. **What was done**: Explicitly disabled built-in functions by passing `global_dict={'__builtins__': {}}` into `parse_expr`, neutralizing the sandbox escape vector while preserving normal mathematical parsing logic. Additionally, fixed a test setup issue in `tests/conftest.py` by adding `import discord` to prevent test collection failures.

---
*PR created automatically by Jules for task [5643822518419718752](https://jules.google.com/task/5643822518419718752) started by @starpig1129*