### PR TITLE
[Security] Fix RCE vulnerability in MathCalculatorCog using SymPy parse_expr

### DIFF
--- a/cogs/math.py
+++ b/cogs/math.py
@@ -180,7 +180,7 @@ class MathCalculatorCog(commands.Cog):
                 transformations=transformations,
                 evaluate=True,
                 local_dict=local_dict,
-                global_dict={},  # Disable global_dict for safety
+                global_dict={'__builtins__': {}},  # Disable global_dict for safety
             )
 
             # Check for undefined functions


### PR DESCRIPTION
1. **What**: A critical Remote Code Execution (RCE) vulnerability was found in the `MathCalculatorCog`.
2. **Where**: `cogs/math.py`, lines 178-184 (the `sympy_expr = parse_expr(...)` call).
3. **Why**: The `parse_expr` function internally uses Python's `eval()`. Without explicitly overriding `__builtins__`, an attacker can pass a mathematical expression containing built-in functions to execute arbitrary shell commands (e.g., `__import__('os').system('...')`), leading to full bot/system takeover.
4. **What was done**: I modified the `global_dict={}` parameter to `global_dict={'__builtins__': {}}` in the `parse_expr` call. This completely neutralizes access to built-in functions, mitigating the RCE vector while maintaining full legitimate mathematical functionality. The change was implemented directly since it is a single-line, highly targeted security fix.

---
*PR created automatically by Jules for task [14489236580553452670](https://jules.google.com/task/14489236580553452670) started by @starpig1129*