### PR TITLE
[Security] Fix RCE vulnerability in MathCalculatorCog by disabling builtins

### DIFF
--- a/cogs/math.py
+++ b/cogs/math.py
@@ -180,7 +180,7 @@ class MathCalculatorCog(commands.Cog):
                 transformations=transformations,
                 evaluate=True,
                 local_dict=local_dict,
-                global_dict={},  # Disable global_dict for safety
+                global_dict={'__builtins__': {}},  # Disable global_dict for safety
             )
 
             # Check for undefined functions

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import discord
 # tests/conftest.py
 #
 # This conftest pre-loads the real addons.settings module before any test


### PR DESCRIPTION
**1. What was found (problem or opportunity):** 
A potential Remote Code Execution (RCE) vulnerability was identified in the `MathCalculatorCog` (`cogs/math.py`) due to improper usage of SymPy's `parse_expr`. When evaluating mathematical expressions, the code attempts to disable the global context by passing `global_dict={}`. However, when an empty dictionary is passed to Python's underlying `eval()`, Python automatically injects the `__builtins__` dictionary. This allows attackers to bypass SymPy filters via reflection payload strings and execute shell commands (e.g., using `__import__('os').system()`).

**2. Where it is:** 
`cogs/math.py`, around lines 181-185, within the `calculate_math` method where `sympy.parsing.sympy_parser.parse_expr` is called.

**3. Why it matters:** 
This is a critical security vulnerability with maximum impact. A malicious user on Discord could exploit this to execute arbitrary shell commands on the host machine running the bot, potentially leading to unauthorized data access, privilege escalation, or full system compromise.

**4. What was done:** 
Modified the `global_dict` parameter in the `parse_expr` call from an empty dictionary `{}` to `{'__builtins__': {}}`. This effectively shadows the default `__builtins__` with an empty dictionary, neutralizing the attack vector and ensuring true sandboxing of the math expression evaluator. Also pre-loaded `discord` module inside `tests/conftest.py` to fix unrelated `AttributeError` failures preventing correct local testing of `test_embed_processor.py`.

---
*PR created automatically by Jules for task [10307627884436052648](https://jules.google.com/task/10307627884436052648) started by @starpig1129*