### PR TITLE
[Perf] Add Event-based thundering herd protection to Memory Providers

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -33,7 +33,8 @@ class KnowledgeMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: (type, target_id), value: (content, expire_at)
         self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
-        self._lock = asyncio.Lock()
+        # prevents cache stampedes
+        self._pending_queries: Dict[Tuple[str, str], asyncio.Event] = {}
 
     async def get(self, guild_id: Optional[str], channel_id: str) -> KnowledgeMemory:
         """Fetch knowledge for the current guild and channel.
@@ -58,36 +59,55 @@ class KnowledgeMemoryProvider:
 
     async def _get_single(self, target_type: str, target_id: str) -> Optional[str]:
         """Internal helper with TTL cache."""
-        now = time.monotonic()
         cache_key = (target_type, target_id)
+        attempted = False
         
-        async with self._lock:
+        while True:
+            now = time.monotonic()
+
             entry = self._cache.get(cache_key)
             if entry is not None and entry[1] > now:
                 return entry[0]
-        
-        # Cache miss
-        try:
-            content = await self.storage.get_knowledge(target_type, target_id)
-        except Exception as e:
-            await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
-            content = None
+
+            if cache_key in self._pending_queries:
+                await self._pending_queries[cache_key].wait()
+                continue
+
+            if attempted:
+                return None
+
+            attempted = True
+            event = asyncio.Event()
+            self._pending_queries[cache_key] = event
             
-        # Update cache
-        expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
-        async with self._lock:
-            self._cache[cache_key] = (content, expire_at)
-            
-            # Prune cache if needed
-            if len(self._cache) > self.max_cache_size:
-                self._cache = {k: v for k, v in self._cache.items() if v[1] > now}
-                while len(self._cache) > self.max_cache_size:
-                    oldest_key = next(iter(self._cache))
-                    self._cache.pop(oldest_key)
+            try:
+                try:
+                    content = await self.storage.get_knowledge(target_type, target_id)
+                except Exception as e:
+                    await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
+                    content = None
                     
-        return content
+                # Update cache
+                expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
+                self._cache[cache_key] = (content, expire_at)
+
+                # Prune cache if needed
+                if len(self._cache) > self.max_cache_size:
+                    now_insert = time.monotonic()
+                    self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+                    while len(self._cache) > self.max_cache_size:
+                        oldest_key = next(iter(self._cache))
+                        self._cache.pop(oldest_key, None)
+
+                return content
+            finally:
+                self._pending_queries.pop(cache_key, None)
+                event.set()
 
     async def invalidate(self, target_type: str, target_id: str) -> None:
         """Invalidate cache for a specific target."""
-        async with self._lock:
-            self._cache.pop((target_type, target_id), None)
+        cache_key = (target_type, target_id)
+        self._cache.pop(cache_key, None)
+        event = self._pending_queries.pop(cache_key, None)
+        if event:
+            event.set()

--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -32,7 +32,8 @@ class ProceduralMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
         self._cache: Dict[str, Tuple[UserInfo, float]] = {}
-        self._lock = asyncio.Lock()
+        # prevents cache stampedes
+        self._pending_queries: Dict[str, asyncio.Event] = {}
 
     async def get(self, user_ids: List[str]) -> ProceduralMemory:
         """Fetch procedural memory with per-user TTL cache.
@@ -49,40 +50,68 @@ class ProceduralMemoryProvider:
         if not user_ids or not self.user_manager:
             return ProceduralMemory(user_info={})
 
-        now = time.monotonic()
+        unique_ids = list(set(str(uid) for uid in user_ids))
         result: Dict[str, UserInfo] = {}
-        missing_ids: List[str] = []
+        attempted_ids = set()
 
-        async with self._lock:
-            for uid in user_ids:
+        while True:
+            now = time.monotonic()
+            missing_ids: List[str] = []
+            pending_events: List[asyncio.Event] = []
+
+            for uid in unique_ids:
+                if uid in result:
+                    continue
+
                 entry = self._cache.get(uid)
                 if entry is not None and entry[1] > now:
                     result[uid] = entry[0]
-                else:
+                elif uid in self._pending_queries:
+                    pending_events.append(self._pending_queries[uid])
+                elif uid not in attempted_ids:
                     missing_ids.append(uid)
+                    self._pending_queries[uid] = asyncio.Event()
 
-        if missing_ids:
-            try:
-                fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
-                    [str(uid) for uid in missing_ids]
-                )
-            except Exception as e:
-                await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
-                fetched = {}
+            if not missing_ids and not pending_events:
+                break
 
-            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
-            async with self._lock:
-                for uid, info in fetched.items():
-                    self._cache[uid] = (info, expire_at)
-                    result[uid] = info
+            attempted_ids.update(missing_ids)
 
-                if len(self._cache) > self.max_cache_size:
-                    now_insert = time.monotonic()
-                    self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+            async def _fetch_and_update() -> None:
+                if not missing_ids:
+                    return
+                try:
+                    try:
+                        fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(missing_ids)
+                    except Exception as e:
+                        await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
+                        fetched = {}
 
-                    while len(self._cache) > self.max_cache_size:
-                        oldest_key = next(iter(self._cache))
-                        self._cache.pop(oldest_key)
+                    expire_at = time.monotonic() + memory_config.procedural_cache_ttl
+
+                    for uid, info in fetched.items():
+                        self._cache[uid] = (info, expire_at)
+                        result[uid] = info
+
+                    if len(self._cache) > self.max_cache_size:
+                        now_insert = time.monotonic()
+                        self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+                        while len(self._cache) > self.max_cache_size:
+                            oldest_key = next(iter(self._cache))
+                            self._cache.pop(oldest_key, None)
+                finally:
+                    for uid in missing_ids:
+                        event = self._pending_queries.pop(uid, None)
+                        if event:
+                            event.set()
+
+            coros = []
+            if pending_events:
+                coros.extend(event.wait() for event in pending_events)
+            if missing_ids:
+                coros.append(_fetch_and_update())
+
+            await asyncio.gather(*coros)
 
         return ProceduralMemory(user_info=result)
 
@@ -95,5 +124,8 @@ class ProceduralMemoryProvider:
         Args:
             user_id: The user_id string to remove from cache.
         """
-        async with self._lock:
-            self._cache.pop(str(user_id), None)
+        user_id_str = str(user_id)
+        self._cache.pop(user_id_str, None)
+        event = self._pending_queries.pop(user_id_str, None)
+        if event:
+            event.set()


### PR DESCRIPTION
1. What was found:
   `llm/memory/procedural.py` (`ProceduralMemoryProvider`) and `llm/memory/knowledge.py` (`KnowledgeMemoryProvider`) were using an `asyncio.Lock()` to guard their caches. While this lock prevents concurrent state modification, it blocks all concurrent readers entirely and causes latency regressions. Upon a cache miss, once the lock is released, waiting readers can cause redundant fetches for the missing key (a dogpiling/cache stampede effect).

2. Where it is:
   - `llm/memory/procedural.py` lines 35, 43-98, 126-131
   - `llm/memory/knowledge.py` lines 36, 42-106

3. Why it matters:
   Under high load, concurrent message arrivals trigger multiple identical database or network cache miss fetches that slow down the bot and strain downstream database providers. The `asyncio.Lock()` also serializes read traffic, artificially capping maximum concurrency for fast read operations.

4. What was done:
   Replaced the `asyncio.Lock()` with an `asyncio.Event`-based `_pending_queries` dictionary lock. This explicitly tracks ongoing fetches by key. Instead of a global read block, readers now check if a key is already being fetched. If yes, they passively `await event.wait()` rather than actively duplicating the database fetch. `try...finally` statements handle cleanup to guarantee wait loops resolve, and concurrent gathers (`asyncio.gather(...)`) speed up resolving pending + missing keys.

---
*PR created automatically by Jules for task [8991912887175639784](https://jules.google.com/task/8991912887175639784) started by @starpig1129*