### PR TITLE
[Perf] Process short-term memory attachments concurrently

### DIFF
--- a/llm/memory/short_term.py
+++ b/llm/memory/short_term.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import List, Any
 import re
 
@@ -42,8 +43,36 @@ class ShortTermMemoryProvider:
             ]
             history.reverse()
 
+            # Collect all attachment processing tasks upfront to process concurrently
+            attachment_tasks = []
+            attachment_task_indices = []  # Maps task index back to (msg_index, attachment)
+
+            for msg_idx, msg in enumerate(history):
+                if msg.attachments and _att_cfg.enabled:
+                    for attachment in msg.attachments:
+                        attachment_tasks.append(process_attachment(attachment))
+                        attachment_task_indices.append(msg_idx)
+
+            # Execute all attachment tasks concurrently
+            processed_attachments_by_msg = {i: [] for i in range(len(history))}
+            if attachment_tasks:
+                results = await asyncio.gather(*attachment_tasks, return_exceptions=True)
+                for i, result_parts in enumerate(results):
+                    msg_idx = attachment_task_indices[i]
+                    if isinstance(result_parts, Exception):
+                        # On failure, we could log it. process_attachment is meant to handle
+                        # its own exceptions and return a fallback text part, but just in case:
+                        from addons.logging import get_logger
+                        log = get_logger(source=__name__, server_id="system")
+                        log.warning(f"Attachment processing raised exception: {result_parts}")
+                        processed_attachments_by_msg[msg_idx].extend(
+                            [{"type": "text", "text": "[Attachment processing failed]"}]
+                        )
+                    else:
+                        processed_attachments_by_msg[msg_idx].extend(result_parts)
+
             result: List[BaseMessage] = []
-            for msg in history:
+            for msg_idx, msg in enumerate(history):
                 content_parts = []
                 content_suffix = []
 
@@ -85,10 +114,8 @@ class ShortTermMemoryProvider:
                 else:
                     content_parts.append({"type": "text", "text": f"[{content_prefix}] <som> <eom>  [{ ' | '.join(content_suffix)}]"})
 
-                if msg.attachments and _att_cfg.enabled:
-                    for attachment in msg.attachments:
-                        parts = await process_attachment(attachment)
-                        content_parts.extend(parts)
+                # Add concurrently processed attachments
+                content_parts.extend(processed_attachments_by_msg[msg_idx])
 
                 if msg.embeds and _att_cfg.embeds.enabled:
                     for embed in msg.embeds:


### PR DESCRIPTION
**What:**
The processing of message attachments in `ShortTermMemoryProvider` (used by `ContextManager` to build the prompt) was done sequentially using an `await process_attachment(attachment)` call inside a loop over the message history.

**Where:**
`llm/memory/short_term.py` inside the `ShortTermMemoryProvider.get` method.

**Why:**
The bot can fetch up to `limit=10` messages by default. If multiple messages contain attachments, downloading and processing them one by one sequentially delays the LLM prompt construction significantly, resulting in high perceived latency for the user.

**What was done:**
Refactored `ShortTermMemoryProvider.get` to collect all attachment processing tasks across all fetched messages up front and run them concurrently using `asyncio.gather(*attachment_tasks, return_exceptions=True)`. The results are then correctly mapped back to their corresponding messages. Embed processing remains sequential as it is synchronous.

---
*PR created automatically by Jules for task [14743185011810073798](https://jules.google.com/task/14743185011810073798) started by @starpig1129*