### PR TITLE
[Perf] Implement thundering herd protection in ProceduralMemoryProvider

### DIFF
--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -32,7 +32,8 @@ class ProceduralMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
         self._cache: Dict[str, Tuple[UserInfo, float]] = {}
-        self._lock = asyncio.Lock()
+        # key: user_id (str), value: asyncio.Event
+        self._pending_queries: Dict[str, asyncio.Event] = {}
 
     async def get(self, user_ids: List[str]) -> ProceduralMemory:
         """Fetch procedural memory with per-user TTL cache.
@@ -49,42 +50,71 @@ class ProceduralMemoryProvider:
         if not user_ids or not self.user_manager:
             return ProceduralMemory(user_info={})
 
-        now = time.monotonic()
         result: Dict[str, UserInfo] = {}
-        missing_ids: List[str] = []
+        unique_ids = list(set(str(uid) for uid in user_ids))
+        attempted_ids = set()
 
-        async with self._lock:
-            for uid in user_ids:
+        while True:
+            now = time.monotonic()
+            missing_ids: List[str] = []
+            events_to_wait: List[asyncio.Event] = []
+
+            for uid in unique_ids:
+                if uid in result:
+                    continue
+
                 entry = self._cache.get(uid)
                 if entry is not None and entry[1] > now:
                     result[uid] = entry[0]
-                else:
+                elif uid in self._pending_queries:
+                    events_to_wait.append(self._pending_queries[uid])
+                elif uid not in attempted_ids:
                     missing_ids.append(uid)
+                    self._pending_queries[uid] = asyncio.Event()
 
-        if missing_ids:
+            if not missing_ids and not events_to_wait:
+                break
+
+            tasks = []
+            if missing_ids:
+                attempted_ids.update(missing_ids)
+                tasks.append(self._fetch_and_cache(missing_ids))
+
+            for event in events_to_wait:
+                tasks.append(event.wait())
+
+            if tasks:
+                await asyncio.gather(*tasks)
+
+        return ProceduralMemory(user_info=result)
+
+    async def _fetch_and_cache(self, missing_ids: List[str]) -> None:
+        try:
             try:
-                fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
-                    [str(uid) for uid in missing_ids]
-                )
+                fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(missing_ids)
+            except asyncio.CancelledError:
+                raise
             except Exception as e:
                 await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
                 fetched = {}
 
             expire_at = time.monotonic() + memory_config.procedural_cache_ttl
-            async with self._lock:
-                for uid, info in fetched.items():
-                    self._cache[uid] = (info, expire_at)
-                    result[uid] = info
 
-                if len(self._cache) > self.max_cache_size:
-                    now_insert = time.monotonic()
-                    self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+            for uid, info in fetched.items():
+                self._cache[uid] = (info, expire_at)
 
-                    while len(self._cache) > self.max_cache_size:
-                        oldest_key = next(iter(self._cache))
-                        self._cache.pop(oldest_key)
+            if len(self._cache) > self.max_cache_size:
+                now_insert = time.monotonic()
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
 
-        return ProceduralMemory(user_info=result)
+                while len(self._cache) > self.max_cache_size:
+                    oldest_key = next(iter(self._cache))
+                    self._cache.pop(oldest_key, None)
+        finally:
+            for uid in missing_ids:
+                event = self._pending_queries.pop(uid, None)
+                if event:
+                    event.set()
 
     async def invalidate(self, user_id: str) -> None:
         """Evict a single user from the cache.
@@ -95,5 +125,7 @@ class ProceduralMemoryProvider:
         Args:
             user_id: The user_id string to remove from cache.
         """
-        async with self._lock:
-            self._cache.pop(str(user_id), None)
+        self._cache.pop(str(user_id), None)
+        event = self._pending_queries.pop(str(user_id), None)
+        if event:
+            event.set()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,4 +14,5 @@
 # real attachment/memory symbols (see that file) so downstream modules remain
 # importable.
 
+import discord
 import addons.settings  # noqa: F401  — side-effect: caches real module


### PR DESCRIPTION
**What:** A cache stampede (thundering herd) vulnerability was found in the procedural memory fetcher. Multiple simultaneous requests for a missing user ID would all bypass the cache and trigger redundant parallel database/API queries.

**Where:** `llm/memory/procedural.py` lines 35, 53-93 (in `ProceduralMemoryProvider.get()` and `ProceduralMemoryProvider._fetch_and_cache()`).

**Why:** Because procedural memory is fetched on the hot-path for every incoming message, a burst of messages for an uncached user would result in excessive DB load and high latency spikes for the user and the system. The previous design wrapped synchronous dictionary operations in an `asyncio.Lock()`, which provided zero actual concurrency protection for the underlying I/O.

**What was done:** 
- Implemented request coalescing using an `asyncio.Event`-based `_pending_queries` dictionary.
- Subsequent concurrent requests for the same missing user ID now wait on the first request's event instead of launching duplicate queries.
- Introduced an `attempted_ids` local set to safely break the loop and prevent infinite retries if the database consistently fails to fetch.
- Factored the actual fetching and cache insertion into a `_fetch_and_cache` helper wrapped in a rigorous `try...finally` block. This correctly handles `asyncio.CancelledError` while guaranteeing events are popped and waiting tasks are awoken.
- Removed the ineffective `asyncio.Lock()`.
- Successfully ran `test_procedural_memory.py` to verify caching logic holds.

---
*PR created automatically by Jules for task [1301790805334464764](https://jules.google.com/task/1301790805334464764) started by @starpig1129*