### PR TITLE
[UX] Fix hanging thinking states on command errors

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -512,7 +512,10 @@ class PigPig(commands.Bot):
                 if not interaction.response.is_done():
                     await interaction.response.send_message(error_msg, ephemeral=True)
                 else:
-                    await interaction.followup.send(error_msg, ephemeral=True)
+                    try:
+                        await interaction.edit_original_response(content=error_msg, embeds=[], attachments=[])
+                    except discord.NotFound:
+                        await interaction.followup.send(error_msg, ephemeral=True)
             except Exception as send_e:
                 logger.error(f"Failed to send slash command error message: {send_e}")
 


### PR DESCRIPTION
1. **What was found**: The global slash command error handler in `bot.py` was directly using `interaction.followup.send()` if a command had already been deferred (i.e. `interaction.response.is_done()`). This resulted in the original "Bot is thinking..." message hanging forever.
2. **Where it is**: `bot.py` lines 512-518 inside the `on_tree_error` method.
3. **Why it matters**: When users encounter an error, a hanging loading state compounds confusion as they don't know if the command has actually failed or is still executing.
4. **What was done**: Modified the error handler to first attempt `interaction.edit_original_response(content=error_msg, embeds=[], attachments=[])` to successfully replace the original "thinking" message with the error message. It gracefully falls back to `interaction.followup.send()` if a `discord.NotFound` error is raised.

---
*PR created automatically by Jules for task [9107234670202744281](https://jules.google.com/task/9107234670202744281) started by @starpig1129*