### PR TITLE
[UX] Clear 'Thinking...' state on slash command errors

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -512,7 +512,10 @@ class PigPig(commands.Bot):
                 if not interaction.response.is_done():
                     await interaction.response.send_message(error_msg, ephemeral=True)
                 else:
-                    await interaction.followup.send(error_msg, ephemeral=True)
+                    try:
+                        await interaction.edit_original_response(content=error_msg, embeds=[], attachments=[], view=None)
+                    except discord.NotFound:
+                        await interaction.followup.send(error_msg, ephemeral=True)
             except Exception as send_e:
                 logger.error(f"Failed to send slash command error message: {send_e}")
 


### PR DESCRIPTION
**What was found:**
When a deferred slash command encounters an error, the error message is sent via `interaction.followup.send()`, but the original 'Thinking...' state is left hanging indefinitely in the user's Discord UI. 

**Where it is:**
`bot.py`, lines 512-517 in the `on_tree_error` function.

**Why it matters:**
This creates a poor user experience. Users see the bot endlessly "Thinking..." and may assume the command is still running or the bot is frozen, completely missing the separate error message followup.

**What was done:**
Modified the `on_tree_error` global handler. When `interaction.response.is_done()` is true (meaning the command was deferred), it now first attempts `await interaction.edit_original_response(content=error_msg, embeds=[], attachments=[], view=None)`. If this fails with `discord.NotFound` (e.g. if the original response was deleted or hasn't propagated), it falls back to the original `interaction.followup.send(...)` behavior. This cleanly replaces the 'Thinking...' message with the error message.

---
*PR created automatically by Jules for task [3311939937128195627](https://jules.google.com/task/3311939937128195627) started by @starpig1129*