### PR TITLE
[UX] Fix lingering 'Bot is thinking...' state in deferred commands

### DIFF
--- a/cogs/gen_img.py
+++ b/cogs/gen_img.py
@@ -221,7 +221,7 @@ class ImageGenerationCog(commands.Cog, name="ImageGenerationCog"):
 
         # Slash command still uses immediate reply but supports attachments (base64 → discord.File)
         if "error" in result:
-            await interaction.followup.send(result["error"])
+            await interaction.edit_original_response(content=result["error"])
         else:
             files = []
             attachments = result.get("attachments") or []
@@ -236,9 +236,9 @@ class ImageGenerationCog(commands.Cog, name="ImageGenerationCog"):
                     self.logger.error(f"Slash reply conversion failed: {e}")
             content = result.get("content")
             if files:
-                await interaction.followup.send(content=content, files=files)
+                await interaction.edit_original_response(content=content, attachments=files)
             else:
-                await interaction.followup.send(content=content)
+                await interaction.edit_original_response(content=content)
 
     def _image_to_base64(self, image: Image.Image) -> str:
         """Convert a PIL Image to a base64-encoded string"""

--- a/cogs/gif_tools.py
+++ b/cogs/gif_tools.py
@@ -119,12 +119,12 @@ class GifTools(commands.Cog):
         gifs = await self.search_gif(query)
         if gifs:
             gif_url = random.choice(gifs)
-            await interaction.followup.send(gif_url)
+            await interaction.edit_original_response(content=gif_url)
         else:
             not_found_message = self.lang_manager.translate(
                 guild_id, "commands", "search_gif", "responses", "not_found"
             ) if self.lang_manager else "找不到相關的 GIF。"
-            await interaction.followup.send(not_found_message)
+            await interaction.edit_original_response(content=not_found_message)
 
     async def get_gif_url(self, query: str, guild_id: str = "0") -> str:
         """取得隨機一個符合搜尋條件的 GIF URL。

--- a/cogs/internet_search.py
+++ b/cogs/internet_search.py
@@ -138,15 +138,18 @@ class InternetSearchCog(commands.Cog):
                 chunks = _split_markdown(result, limit=1900)
                 try:
                     if not chunks:
-                        await interaction.followup.send(content=result[:1900])
+                        await interaction.edit_original_response(content=result[:1900])
                     else:
-                        for chunk in chunks:
-                            await interaction.followup.send(content=chunk)
+                        for i, chunk in enumerate(chunks):
+                            if i == 0:
+                                await interaction.edit_original_response(content=chunk)
+                            else:
+                                await interaction.followup.send(content=chunk)
                 except Exception as send_err:
                     await func.report_error(send_err, f"search_command send followup failed: {send_err}")
                     try:
                         short = (result[:1900] + "...") if len(result) > 1900 else result
-                        await interaction.followup.send(content=short)
+                        await interaction.edit_original_response(content=short)
                     except Exception:
                         pass
             else:
@@ -163,14 +166,14 @@ class InternetSearchCog(commands.Cog):
                         ) if self.lang_manager else f"Search for '{query}' completed."
                         if len(confirmation) > 1900:
                             confirmation = confirmation[:1897] + "..."
-                        await interaction.followup.send(content=confirmation)
+                        await interaction.edit_original_response(content=confirmation)
                 except Exception as notify_err:
                     await func.report_error(notify_err, f"search_command confirmation send failed: {notify_err}")
                     pass
         except Exception as e:
             await func.report_error(e, f"search_command: {e}")
             try:
-                await interaction.followup.send(content=f"Search failed: {e}")
+                await interaction.edit_original_response(content=f"Search failed: {e}")
             except Exception:
                 pass
 

--- a/cogs/schedule.py
+++ b/cogs/schedule.py
@@ -51,13 +51,13 @@ class ScheduleManager(commands.Cog):
             success_msg = self.lang_manager.translate(
                 guild_id, "commands", "upload_schedule", "responses", "success"
             ) if self.lang_manager else "行程表已成功上傳！"
-            await interaction.followup.send(success_msg)
+            await interaction.edit_original_response(content=success_msg)
         except Exception as e:
             await func.report_error(e, "uploading schedule")
             error_msg = self.lang_manager.translate(
                 guild_id, "commands", "upload_schedule", "responses", "error", error=str(e)
             ) if self.lang_manager else f"上傳行程表時發生錯誤：{str(e)}"
-            await interaction.followup.send(error_msg)
+            await interaction.edit_original_response(content=error_msg)
 
     async def _core_upload_schedule(self, user_id: int, channel_id: int, yaml_data: bytes):
         try:
@@ -95,13 +95,13 @@ class ScheduleManager(commands.Cog):
         try:
             target_user_id = target_user.id if target_user else interaction.user.id
             result = await self._core_query_schedule(interaction, query_type.value, target_user_id, time, day.value if day else None)
-            await interaction.followup.send(result)
+            await interaction.edit_original_response(content=result)
         except Exception as e:
             await func.report_error(e, "querying schedule")
             error_msg = self.lang_manager.translate(
                 guild_id, "commands", "query_schedule", "responses", "error", error=str(e)
             ) if self.lang_manager else f"查詢行程表時發生錯誤：{str(e)}"
-            await interaction.followup.send(error_msg)
+            await interaction.edit_original_response(content=error_msg)
 
     async def _core_query_schedule(self, interaction_or_ctx, query_type: str, target_user_id:int, time: str = None, day: str = None):
         guild_id = str(interaction_or_ctx.guild_id) if hasattr(interaction_or_ctx, 'guild_id') and interaction_or_ctx.guild_id else str(interaction_or_ctx.guild.id) if hasattr(interaction_or_ctx, 'guild') else "0"
@@ -307,13 +307,13 @@ class ScheduleManager(commands.Cog):
             success_msg = self.lang_manager.translate(
                 guild_id, "commands", "update_schedule", "responses", "success"
             ) if self.lang_manager else "行程表已成功更新或創建！"
-            await interaction.followup.send(success_msg)
+            await interaction.edit_original_response(content=success_msg)
         except Exception as e:
             await func.report_error(e, "updating schedule")
             error_msg = self.lang_manager.translate(
                 guild_id, "commands", "update_schedule", "responses", "error", error=str(e)
             ) if self.lang_manager else f"更新或創建行程表時發生錯誤：{str(e)}"
-            await interaction.followup.send(error_msg)
+            await interaction.edit_original_response(content=error_msg)
 
     async def _core_update_schedule(self, user_id: int, day: str, time: str, description: str):
         filepath = os.path.join(self.schedule_dir, f"{user_id}.yaml")


### PR DESCRIPTION
1. **What was found:** Several Discord slash commands (`/search`, `/upload_schedule`, `/query_schedule`, `/update_schedule`, `/generate_image`, `/search_gif`) defer their response using `await interaction.response.defer(thinking=True)`. However, when sending the result, they used `await interaction.followup.send(...)` instead of editing the original response.
2. **Where it is:** 
   - `cogs/internet_search.py` lines ~138-180
   - `cogs/schedule.py` lines ~45-65, ~90-105, ~300-320
   - `cogs/gen_img.py` lines ~220-245
   - `cogs/gif_tools.py` lines ~120-130
3. **Why it matters:** Using `followup.send` creates a brand new webhook message in the channel and leaves the initial "PigPig is thinking..." message hanging permanently in the Discord client UI, confusing users.
4. **What was done:** Replaced the initial `followup.send` calls with `edit_original_response(content=...)` across these endpoints to clear the deferred state. Handled the `attachments=` argument for `discord.File` objects in the image generation cog. Handled chunked outputs (like long web search text) by editing the original message for the first chunk and sending follow-ups for the remaining chunks.

---
*PR created automatically by Jules for task [13480416724660200098](https://jules.google.com/task/13480416724660200098) started by @starpig1129*