### PR TITLE
[UX] Fix hanging "Thinking..." states by using edit_original_response

### DIFF
--- a/cogs/channel_manager.py
+++ b/cogs/channel_manager.py
@@ -91,7 +91,7 @@ class ChannelManager(commands.Cog):
             error_message = "You do not have permission to perform this action. Restricted to administrators."
         
         if interaction.response.is_done():
-            await interaction.followup.send(error_message, ephemeral=True)
+            await interaction.edit_original_response(content=error_message)
         else:
             await interaction.response.send_message(error_message, ephemeral=True)
         return False
@@ -122,7 +122,7 @@ class ChannelManager(commands.Cog):
         else:
             response = f"Set **Server-wide** response mode to: {mode.name}"
 
-        await interaction.followup.send(response, ephemeral=True)
+        await interaction.edit_original_response(content=response)
 
     @app_commands.command(name="set_channel_mode", description="Set a special mode for a specific channel (e.g., Story Mode)")
     @app_commands.describe(channel="The channel to set", mode="The mode to set for this channel")
@@ -168,7 +168,7 @@ class ChannelManager(commands.Cog):
                 message = f"Set mode for {channel.mention} to: **{mode.name}**."
 
         self.save_config(guild_id, config)
-        await interaction.followup.send(message, ephemeral=True)
+        await interaction.edit_original_response(content=message)
 
     @app_commands.command(name="add_channel", description="Add channel to whitelist or blacklist")
     @app_commands.choices(list_type=[
@@ -202,7 +202,7 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"Added <#{channel_id}> to {list_type_name}"
             
-            await interaction.followup.send(success_message, ephemeral=True)
+            await interaction.edit_original_response(content=success_message)
         else:
             if self.lang_manager:
                 exists_message = self.lang_manager.translate(
@@ -211,7 +211,7 @@ class ChannelManager(commands.Cog):
             else:
                 exists_message = f"<#{channel_id}> already exists in {list_type_name}"
             
-            await interaction.followup.send(exists_message, ephemeral=True)
+            await interaction.edit_original_response(content=exists_message)
 
     @app_commands.command(name="remove_channel", description="Remove channel from whitelist or blacklist")
     @app_commands.choices(list_type=[
@@ -245,7 +245,7 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"Removed <#{channel_id}> from {list_type_name}"
             
-            await interaction.followup.send(success_message, ephemeral=True)
+            await interaction.edit_original_response(content=success_message)
         else:
             if self.lang_manager:
                 not_found_message = self.lang_manager.translate(
@@ -254,7 +254,7 @@ class ChannelManager(commands.Cog):
             else:
                 not_found_message = f"<#{channel_id}> does not exist in {list_type_name}"
             
-            await interaction.followup.send(not_found_message, ephemeral=True)
+            await interaction.edit_original_response(content=not_found_message)
 
     @app_commands.command(name="auto_response", description="Set channel auto-response")
     async def auto_response_command(self, interaction: discord.Interaction, channel: discord.TextChannel, enabled: bool):
@@ -275,7 +275,7 @@ class ChannelManager(commands.Cog):
         else:
             success_message = f"Set auto-response for <#{channel_id}> to: {enabled}"
         
-        await interaction.followup.send(success_message, ephemeral=True)
+        await interaction.edit_original_response(content=success_message)
 
     def is_allowed_channel(self, channel: discord.TextChannel, guild_id: str) -> Tuple[bool, bool, Optional[str]]:
         """

--- a/cogs/gen_img.py
+++ b/cogs/gen_img.py
@@ -221,7 +221,7 @@ class ImageGenerationCog(commands.Cog, name="ImageGenerationCog"):
 
         # Slash command still uses immediate reply but supports attachments (base64 → discord.File)
         if "error" in result:
-            await interaction.followup.send(result["error"])
+            await interaction.edit_original_response(content=result["error"])
         else:
             files = []
             attachments = result.get("attachments") or []
@@ -236,9 +236,9 @@ class ImageGenerationCog(commands.Cog, name="ImageGenerationCog"):
                     self.logger.error(f"Slash reply conversion failed: {e}")
             content = result.get("content")
             if files:
-                await interaction.followup.send(content=content, files=files)
+                await interaction.edit_original_response(content=content, attachments=files)
             else:
-                await interaction.followup.send(content=content)
+                await interaction.edit_original_response(content=content)
 
     def _image_to_base64(self, image: Image.Image) -> str:
         """Convert a PIL Image to a base64-encoded string"""

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -145,12 +145,16 @@ class HelpCog(commands.Cog):
                     "no_commands",
                     default="目前沒有可用的指令。"
                 )
-                await interaction.followup.send(fallback, ephemeral=True)
+                await interaction.edit_original_response(content=fallback)
                 return
 
             # Discord allows up to 10 embeds per message; send in batches if needed
             for start in range(0, len(embeds), 10):
-                await interaction.followup.send(embeds=embeds[start:start + 10])
+
+                if start == 0:
+                    await interaction.edit_original_response(embeds=embeds[start:start + 10])
+                else:
+                    await interaction.followup.send(embeds=embeds[start:start + 10])
 
         except Exception as e:
             log.exception("Error building help response")
@@ -162,7 +166,7 @@ class HelpCog(commands.Cog):
                 "error_message",
                 default="生成指令列表時發生錯誤，請稍後再試。"
             )
-            await interaction.followup.send(fallback_error, ephemeral=True)
+            await interaction.edit_original_response(content=fallback_error)
 
 async def setup(bot):
     await bot.add_cog(HelpCog(bot))

--- a/cogs/internet_search.py
+++ b/cogs/internet_search.py
@@ -138,15 +138,16 @@ class InternetSearchCog(commands.Cog):
                 chunks = _split_markdown(result, limit=1900)
                 try:
                     if not chunks:
-                        await interaction.followup.send(content=result[:1900])
+                        await interaction.edit_original_response(content=result[:1900])
                     else:
-                        for chunk in chunks:
+                        await interaction.edit_original_response(content=chunks[0])
+                        for chunk in chunks[1:]:
                             await interaction.followup.send(content=chunk)
                 except Exception as send_err:
                     await func.report_error(send_err, f"search_command send followup failed: {send_err}")
                     try:
                         short = (result[:1900] + "...") if len(result) > 1900 else result
-                        await interaction.followup.send(content=short)
+                        await interaction.edit_original_response(content=short)
                     except Exception:
                         pass
             else:
@@ -163,14 +164,14 @@ class InternetSearchCog(commands.Cog):
                         ) if self.lang_manager else f"Search for '{query}' completed."
                         if len(confirmation) > 1900:
                             confirmation = confirmation[:1897] + "..."
-                        await interaction.followup.send(content=confirmation)
+                        await interaction.edit_original_response(content=confirmation)
                 except Exception as notify_err:
                     await func.report_error(notify_err, f"search_command confirmation send failed: {notify_err}")
                     pass
         except Exception as e:
             await func.report_error(e, f"search_command: {e}")
             try:
-                await interaction.followup.send(content=f"Search failed: {e}")
+                await interaction.edit_original_response(content=f"Search failed: {e}")
             except Exception:
                 pass
 

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -120,7 +120,7 @@ class YTMusic(commands.Cog):
                 await func.report_error(e, "music.py/play/channel.connect")
                 title = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "voice_connect_failed")
                 embed = discord.Embed(title=f"❌ | {title}", color=discord.Color.red())
-                await interaction.followup.send(embed=embed, ephemeral=True)
+                await interaction.edit_original_response(embed=embed)
                 return
 
         # 如果沒有提供查詢，刷新UI
@@ -139,10 +139,10 @@ class YTMusic(commands.Cog):
                     self
                 )
                 refresh_message = self.lang_manager.translate(str(guild_id), "commands", "play", "responses", "refreshed_ui")
-                await interaction.followup.send(refresh_message, ephemeral=True)
+                await interaction.edit_original_response(content=refresh_message)
             else:
                 no_song_message = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "nothing_playing")
-                await interaction.followup.send(no_song_message, ephemeral=True)
+                await interaction.edit_original_response(content=no_song_message)
             return
 
         # 如果有提供查詢，將音樂加入播放清單
@@ -175,7 +175,7 @@ class YTMusic(commands.Cog):
         if error:
             title = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "playlist_download_failed", error=error)
             embed = discord.Embed(title=f"❌ | {title}", color=discord.Color.red())
-            await interaction.followup.send(embed=embed, ephemeral=True)
+            await interaction.edit_original_response(embed=embed)
             return
             
         # Add initial songs to queue
@@ -200,7 +200,7 @@ class YTMusic(commands.Cog):
             description=description,
             color=discord.Color.blue()
         )
-        await interaction.followup.send(embed=embed, ephemeral=True)
+        await interaction.edit_original_response(embed=embed)
 
     async def _handle_single_video(self, interaction: discord.Interaction, url: str) -> bool:
         """Handle single video URL"""
@@ -219,7 +219,7 @@ class YTMusic(commands.Cog):
         if error:
             title = self.lang_manager.translate(guild_id_str, "commands", "play", "errors", "video_info_failed", error=error)
             embed = discord.Embed(title=f"❌ | {title}", color=discord.Color.red())
-            await interaction.followup.send(embed=embed, ephemeral=True)
+            await interaction.edit_original_response(embed=embed)
             return False
             
         video_info['added_by'] = interaction.user.id
@@ -230,7 +230,7 @@ class YTMusic(commands.Cog):
         if success:
             title = self.lang_manager.translate(guild_id_str, "commands", "play", "responses", "song_added", title=video_info['title'])
             embed = discord.Embed(title=f"✅ | {title}", color=discord.Color.blue())
-            await interaction.followup.send(embed=embed, ephemeral=True)
+            await interaction.edit_original_response(embed=embed)
             return True
         else:
             title = self.lang_manager.translate(guild_id_str, "commands", "play", "errors", "queue_full_title")
@@ -240,7 +240,7 @@ class YTMusic(commands.Cog):
                 description=desc,
                 color=discord.Color.red()
             )
-            await interaction.followup.send(embed=embed, ephemeral=True)
+            await interaction.edit_original_response(embed=embed)
             return False
 
     async def _handle_search(self, interaction: discord.Interaction, query: str):
@@ -250,7 +250,7 @@ class YTMusic(commands.Cog):
         if not results:
             title = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "no_results")
             embed = discord.Embed(title=f"❌ | {title}", color=discord.Color.red())
-            await interaction.followup.send(embed=embed, ephemeral=True)
+            await interaction.edit_original_response(embed=embed)
             return
         
         # Format durations properly
@@ -271,7 +271,7 @@ class YTMusic(commands.Cog):
             color=discord.Color.blue()
         )
         
-        await interaction.followup.send(embed=embed, view=view, ephemeral=True)
+        await interaction.edit_original_response(embed=embed, view=view)
 
     async def play_next(self, interaction: discord.Interaction, force_new: bool = False):
         """Play the next song in queue"""
@@ -665,7 +665,7 @@ class YTMusic(commands.Cog):
         if not interaction.response.is_done():
             await interaction.response.send_message(embed=embed, ephemeral=True)
         else:
-            await interaction.followup.send(embed=embed, ephemeral=True)
+            await interaction.edit_original_response(embed=embed)
 
     async def handle_toggle_mode(self, interaction: discord.Interaction):
         guild_id = interaction.guild.id

--- a/cogs/schedule.py
+++ b/cogs/schedule.py
@@ -51,13 +51,13 @@ class ScheduleManager(commands.Cog):
             success_msg = self.lang_manager.translate(
                 guild_id, "commands", "upload_schedule", "responses", "success"
             ) if self.lang_manager else "行程表已成功上傳！"
-            await interaction.followup.send(success_msg)
+            await interaction.edit_original_response(content=success_msg)
         except Exception as e:
             await func.report_error(e, "uploading schedule")
             error_msg = self.lang_manager.translate(
                 guild_id, "commands", "upload_schedule", "responses", "error", error=str(e)
             ) if self.lang_manager else f"上傳行程表時發生錯誤：{str(e)}"
-            await interaction.followup.send(error_msg)
+            await interaction.edit_original_response(content=error_msg)
 
     async def _core_upload_schedule(self, user_id: int, channel_id: int, yaml_data: bytes):
         try:
@@ -95,13 +95,13 @@ class ScheduleManager(commands.Cog):
         try:
             target_user_id = target_user.id if target_user else interaction.user.id
             result = await self._core_query_schedule(interaction, query_type.value, target_user_id, time, day.value if day else None)
-            await interaction.followup.send(result)
+            await interaction.edit_original_response(content=result)
         except Exception as e:
             await func.report_error(e, "querying schedule")
             error_msg = self.lang_manager.translate(
                 guild_id, "commands", "query_schedule", "responses", "error", error=str(e)
             ) if self.lang_manager else f"查詢行程表時發生錯誤：{str(e)}"
-            await interaction.followup.send(error_msg)
+            await interaction.edit_original_response(content=error_msg)
 
     async def _core_query_schedule(self, interaction_or_ctx, query_type: str, target_user_id:int, time: str = None, day: str = None):
         guild_id = str(interaction_or_ctx.guild_id) if hasattr(interaction_or_ctx, 'guild_id') and interaction_or_ctx.guild_id else str(interaction_or_ctx.guild.id) if hasattr(interaction_or_ctx, 'guild') else "0"
@@ -307,13 +307,13 @@ class ScheduleManager(commands.Cog):
             success_msg = self.lang_manager.translate(
                 guild_id, "commands", "update_schedule", "responses", "success"
             ) if self.lang_manager else "行程表已成功更新或創建！"
-            await interaction.followup.send(success_msg)
+            await interaction.edit_original_response(content=success_msg)
         except Exception as e:
             await func.report_error(e, "updating schedule")
             error_msg = self.lang_manager.translate(
                 guild_id, "commands", "update_schedule", "responses", "error", error=str(e)
             ) if self.lang_manager else f"更新或創建行程表時發生錯誤：{str(e)}"
-            await interaction.followup.send(error_msg)
+            await interaction.edit_original_response(content=error_msg)
 
     async def _core_update_schedule(self, user_id: int, day: str, time: str, description: str):
         filepath = os.path.join(self.schedule_dir, f"{user_id}.yaml")

--- a/cogs/summarizer.py
+++ b/cogs/summarizer.py
@@ -119,7 +119,7 @@ class SummarizerCog(commands.Cog):
 
             if not dialogue_history or human_msg_count == 0:
                 no_msg_text = self.lang_manager.translate(guild_id, "commands", "summarize", "responses", "no_messages") if self.lang_manager else "No messages to summarize."
-                await interaction.followup.send(no_msg_text, ephemeral=True)
+                await interaction.edit_original_response(content=no_msg_text)
                 return
 
             # Localization for AI prompt
@@ -187,7 +187,7 @@ class SummarizerCog(commands.Cog):
                 footer_text = f"Analyzed {human_msg_count} messages. {current_char_count}/{self.MAX_CHAR_COUNT} chars."
                 
             main_embed.set_footer(text=footer_text)
-            await interaction.followup.send(embed=main_embed)
+            await interaction.edit_original_response(embed=main_embed)
             
             if len(summary_chunks) > 1:
                 log.info(f"Summary long, splitting into {len(summary_chunks)} messages.")
@@ -206,7 +206,7 @@ class SummarizerCog(commands.Cog):
         except Exception as e:
             await func.report_error(e, "summarizing channel")
             error_text = self.lang_manager.translate(guild_id, "commands", "summarize", "responses", "error", error=str(e)) if self.lang_manager else f"Error: {e}"
-            await interaction.followup.send(error_text, ephemeral=True)
+            await interaction.edit_original_response(content=error_text)
 
 
 async def setup(bot: commands.Bot):

--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -741,7 +741,7 @@ class UserDataCog(commands.Cog):
             action='save'
         )
         
-        await interaction.followup.send(result, ephemeral=True)
+        await interaction.edit_original_response(content=result)
 
     @memory_group.command(
         name="clear",
@@ -765,7 +765,7 @@ class UserDataCog(commands.Cog):
             action='clear'
         )
 
-        await interaction.followup.send(result, ephemeral=True)
+        await interaction.edit_original_response(content=result)
 
     @memory_group.command(
         name="show",
@@ -789,7 +789,7 @@ class UserDataCog(commands.Cog):
             action='read'
         )
         
-        await interaction.followup.send(result, ephemeral=True)
+        await interaction.edit_original_response(content=result)
 
     @knowledge_group.command(
         name="show",
@@ -813,22 +813,22 @@ class UserDataCog(commands.Cog):
         target_id = str(interaction.guild_id) if target_type == "guild" else str(interaction.channel_id)
 
         if target_type == "guild" and not interaction.guild_id:
-            await interaction.followup.send("Guild knowledge is only available within a server.", ephemeral=True)
+            await interaction.edit_original_response(content="Guild knowledge is only available within a server.")
             return
 
         if not self.knowledge_storage:
-            await interaction.followup.send("Knowledge storage is not initialized.", ephemeral=True)
+            await interaction.edit_original_response(content="Knowledge storage is not initialized.")
             return
 
         try:
             content = await self.knowledge_storage.get_knowledge(target_type, target_id)
             if content:
-                await interaction.followup.send(f"Current {target_type} knowledge:\n\n{content}", ephemeral=True)
+                await interaction.edit_original_response(content=f"Current {target_type} knowledge:\n\n{content}")
             else:
-                await interaction.followup.send(f"There is no {target_type} knowledge currently stored.", ephemeral=True)
+                await interaction.edit_original_response(content=f"There is no {target_type} knowledge currently stored.")
         except Exception as e:
             self.logger.error(f"Failed to read {target_type} knowledge for {target_id}: {e}")
-            await interaction.followup.send(f"Failed to read knowledge: {e}", ephemeral=True)
+            await interaction.edit_original_response(content=f"Failed to read knowledge: {e}")
 
     @knowledge_group.command(
         name="save",
@@ -861,11 +861,11 @@ class UserDataCog(commands.Cog):
         target_id = str(interaction.guild_id) if target_type == "guild" else str(interaction.channel_id)
 
         if target_type == "guild" and not interaction.guild_id:
-            await interaction.followup.send("Guild knowledge is only available within a server.", ephemeral=True)
+            await interaction.edit_original_response(content="Guild knowledge is only available within a server.")
             return
 
         if not self.knowledge_storage:
-            await interaction.followup.send("Knowledge storage is not initialized.", ephemeral=True)
+            await interaction.edit_original_response(content="Knowledge storage is not initialized.")
             return
 
         try:
@@ -876,10 +876,10 @@ class UserDataCog(commands.Cog):
                 category=category,
                 context=interaction
             )
-            await interaction.followup.send(result_msg, ephemeral=True)
+            await interaction.edit_original_response(content=result_msg)
         except Exception as e:
             self.logger.error(f"Failed to save {target_type} knowledge for {target_id}: {e}")
-            await interaction.followup.send(f"Failed to save knowledge: {e}", ephemeral=True)
+            await interaction.edit_original_response(content=f"Failed to save knowledge: {e}")
 
 
     @knowledge_group.command(
@@ -905,11 +905,11 @@ class UserDataCog(commands.Cog):
         target_id = str(interaction.guild_id) if target_type == "guild" else str(interaction.channel_id)
 
         if target_type == "guild" and not interaction.guild_id:
-            await interaction.followup.send("Guild knowledge is only available within a server.", ephemeral=True)
+            await interaction.edit_original_response(content="Guild knowledge is only available within a server.")
             return
 
         if not self.knowledge_storage:
-            await interaction.followup.send("Knowledge storage is not initialized.", ephemeral=True)
+            await interaction.edit_original_response(content="Knowledge storage is not initialized.")
             return
 
         try:
@@ -929,12 +929,12 @@ class UserDataCog(commands.Cog):
                 except Exception as cache_err:
                     self.logger.warning(f"Failed to invalidate knowledge cache for {target_type} {target_id}: {cache_err}")
 
-                await interaction.followup.send(f"Successfully cleared {target_type} knowledge.", ephemeral=True)
+                await interaction.edit_original_response(content=f"Successfully cleared {target_type} knowledge.")
             else:
-                await interaction.followup.send(f"There was no {target_type} knowledge to clear or an error occurred.", ephemeral=True)
+                await interaction.edit_original_response(content=f"There was no {target_type} knowledge to clear or an error occurred.")
         except Exception as e:
             self.logger.error(f"Failed to clear {target_type} knowledge for {target_id}: {e}")
-            await interaction.followup.send(f"Failed to clear knowledge: {e}", ephemeral=True)
+            await interaction.edit_original_response(content=f"Failed to clear knowledge: {e}")
 
     async def manage_user_data(
         self,


### PR DESCRIPTION
### What was found
The Discord bot's UX suffered from a common friction point: whenever a command handler used `await interaction.response.defer(thinking=True)` to indicate background processing, the eventual response was often sent via `await interaction.followup.send(...)`. This created a new message containing the response while leaving the initial ephemeral "Thinking..." state permanently hanging in the user's view, which looks buggy and clutters the UI.

### Where it is
Several files in the `cogs/` directory:
- `cogs/userdata.py` (around lines 741, 765, 789, 813, 861, 905, etc.)
- `cogs/schedule.py` (around lines 51, 95, 307)
- `cogs/gen_img.py` (around lines 221, 236)
- `cogs/help.py` (around lines 145, 166)
- `cogs/internet_search.py` (around lines 138, 164)
- `cogs/music.py` (around lines 120, 139, 175, 200, 219, 230, etc.)
- `cogs/channel_manager.py` (around lines 91, 122, 168, 202, 245, etc.)
- `cogs/summarizer.py` (around lines 119, 187, 206)

### Why it matters
The "Thinking..." state hanging around creates a high-frequency, highly confusing UX problem. Users are often unsure if the bot has fully completed the task or is still doing something in the background. Fixing this makes interactions feel much snappier and gives the bot a highly polished feel.

### What was done
I updated the response handling code in the aforementioned files to use `await interaction.edit_original_response(...)` instead of `followup.send(...)`. This correctly overwrites the initial "Thinking..." message, cleanly ending the loading state as soon as the bot's response is ready. Ephemeral flags and complex parameters like multiple attachments and paginated embeds were properly handled by replacing kwargs (e.g., swapping `files` with `attachments` for `edit_original_response`).

---
*PR created automatically by Jules for task [8479512207295727793](https://jules.google.com/task/8479512207295727793) started by @starpig1129*