### PR TITLE
[Security] Fix RCE vulnerability in math expression evaluation

### DIFF
--- a/cogs/math.py
+++ b/cogs/math.py
@@ -180,7 +180,7 @@ class MathCalculatorCog(commands.Cog):
                 transformations=transformations,
                 evaluate=True,
                 local_dict=local_dict,
-                global_dict={},  # Disable global_dict for safety
+                global_dict={'__builtins__': {}},  # Disable global_dict for safety
             )
 
             # Check for undefined functions


### PR DESCRIPTION
1. **What was found**: A Remote Code Execution (RCE) vulnerability exists in the mathematical parser (`parse_expr` from `sympy`) due to Python's automatic injection of the `__builtins__` dictionary when `eval()` is called with an empty `global_dict`.
2. **Where it is**: `cogs/math.py`, specifically at line 183 during the `parse_expr` call.
3. **Why it matters**: This is a critical security risk. It allows a malicious user to craft a math expression that breaks out of the sympy environment and executes arbitrary shell commands on the host machine using built-in functions like `__import__('os').system(...)`.
4. **What was done**: Modified the `parse_expr` invocation to explicitly pass `global_dict={'__builtins__': {}}` instead of `{}`. This safely disables the availability of built-in functions during evaluation, mitigating the RCE vector while maintaining normal mathematical parsing.

---
*PR created automatically by Jules for task [11133603689072908490](https://jules.google.com/task/11133603689072908490) started by @starpig1129*