### PR TITLE
[Perf] Fetch guild and channel knowledge concurrently

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -45,11 +45,15 @@ class KnowledgeMemoryProvider:
         Returns:
             KnowledgeMemory object containing both levels of knowledge.
         """
-        guild_knowledge = None
-        if guild_id:
-            guild_knowledge = await self._get_single("guild", guild_id)
-            
-        channel_knowledge = await self._get_single("channel", channel_id)
+        async def fetch_guild():
+            if guild_id:
+                return await self._get_single("guild", guild_id)
+            return None
+
+        guild_knowledge, channel_knowledge = await asyncio.gather(
+            fetch_guild(),
+            self._get_single("channel", channel_id)
+        )
         
         return KnowledgeMemory(
             guild_knowledge=guild_knowledge,


### PR DESCRIPTION
**What**: The `KnowledgeMemoryProvider.get()` method fetched guild and channel knowledge sequentially on cache misses.
**Where**: `llm/memory/knowledge.py` lines 48-56.
**Why**: This sequential fetching adds unnecessary database latency to the bot's hot path (during `ContextManager.get_context()`), effectively doubling the DB wait time before the LLM can begin processing.
**What was done**: Replaced the sequential `await` calls with `asyncio.gather` to fetch both knowledge scopes concurrently, resolving the latency bottleneck.

---
*PR created automatically by Jules for task [16196100653347833642](https://jules.google.com/task/16196100653347833642) started by @starpig1129*