### PR TITLE
[Perf] Fetch guild and channel knowledge concurrently in KnowledgeMemoryProvider

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -45,11 +45,15 @@ class KnowledgeMemoryProvider:
         Returns:
             KnowledgeMemory object containing both levels of knowledge.
         """
-        guild_knowledge = None
-        if guild_id:
-            guild_knowledge = await self._get_single("guild", guild_id)
-            
-        channel_knowledge = await self._get_single("channel", channel_id)
+        async def fetch_guild_knowledge():
+            if guild_id:
+                return await self._get_single("guild", guild_id)
+            return None
+
+        guild_knowledge, channel_knowledge = await asyncio.gather(
+            fetch_guild_knowledge(),
+            self._get_single("channel", channel_id)
+        )
         
         return KnowledgeMemory(
             guild_knowledge=guild_knowledge,


### PR DESCRIPTION
**1. What was found**
In `llm/memory/knowledge.py`, the `KnowledgeMemoryProvider.get()` method fetched `guild_knowledge` and `channel_knowledge` sequentially using separate `await` calls.

**2. Where it is**
File: `llm/memory/knowledge.py`, `KnowledgeMemoryProvider.get()`

**3. Why it matters**
Fetching independent context sequentially accumulates latency. By running these database/cache reads concurrently, we reduce the total time it takes for the Orchestrator to gather context, reducing bot response times for users.

**4. What was done**
Refactored `KnowledgeMemoryProvider.get()` to use `asyncio.gather()`, fetching the guild knowledge (via an inline helper async function) and channel knowledge in parallel.

---
*PR created automatically by Jules for task [10807827990234328177](https://jules.google.com/task/10807827990234328177) started by @starpig1129*