### PR TITLE
[Perf] Process short-term memory attachments concurrently

### DIFF
--- a/llm/memory/short_term.py
+++ b/llm/memory/short_term.py
@@ -43,6 +43,32 @@ class ShortTermMemoryProvider:
             history.reverse()
 
             result: List[BaseMessage] = []
+
+            # 1. Collect all attachment processing tasks across all messages
+            attachment_tasks = []
+            if _att_cfg.enabled:
+                for msg in history:
+                    if msg.attachments:
+                        for attachment in msg.attachments:
+                            attachment_tasks.append(process_attachment(attachment))
+
+            # 2. Process attachments concurrently
+            attachment_results = []
+            if attachment_tasks:
+                import asyncio
+                # Use return_exceptions=True so one failure doesn't crash the whole batch
+                raw_results = await asyncio.gather(*attachment_tasks, return_exceptions=True)
+                for res in raw_results:
+                    if isinstance(res, Exception):
+                        from addons.logging import get_logger
+                        log = get_logger(source=__name__, server_id="system")
+                        log.warning(f"Attachment processing failed during gather: {res}")
+                        attachment_results.append([{"type": "text", "text": "[Attachment processing failed]"}])
+                    else:
+                        attachment_results.append(res)
+
+            attachment_result_iter = iter(attachment_results)
+
             for msg in history:
                 content_parts = []
                 content_suffix = []
@@ -86,9 +112,12 @@ class ShortTermMemoryProvider:
                     content_parts.append({"type": "text", "text": f"[{content_prefix}] <som> <eom>  [{ ' | '.join(content_suffix)}]"})
 
                 if msg.attachments and _att_cfg.enabled:
-                    for attachment in msg.attachments:
-                        parts = await process_attachment(attachment)
-                        content_parts.extend(parts)
+                    for _ in msg.attachments:
+                        try:
+                            parts = next(attachment_result_iter)
+                            content_parts.extend(parts)
+                        except StopIteration:
+                            pass
 
                 if msg.embeds and _att_cfg.embeds.enabled:
                     for embed in msg.embeds:


### PR DESCRIPTION
**What:** The `ShortTermMemoryProvider.get()` method fetches recent history and converts Discord messages to LangChain messages. It was processing each attachment sequentially `await process_attachment(attachment)` in a nested loop.
**Where:** `llm/memory/short_term.py` lines ~90-100.
**Why:** Sequential downloading and processing of images, PDFs, and videos across multiple historical messages causes a significant I/O latency bottleneck in the LLM pipeline, slowing down the bot's response time.
**What was done:** Refactored the nested loop to collect all attachment processing tasks upfront into a single list. These are then executed concurrently using `await asyncio.gather(*attachment_tasks, return_exceptions=True)`. The resulting content parts are mapped back to their corresponding messages using an iterator, preserving order while safely handling individual attachment processing failures.

---
*PR created automatically by Jules for task [8129509494770242889](https://jules.google.com/task/8129509494770242889) started by @starpig1129*