### PR TITLE
[UX] Fix hanging "Thinking..." states in deferred commands

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -512,7 +512,10 @@ class PigPig(commands.Bot):
                 if not interaction.response.is_done():
                     await interaction.response.send_message(error_msg, ephemeral=True)
                 else:
-                    await interaction.followup.send(error_msg, ephemeral=True)
+                    try:
+                        await interaction.edit_original_response(content=error_msg, embeds=[], attachments=[])
+                    except discord.NotFound:
+                        await interaction.followup.send(error_msg, ephemeral=True)
             except Exception as send_e:
                 logger.error(f"Failed to send slash command error message: {send_e}")
 

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -145,12 +145,15 @@ class HelpCog(commands.Cog):
                     "no_commands",
                     default="目前沒有可用的指令。"
                 )
-                await interaction.followup.send(fallback, ephemeral=True)
+                await interaction.edit_original_response(content=fallback, embeds=[])
                 return
 
             # Discord allows up to 10 embeds per message; send in batches if needed
-            for start in range(0, len(embeds), 10):
-                await interaction.followup.send(embeds=embeds[start:start + 10])
+            for i, start in enumerate(range(0, len(embeds), 10)):
+                if i == 0:
+                    await interaction.edit_original_response(embeds=embeds[start:start + 10])
+                else:
+                    await interaction.followup.send(embeds=embeds[start:start + 10])
 
         except Exception as e:
             log.exception("Error building help response")
@@ -162,7 +165,7 @@ class HelpCog(commands.Cog):
                 "error_message",
                 default="生成指令列表時發生錯誤，請稍後再試。"
             )
-            await interaction.followup.send(fallback_error, ephemeral=True)
+            await interaction.edit_original_response(content=fallback_error, embeds=[])
 
 async def setup(bot):
     await bot.add_cog(HelpCog(bot))

--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -741,7 +741,7 @@ class UserDataCog(commands.Cog):
             action='save'
         )
         
-        await interaction.followup.send(result, ephemeral=True)
+        await interaction.edit_original_response(content=result)
 
     @memory_group.command(
         name="clear",
@@ -765,7 +765,7 @@ class UserDataCog(commands.Cog):
             action='clear'
         )
 
-        await interaction.followup.send(result, ephemeral=True)
+        await interaction.edit_original_response(content=result)
 
     @memory_group.command(
         name="show",
@@ -789,7 +789,7 @@ class UserDataCog(commands.Cog):
             action='read'
         )
         
-        await interaction.followup.send(result, ephemeral=True)
+        await interaction.edit_original_response(content=result)
 
     @knowledge_group.command(
         name="show",
@@ -813,22 +813,22 @@ class UserDataCog(commands.Cog):
         target_id = str(interaction.guild_id) if target_type == "guild" else str(interaction.channel_id)
 
         if target_type == "guild" and not interaction.guild_id:
-            await interaction.followup.send("Guild knowledge is only available within a server.", ephemeral=True)
+            await interaction.edit_original_response(content="Guild knowledge is only available within a server.")
             return
 
         if not self.knowledge_storage:
-            await interaction.followup.send("Knowledge storage is not initialized.", ephemeral=True)
+            await interaction.edit_original_response(content="Knowledge storage is not initialized.")
             return
 
         try:
             content = await self.knowledge_storage.get_knowledge(target_type, target_id)
             if content:
-                await interaction.followup.send(f"Current {target_type} knowledge:\n\n{content}", ephemeral=True)
+                await interaction.edit_original_response(content=f"Current {target_type} knowledge:\n\n{content}")
             else:
-                await interaction.followup.send(f"There is no {target_type} knowledge currently stored.", ephemeral=True)
+                await interaction.edit_original_response(content=f"There is no {target_type} knowledge currently stored.")
         except Exception as e:
             self.logger.error(f"Failed to read {target_type} knowledge for {target_id}: {e}")
-            await interaction.followup.send(f"Failed to read knowledge: {e}", ephemeral=True)
+            await interaction.edit_original_response(content=f"Failed to read knowledge: {e}")
 
     @knowledge_group.command(
         name="save",
@@ -861,11 +861,11 @@ class UserDataCog(commands.Cog):
         target_id = str(interaction.guild_id) if target_type == "guild" else str(interaction.channel_id)
 
         if target_type == "guild" and not interaction.guild_id:
-            await interaction.followup.send("Guild knowledge is only available within a server.", ephemeral=True)
+            await interaction.edit_original_response(content="Guild knowledge is only available within a server.")
             return
 
         if not self.knowledge_storage:
-            await interaction.followup.send("Knowledge storage is not initialized.", ephemeral=True)
+            await interaction.edit_original_response(content="Knowledge storage is not initialized.")
             return
 
         try:
@@ -876,10 +876,10 @@ class UserDataCog(commands.Cog):
                 category=category,
                 context=interaction
             )
-            await interaction.followup.send(result_msg, ephemeral=True)
+            await interaction.edit_original_response(content=result_msg)
         except Exception as e:
             self.logger.error(f"Failed to save {target_type} knowledge for {target_id}: {e}")
-            await interaction.followup.send(f"Failed to save knowledge: {e}", ephemeral=True)
+            await interaction.edit_original_response(content=f"Failed to save knowledge: {e}")
 
 
     @knowledge_group.command(
@@ -905,11 +905,11 @@ class UserDataCog(commands.Cog):
         target_id = str(interaction.guild_id) if target_type == "guild" else str(interaction.channel_id)
 
         if target_type == "guild" and not interaction.guild_id:
-            await interaction.followup.send("Guild knowledge is only available within a server.", ephemeral=True)
+            await interaction.edit_original_response(content="Guild knowledge is only available within a server.")
             return
 
         if not self.knowledge_storage:
-            await interaction.followup.send("Knowledge storage is not initialized.", ephemeral=True)
+            await interaction.edit_original_response(content="Knowledge storage is not initialized.")
             return
 
         try:
@@ -929,12 +929,12 @@ class UserDataCog(commands.Cog):
                 except Exception as cache_err:
                     self.logger.warning(f"Failed to invalidate knowledge cache for {target_type} {target_id}: {cache_err}")
 
-                await interaction.followup.send(f"Successfully cleared {target_type} knowledge.", ephemeral=True)
+                await interaction.edit_original_response(content=f"Successfully cleared {target_type} knowledge.")
             else:
-                await interaction.followup.send(f"There was no {target_type} knowledge to clear or an error occurred.", ephemeral=True)
+                await interaction.edit_original_response(content=f"There was no {target_type} knowledge to clear or an error occurred.")
         except Exception as e:
             self.logger.error(f"Failed to clear {target_type} knowledge for {target_id}: {e}")
-            await interaction.followup.send(f"Failed to clear knowledge: {e}", ephemeral=True)
+            await interaction.edit_original_response(content=f"Failed to clear knowledge: {e}")
 
     async def manage_user_data(
         self,


### PR DESCRIPTION
**What was found**: 
When slash commands are deferred (showing "PigPig is thinking..."), the bot was responding using `interaction.followup.send(...)` instead of `interaction.edit_original_response(...)`. This sent the response as a separate new message and left the original "Thinking..." state permanently lingering in the user's chat until it eventually showed an "Interaction failed" error or stayed frozen.

**Where it is**: 
- `bot.py` (lines ~511-516) in the global slash command error handler `on_tree_error`.
- `cogs/help.py` (lines ~145-165) in the `help_command` loop and error catch block.
- `cogs/userdata.py` (throughout the file, e.g., lines 744, 768, 792, 816, 826, 879, 932) inside the `memory_group` and `knowledge_group` slash commands.

**Why it matters**: 
This is a high-frequency and confusing UX friction point. Users run a command, see the result, but also see a frozen spinning loading state, making them feel like the bot broke or is stuck in an infinite loop, degrading trust and chat cleanliness.

**What was done**: 
Replaced `interaction.followup.send(...)` with `interaction.edit_original_response(...)` (or added appropriate fallback logic catching `discord.NotFound`) across the codebase for commands that are deferred upfront. For batch operations like `/help` with >10 embeds, only the first batch uses `edit_original_response` to consume the thinking state, and subsequent batches continue to correctly use `followup.send`.

---
*PR created automatically by Jules for task [4447255191666737357](https://jules.google.com/task/4447255191666737357) started by @starpig1129*