### PR TITLE
[Perf] Fetch guild and channel knowledge concurrently

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -45,12 +45,15 @@ class KnowledgeMemoryProvider:
         Returns:
             KnowledgeMemory object containing both levels of knowledge.
         """
-        guild_knowledge = None
         if guild_id:
-            guild_knowledge = await self._get_single("guild", guild_id)
+            guild_knowledge, channel_knowledge = await asyncio.gather(
+                self._get_single("guild", guild_id),
+                self._get_single("channel", channel_id)
+            )
+        else:
+            guild_knowledge = None
+            channel_knowledge = await self._get_single("channel", channel_id)
             
-        channel_knowledge = await self._get_single("channel", channel_id)
-        
         return KnowledgeMemory(
             guild_knowledge=guild_knowledge,
             channel_knowledge=channel_knowledge


### PR DESCRIPTION
1. **What**: The `KnowledgeMemoryProvider.get()` method fetched guild and channel knowledge sequentially.
2. **Where**: `llm/memory/knowledge.py` lines 40-44.
3. **Why**: This adds unnecessary sequential wait time (latency) to the context injection phase on every message orchestration. Fetching them concurrently effectively cuts this specific retrieval time significantly without increasing database load.
4. **What was done**: Refactored the `get()` method to use `asyncio.gather()` to fetch `guild_knowledge` and `channel_knowledge` concurrently when `guild_id` is provided.

---
*PR created automatically by Jules for task [8166521833182635181](https://jules.google.com/task/8166521833182635181) started by @starpig1129*