### PR TITLE
[Perf] Fetch guild and channel knowledge concurrently in KnowledgeMemoryProvider

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -45,11 +45,15 @@ class KnowledgeMemoryProvider:
         Returns:
             KnowledgeMemory object containing both levels of knowledge.
         """
-        guild_knowledge = None
-        if guild_id:
-            guild_knowledge = await self._get_single("guild", guild_id)
-            
-        channel_knowledge = await self._get_single("channel", channel_id)
+        async def fetch_guild() -> Optional[str]:
+            if guild_id:
+                return await self._get_single("guild", guild_id)
+            return None
+
+        guild_knowledge, channel_knowledge = await asyncio.gather(
+            fetch_guild(),
+            self._get_single("channel", channel_id)
+        )
         
         return KnowledgeMemory(
             guild_knowledge=guild_knowledge,


### PR DESCRIPTION
**What was found:** The `get()` method in `KnowledgeMemoryProvider` performed sequential database fetches for `guild_knowledge` and `channel_knowledge` (i.e. awaited `guild_knowledge`, then awaited `channel_knowledge`).
**Where it is:** `llm/memory/knowledge.py` inside the `get()` method.
**Why it matters:** Because these fetches are completely independent of one another, running them sequentially introduced unnecessary latency in the bot's hot path (during context gathering in the Orchestrator), slowing down the time to start LLM generation.
**What was done:** Refactored `KnowledgeMemoryProvider.get()` to use `asyncio.gather` to fetch both `guild_knowledge` and `channel_knowledge` concurrently, thereby optimizing the response time without changing any external interfaces.

---
*PR created automatically by Jules for task [5496487764338863335](https://jules.google.com/task/5496487764338863335) started by @starpig1129*