### PR TITLE
[UX] Clear hanging 'Thinking...' state on slash command errors

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -512,7 +512,10 @@ class PigPig(commands.Bot):
                 if not interaction.response.is_done():
                     await interaction.response.send_message(error_msg, ephemeral=True)
                 else:
-                    await interaction.followup.send(error_msg, ephemeral=True)
+                    try:
+                        await interaction.edit_original_response(content=error_msg, embeds=[], attachments=[])
+                    except discord.NotFound:
+                        await interaction.followup.send(error_msg, ephemeral=True)
             except Exception as send_e:
                 logger.error(f"Failed to send slash command error message: {send_e}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import discord
+
 # tests/conftest.py
 #
 # This conftest pre-loads the real addons.settings module before any test


### PR DESCRIPTION
1. **What was found:** The bot's global error handler for slash commands (`on_tree_error` in `bot.py`) uses `interaction.followup.send()` when an interaction has already been deferred (`interaction.response.is_done()` is True).
2. **Where it is:** `bot.py`, lines 514-515.
3. **Why it matters:** Using `followup.send()` creates a new message but leaves the original "PigPig is thinking..." message hanging permanently in the channel. This creates major confusion for users who assume the bot is still processing their request and may needlessly wait or spam the command again.
4. **What was done:** Modified `on_tree_error` to attempt `await interaction.edit_original_response()` first, replacing the hanging "thinking" state with the error message. It catches `discord.NotFound` and falls back to `interaction.followup.send()` if the original message is missing.

---
*PR created automatically by Jules for task [16467944409525339952](https://jules.google.com/task/16467944409525339952) started by @starpig1129*