### PR TITLE
[Perf] Add thundering herd protection to memory providers

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -33,7 +33,7 @@ class KnowledgeMemoryProvider:
         self.max_cache_size = max_cache_size
         # key: (type, target_id), value: (content, expire_at)
         self._cache: Dict[Tuple[str, str], Tuple[Optional[str], float]] = {}
-        self._lock = asyncio.Lock()
+        self._pending_queries: Dict[Tuple[str, str], asyncio.Event] = {}
 
     async def get(self, guild_id: Optional[str], channel_id: str) -> KnowledgeMemory:
         """Fetch knowledge for the current guild and channel.
@@ -45,49 +45,71 @@ class KnowledgeMemoryProvider:
         Returns:
             KnowledgeMemory object containing both levels of knowledge.
         """
-        guild_knowledge = None
+        # Fetch both levels concurrently to optimize orchestration latency
+        tasks = []
         if guild_id:
-            guild_knowledge = await self._get_single("guild", guild_id)
+            tasks.append(self._get_single("guild", guild_id))
+        else:
+            tasks.append(asyncio.sleep(0, result=None))
             
-        channel_knowledge = await self._get_single("channel", channel_id)
+        tasks.append(self._get_single("channel", channel_id))
+
+        results = await asyncio.gather(*tasks)
         
         return KnowledgeMemory(
-            guild_knowledge=guild_knowledge,
-            channel_knowledge=channel_knowledge
+            guild_knowledge=results[0],
+            channel_knowledge=results[1]
         )
 
     async def _get_single(self, target_type: str, target_id: str) -> Optional[str]:
-        """Internal helper with TTL cache."""
-        now = time.monotonic()
+        """Internal helper with TTL cache and thundering herd protection."""
         cache_key = (target_type, target_id)
         
-        async with self._lock:
+        while True:
+            now = time.monotonic()
+
+            if cache_key in self._pending_queries:
+                await self._pending_queries[cache_key].wait()
+                continue
+
             entry = self._cache.get(cache_key)
             if entry is not None and entry[1] > now:
                 return entry[0]
-        
-        # Cache miss
-        try:
-            content = await self.storage.get_knowledge(target_type, target_id)
-        except Exception as e:
-            await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
-            content = None
+
+            # Cache miss, register event and fetch
+            self._pending_queries[cache_key] = asyncio.Event()
+            break
             
-        # Update cache
-        expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
-        async with self._lock:
+        try:
+            try:
+                content = await self.storage.get_knowledge(target_type, target_id)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                await func.report_error(e, f"KnowledgeMemoryProvider fetch failed ({target_type}:{target_id})")
+                content = None
+
+            now = time.monotonic()
+            expire_at = now + getattr(memory_config, "knowledge_cache_ttl", 300) # Default 5 mins
             self._cache[cache_key] = (content, expire_at)
             
-            # Prune cache if needed
             if len(self._cache) > self.max_cache_size:
-                self._cache = {k: v for k, v in self._cache.items() if v[1] > now}
+                now_insert = time.monotonic()
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
                 while len(self._cache) > self.max_cache_size:
                     oldest_key = next(iter(self._cache))
-                    self._cache.pop(oldest_key)
+                    self._cache.pop(oldest_key, None)
                     
-        return content
+            return content
+        finally:
+            event = self._pending_queries.pop(cache_key, None)
+            if event:
+                event.set()
 
     async def invalidate(self, target_type: str, target_id: str) -> None:
         """Invalidate cache for a specific target."""
-        async with self._lock:
-            self._cache.pop((target_type, target_id), None)
+        cache_key = (target_type, target_id)
+        self._cache.pop(cache_key, None)
+        event = self._pending_queries.pop(cache_key, None)
+        if event:
+            event.set()

--- a/llm/memory/procedural.py
+++ b/llm/memory/procedural.py
@@ -30,12 +30,12 @@ class ProceduralMemoryProvider:
             raise ValueError("max_cache_size must be >= 0")
         self.user_manager = user_manager
         self.max_cache_size = max_cache_size
-        # key: user_id (str), value: (UserInfo, expire_at: float monotonic)
-        self._cache: Dict[str, Tuple[UserInfo, float]] = {}
-        self._lock = asyncio.Lock()
+        # key: user_id (str), value: (Optional[UserInfo], expire_at: float monotonic)
+        self._cache: Dict[str, Tuple[Optional[UserInfo], float]] = {}
+        self._pending_queries: Dict[str, asyncio.Event] = {}
 
     async def get(self, user_ids: List[str]) -> ProceduralMemory:
-        """Fetch procedural memory with per-user TTL cache.
+        """Fetch procedural memory with per-user TTL cache and thundering herd protection.
 
         Cache hit: return cached UserInfo without DB call.
         Cache miss: fetch from DB and store in cache.
@@ -49,42 +49,87 @@ class ProceduralMemoryProvider:
         if not user_ids or not self.user_manager:
             return ProceduralMemory(user_info={})
 
-        now = time.monotonic()
+        unique_ids = list(set(str(uid) for uid in user_ids))
         result: Dict[str, UserInfo] = {}
-        missing_ids: List[str] = []
 
-        async with self._lock:
-            for uid in user_ids:
+        while True:
+            now = time.monotonic()
+            missing_ids: List[str] = []
+            pending_events: List[asyncio.Event] = []
+
+            for uid in unique_ids:
+                if uid in result:
+                    continue
+
+                if uid in self._pending_queries:
+                    pending_events.append(self._pending_queries[uid])
+                    continue
+
                 entry = self._cache.get(uid)
                 if entry is not None and entry[1] > now:
-                    result[uid] = entry[0]
+                    if entry[0] is not None:
+                        result[uid] = entry[0]
                 else:
                     missing_ids.append(uid)
+                    self._pending_queries[uid] = asyncio.Event()
 
-        if missing_ids:
+            if not missing_ids and not pending_events:
+                break
+
+            tasks = []
+            if missing_ids:
+                tasks.append(self._fetch_missing(missing_ids))
+            if pending_events:
+                tasks.extend([event.wait() for event in pending_events])
+
             try:
-                fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(
-                    [str(uid) for uid in missing_ids]
-                )
+                fetch_results = await asyncio.gather(*tasks)
+                if missing_ids:
+                    fetched = fetch_results[0]
+                    for uid in missing_ids:
+                        info = fetched.get(uid)
+                        if info is not None:
+                            result[uid] = info
+            except asyncio.CancelledError:
+                raise
             except Exception as e:
-                await func.report_error(e, "ProceduralMemoryProvider.get failed while fetching users")
-                fetched = {}
-
-            expire_at = time.monotonic() + memory_config.procedural_cache_ttl
-            async with self._lock:
-                for uid, info in fetched.items():
-                    self._cache[uid] = (info, expire_at)
-                    result[uid] = info
-
-                if len(self._cache) > self.max_cache_size:
-                    now_insert = time.monotonic()
-                    self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
-
-                    while len(self._cache) > self.max_cache_size:
-                        oldest_key = next(iter(self._cache))
-                        self._cache.pop(oldest_key)
+                await func.report_error(e, "ProceduralMemoryProvider.get failed")
+                # On error, we still need to break the loop, but _fetch_missing handles event cleanup
 
         return ProceduralMemory(user_info=result)
+
+    async def _fetch_missing(self, missing_ids: List[str]) -> Dict[str, UserInfo]:
+        """Fetch missing IDs from DB and update cache, handling events."""
+        try:
+            fetched: Dict[str, UserInfo] = await self.user_manager.get_multiple_users(missing_ids)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            await func.report_error(e, "ProceduralMemoryProvider._fetch_missing failed while fetching users")
+            fetched = {}
+
+        now = time.monotonic()
+        expire_at = now + memory_config.procedural_cache_ttl
+
+        try:
+            for uid in missing_ids:
+                info = fetched.get(uid)
+                self._cache[uid] = (info, expire_at)
+
+            if len(self._cache) > self.max_cache_size:
+                now_insert = time.monotonic()
+                self._cache = {k: v for k, v in self._cache.items() if v[1] > now_insert}
+
+                while len(self._cache) > self.max_cache_size:
+                    oldest_key = next(iter(self._cache))
+                    self._cache.pop(oldest_key, None)
+
+            return fetched
+        finally:
+            for uid in missing_ids:
+                event = self._pending_queries.pop(uid, None)
+                if event:
+                    event.set()
 
     async def invalidate(self, user_id: str) -> None:
         """Evict a single user from the cache.
@@ -95,5 +140,8 @@ class ProceduralMemoryProvider:
         Args:
             user_id: The user_id string to remove from cache.
         """
-        async with self._lock:
-            self._cache.pop(str(user_id), None)
+        uid_str = str(user_id)
+        self._cache.pop(uid_str, None)
+        event = self._pending_queries.pop(uid_str, None)
+        if event:
+            event.set()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,4 +14,5 @@
 # real attachment/memory symbols (see that file) so downstream modules remain
 # importable.
 
+import discord
 import addons.settings  # noqa: F401  — side-effect: caches real module


### PR DESCRIPTION
1. **What was found**: `ProceduralMemoryProvider` and `KnowledgeMemoryProvider` used an `asyncio.Lock()` wrapped around synchronous dictionary operations, offering no real concurrency protection and leading to serialized cache-miss fetches (thundering herd problem).
2. **Where it is**: `llm/memory/procedural.py` and `llm/memory/knowledge.py`.
3. **Why it matters**: This causes massive redundant database load and latency spikes during high concurrency scenarios, as multiple concurrent cache misses for the same key would all hit the database.
4. **What was done**: Replaced `asyncio.Lock()` with `asyncio.Event`-based thundering herd protection. Refactored `KnowledgeMemoryProvider.get()` to concurrently fetch guild and channel data using `asyncio.gather`. Explicitly handled `asyncio.CancelledError` and wrapped event pop/set in `finally` blocks to guarantee no deadlocks.

---
*PR created automatically by Jules for task [5019292618362784821](https://jules.google.com/task/5019292618362784821) started by @starpig1129*