### PR TITLE
[Perf] Parallelize guild and channel knowledge fetch

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -45,11 +45,15 @@ class KnowledgeMemoryProvider:
         Returns:
             KnowledgeMemory object containing both levels of knowledge.
         """
-        guild_knowledge = None
-        if guild_id:
-            guild_knowledge = await self._get_single("guild", guild_id)
-            
-        channel_knowledge = await self._get_single("channel", channel_id)
+        async def fetch_guild():
+            if guild_id:
+                return await self._get_single("guild", guild_id)
+            return None
+
+        guild_knowledge, channel_knowledge = await asyncio.gather(
+            fetch_guild(),
+            self._get_single("channel", channel_id)
+        )
         
         return KnowledgeMemory(
             guild_knowledge=guild_knowledge,


### PR DESCRIPTION
**What was found**: The `KnowledgeMemoryProvider.get` method awaited guild knowledge and channel knowledge sequentially. This means the overall latency was the sum of both fetch times.
**Where it is**: `llm/memory/knowledge.py` around lines 48-52.
**Why it matters**: Fetching these sequentially blocks the critical path in the LLM orchestrator loop during context gathering, adding unneeded latency to the bot's user response time.
**What was done**: Replaced the sequential `await self._get_single(...)` calls with a concurrent `await asyncio.gather(...)` call, cutting the theoretical maximum response delay from this method by up to 50%.

---
*PR created automatically by Jules for task [11989882224586011745](https://jules.google.com/task/11989882224586011745) started by @starpig1129*