### PR TITLE
[UX] Fix hanging thinking state in help command

### DIFF
--- a/cogs/help.py
+++ b/cogs/help.py
@@ -145,12 +145,16 @@ class HelpCog(commands.Cog):
                     "no_commands",
                     default="目前沒有可用的指令。"
                 )
-                await interaction.followup.send(fallback, ephemeral=True)
+                await interaction.edit_original_response(content=fallback)
                 return
 
             # Discord allows up to 10 embeds per message; send in batches if needed
-            for start in range(0, len(embeds), 10):
-                await interaction.followup.send(embeds=embeds[start:start + 10])
+            for i, start in enumerate(range(0, len(embeds), 10)):
+                batch = embeds[start:start + 10]
+                if i == 0:
+                    await interaction.edit_original_response(embeds=batch)
+                else:
+                    await interaction.followup.send(embeds=batch)
 
         except Exception as e:
             log.exception("Error building help response")
@@ -162,7 +166,7 @@ class HelpCog(commands.Cog):
                 "error_message",
                 default="生成指令列表時發生錯誤，請稍後再試。"
             )
-            await interaction.followup.send(fallback_error, ephemeral=True)
+            await interaction.edit_original_response(content=fallback_error)
 
 async def setup(bot):
     await bot.add_cog(HelpCog(bot))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,4 +14,5 @@
 # real attachment/memory symbols (see that file) so downstream modules remain
 # importable.
 
+import discord          # noqa: F401  — side-effect: caches real discord module safely
 import addons.settings  # noqa: F401  — side-effect: caches real module


### PR DESCRIPTION
When the help command is run, the bot initially defers the interaction with `await interaction.response.defer(thinking=True)`. However, when sending the result embeds or error fallbacks, it exclusively used `await interaction.followup.send()`. In discord.py, `followup.send()` creates a brand new webhook message. This leaves the original "Thinking..." placeholder message hanging forever in the user's view, creating a confusing and ugly UX.

1. **What was found**: `help_command` defers its interaction but never edits the original response to clear the "Thinking..." state.
2. **Where it is**: `cogs/help.py` (lines ~145-165).
3. **Why it matters**: A permanently hanging "Thinking..." state makes the bot look broken or stalled, confusing users about whether their command actually finished. This affects every single user who types `/help` or encounters the fallback errors.
4. **What was done**: Modified the `help_command` in `cogs/help.py`. Since `embeds` might be sent in batches of 10, the *first* batch (or the error fallbacks) now uses `await interaction.edit_original_response(...)` to clear the thinking state. Subsequent batches continue to use `interaction.followup.send(...)`.

*Also includes a minor addition to `tests/conftest.py` to ensure the `discord` module is safely cached before collection to prevent weak local mock test failures.*

---
*PR created automatically by Jules for task [16142715259293721441](https://jules.google.com/task/16142715259293721441) started by @starpig1129*