### PR TITLE
[UX] Fix hanging thinking state on slash command errors

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -512,7 +512,10 @@ class PigPig(commands.Bot):
                 if not interaction.response.is_done():
                     await interaction.response.send_message(error_msg, ephemeral=True)
                 else:
-                    await interaction.followup.send(error_msg, ephemeral=True)
+                    try:
+                        await interaction.edit_original_response(content=error_msg, embeds=[], attachments=[])
+                    except discord.NotFound:
+                        await interaction.followup.send(error_msg, ephemeral=True)
             except Exception as send_e:
                 logger.error(f"Failed to send slash command error message: {send_e}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,4 +14,5 @@
 # real attachment/memory symbols (see that file) so downstream modules remain
 # importable.
 
+import discord # noqa: F401 - side-effect: caches real discord module
 import addons.settings  # noqa: F401  — side-effect: caches real module


### PR DESCRIPTION
**What was found:** When an error occurs during a deferred slash command (one that is currently showing "PigPig is thinking..."), the error message is sent via `interaction.followup.send()`. This sends a new message but leaves the original "Thinking..." message hanging forever in the channel.
**Where it is:** `bot.py` lines ~514-518 (inside `on_tree_error`).
**Why it matters:** It causes severe confusion for users, who see the bot permanently stuck in a "thinking" state even after the command has errored out, degrading the perceived reliability and UX of the bot.
**What was done:** Modified `bot.py` so that if `interaction.response.is_done()` is true, it first tries `await interaction.edit_original_response(...)` (which properly clears the thinking state and replaces it with the error message). If that raises `discord.NotFound` (e.g., the original message expired), it falls back to the previous `followup.send` behavior. Also updated `tests/conftest.py` to ensure the real `discord` module is cached before test-specific mocks, fixing a pre-existing test collection issue.

---
*PR created automatically by Jules for task [9734774266130009876](https://jules.google.com/task/9734774266130009876) started by @starpig1129*