### PR TITLE
[Perf] Process attachments concurrently in ShortTermMemoryProvider

### DIFF
--- a/llm/memory/short_term.py
+++ b/llm/memory/short_term.py
@@ -1,5 +1,6 @@
 from typing import List, Any
 import re
+import asyncio
 
 import discord
 from langchain_core.messages import BaseMessage, HumanMessage, AIMessage
@@ -86,9 +87,13 @@ class ShortTermMemoryProvider:
                     content_parts.append({"type": "text", "text": f"[{content_prefix}] <som> <eom>  [{ ' | '.join(content_suffix)}]"})
 
                 if msg.attachments and _att_cfg.enabled:
-                    for attachment in msg.attachments:
-                        parts = await process_attachment(attachment)
-                        content_parts.extend(parts)
+                    tasks = [process_attachment(attachment) for attachment in msg.attachments]
+                    results = await asyncio.gather(*tasks, return_exceptions=True)
+                    for result in results:
+                        if isinstance(result, Exception):
+                            content_parts.append({"type": "text", "text": f"[Attachment processing failed: {result}]"})
+                        elif isinstance(result, list):
+                            content_parts.extend(result)
 
                 if msg.embeds and _att_cfg.embeds.enabled:
                     for embed in msg.embeds:


### PR DESCRIPTION
1. **What was found**: `ShortTermMemoryProvider` processes attachments for each message sequentially in a loop.
2. **Where it is**: `llm/memory/short_term.py` around line 86 (`for attachment in msg.attachments: parts = await process_attachment(attachment)`).
3. **Why it matters**: Processing attachments sequentially causes a significant I/O latency bottleneck, especially when a channel has multiple attachments in its recent history, delaying the bot's response time. 
4. **What was done**: Refactored `ShortTermMemoryProvider.get()` to collect all attachment processing tasks for a message and execute them concurrently using `asyncio.gather(*tasks, return_exceptions=True)`, handling successful results and exceptions gracefully without modifying public interfaces.

---
*PR created automatically by Jules for task [14277734209731576513](https://jules.google.com/task/14277734209731576513) started by @starpig1129*