### PR TITLE
[UX] Clear hanging 'Thinking...' states on slash command errors

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -512,7 +512,10 @@ class PigPig(commands.Bot):
                 if not interaction.response.is_done():
                     await interaction.response.send_message(error_msg, ephemeral=True)
                 else:
-                    await interaction.followup.send(error_msg, ephemeral=True)
+                    try:
+                        await interaction.edit_original_response(content=error_msg, embeds=[], attachments=[])
+                    except discord.NotFound:
+                        await interaction.followup.send(error_msg, ephemeral=True)
             except Exception as send_e:
                 logger.error(f"Failed to send slash command error message: {send_e}")
 


### PR DESCRIPTION
### What was found
When a deferred slash command encounters an error that is caught by the global error handler (`on_tree_error` in `bot.py`), the bot responds using `await interaction.followup.send()`. This sends the error as a new message but leaves the original "Bot is thinking..." state hanging indefinitely in the Discord UI.

### Where it is
`bot.py`, lines 512-518 inside the `on_tree_error` function.

### Why it matters
This creates significant user confusion. The user receives an error message but also continues to see a loading indicator, making it seem like the bot is simultaneously failed and still working. This degrades the overall interaction experience.

### What was done
I updated the global error handler in `bot.py` to first attempt `await interaction.edit_original_response(content=error_msg, embeds=[], attachments=[])` when `interaction.response.is_done()` is true. This effectively replaces the "Thinking..." state with the error message. I also wrapped this in a `try...except discord.NotFound:` block that falls back to `interaction.followup.send()` just in case the original interaction has expired or the original message was deleted.

---
*PR created automatically by Jules for task [10657766100840265226](https://jules.google.com/task/10657766100840265226) started by @starpig1129*