### PR TITLE
[Perf] Use asyncio.gather for concurrent knowledge fetching

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -46,10 +46,15 @@ class KnowledgeMemoryProvider:
             KnowledgeMemory object containing both levels of knowledge.
         """
         guild_knowledge = None
+        channel_knowledge = None
+
         if guild_id:
-            guild_knowledge = await self._get_single("guild", guild_id)
-            
-        channel_knowledge = await self._get_single("channel", channel_id)
+            guild_knowledge, channel_knowledge = await asyncio.gather(
+                self._get_single("guild", guild_id),
+                self._get_single("channel", channel_id)
+            )
+        else:
+            channel_knowledge = await self._get_single("channel", channel_id)
         
         return KnowledgeMemory(
             guild_knowledge=guild_knowledge,


### PR DESCRIPTION
1. **What was found**: A performance bottleneck caused by sequential fetches of guild and channel knowledge.
2. **Where it is**: `llm/memory/knowledge.py`, lines 48-52 in the `KnowledgeMemoryProvider.get()` method.
3. **Why it matters**: Since knowledge fetching happens for every orchestrated message, serialized database calls add unnecessary latency, slowing down the bot's response time.
4. **What was done**: Replaced the sequential `await` calls with `asyncio.gather()`, fetching both guild and channel knowledge concurrently.

---
*PR created automatically by Jules for task [15168576936036677829](https://jules.google.com/task/15168576936036677829) started by @starpig1129*