### PR TITLE
[Perf] Fetch guild and channel knowledge concurrently in KnowledgeMemoryProvider

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -45,11 +45,15 @@ class KnowledgeMemoryProvider:
         Returns:
             KnowledgeMemory object containing both levels of knowledge.
         """
-        guild_knowledge = None
-        if guild_id:
-            guild_knowledge = await self._get_single("guild", guild_id)
-            
-        channel_knowledge = await self._get_single("channel", channel_id)
+        async def fetch_guild():
+            if guild_id:
+                return await self._get_single("guild", guild_id)
+            return None
+
+        guild_knowledge, channel_knowledge = await asyncio.gather(
+            fetch_guild(),
+            self._get_single("channel", channel_id)
+        )
         
         return KnowledgeMemory(
             guild_knowledge=guild_knowledge,


### PR DESCRIPTION
**What was found:** In `llm/memory/knowledge.py`, the `get()` method fetched `guild_knowledge` and `channel_knowledge` sequentially using two separate `await` calls.

**Where it is:** `llm/memory/knowledge.py` around line 48 in `KnowledgeMemoryProvider.get()`.

**Why it matters:** Because both pieces of knowledge are retrieved independently over potential database/cache boundaries, performing these queries sequentially adds unnecessary serial latency to the LLM context generation phase for every message the bot processes. Using concurrent fetches effectively cuts the I/O latency for this specific bottleneck by half when both pieces of data need to be loaded.

**What was done:** 
- Introduced a nested `async def fetch_guild()` to handle the conditional check for `guild_id`.
- Replaced the two sequential `await self._get_single()` calls with a single `await asyncio.gather(...)` call, fetching `fetch_guild()` and `self._get_single("channel", channel_id)` concurrently.

---
*PR created automatically by Jules for task [15814335096370740021](https://jules.google.com/task/15814335096370740021) started by @starpig1129*