### PR TITLE
[Perf] Process short-term memory attachments concurrently

### DIFF
--- a/llm/memory/short_term.py
+++ b/llm/memory/short_term.py
@@ -1,5 +1,6 @@
 from typing import List, Any
 import re
+import asyncio
 
 import discord
 from langchain_core.messages import BaseMessage, HumanMessage, AIMessage
@@ -41,6 +42,21 @@ class ShortTermMemoryProvider:
                 msg async for msg in message.channel.history(limit=self.limit)
             ]
             history.reverse()
+
+            attachment_map = {}
+            if _att_cfg.enabled:
+                attachments_to_process = []
+                for msg in history:
+                    attachments_to_process.extend(msg.attachments)
+
+                if attachments_to_process:
+                    tasks = [process_attachment(att) for att in attachments_to_process]
+                    results = await asyncio.gather(*tasks, return_exceptions=True)
+                    for att, res in zip(attachments_to_process, results):
+                        if isinstance(res, Exception):
+                            attachment_map[att.id] = [{"type": "text", "text": f"[Attachment processing failed: {getattr(att, 'filename', 'unknown')}]"}]
+                        else:
+                            attachment_map[att.id] = res
 
             result: List[BaseMessage] = []
             for msg in history:
@@ -87,8 +103,9 @@ class ShortTermMemoryProvider:
 
                 if msg.attachments and _att_cfg.enabled:
                     for attachment in msg.attachments:
-                        parts = await process_attachment(attachment)
-                        content_parts.extend(parts)
+                        parts = attachment_map.get(attachment.id, [])
+                        if parts:
+                            content_parts.extend(parts)
 
                 if msg.embeds and _att_cfg.embeds.enabled:
                     for embed in msg.embeds:


### PR DESCRIPTION
1. **What**: The `ShortTermMemoryProvider` was processing attachments sequentially in a loop, waiting for each attachment to download and convert before moving on to the next.
2. **Where**: `llm/memory/short_term.py` lines 88-91.
3. **Why**: Downloading and processing images/PDFs sequentially causes significant I/O blocking. If a user asks a question about multiple images or a history containing multiple images, the bot latency spikes massively because it processes them one by one.
4. **What was done**: Refactored `ShortTermMemoryProvider.get()` to first collect all attachments from the message history into a list, run `asyncio.gather(*tasks, return_exceptions=True)` to process all attachments concurrently in the background, and map the results into an `attachment_map` (using the object ID) that is then synchronously referenced during message construction. Failed attachments are gracefully handled and annotated with an error message to match the existing behavior.

---
*PR created automatically by Jules for task [15260709826860414706](https://jules.google.com/task/15260709826860414706) started by @starpig1129*