### PR TITLE
[UX] Fix hanging Thinking states in deferred interactions

### DIFF
--- a/cogs/botinfo.py
+++ b/cogs/botinfo.py
@@ -198,7 +198,7 @@ class BotInfo(commands.Cog):
                 icon_url=avatar_url
             )
 
-            await interaction.followup.send(embed=main_embed)
+            await interaction.edit_original_response(embed=main_embed)
         except Exception as e:
             await func.report_error(e, "getting bot info")
 

--- a/cogs/gen_img.py
+++ b/cogs/gen_img.py
@@ -221,7 +221,7 @@ class ImageGenerationCog(commands.Cog, name="ImageGenerationCog"):
 
         # Slash command still uses immediate reply but supports attachments (base64 → discord.File)
         if "error" in result:
-            await interaction.followup.send(result["error"])
+            await interaction.edit_original_response(content=result["error"])
         else:
             files = []
             attachments = result.get("attachments") or []
@@ -236,9 +236,9 @@ class ImageGenerationCog(commands.Cog, name="ImageGenerationCog"):
                     self.logger.error(f"Slash reply conversion failed: {e}")
             content = result.get("content")
             if files:
-                await interaction.followup.send(content=content, files=files)
+                await interaction.edit_original_response(content=content, attachments=files)
             else:
-                await interaction.followup.send(content=content)
+                await interaction.edit_original_response(content=content)
 
     def _image_to_base64(self, image: Image.Image) -> str:
         """Convert a PIL Image to a base64-encoded string"""

--- a/cogs/internet_search.py
+++ b/cogs/internet_search.py
@@ -138,15 +138,16 @@ class InternetSearchCog(commands.Cog):
                 chunks = _split_markdown(result, limit=1900)
                 try:
                     if not chunks:
-                        await interaction.followup.send(content=result[:1900])
+                        await interaction.edit_original_response(content=result[:1900])
                     else:
-                        for chunk in chunks:
+                        await interaction.edit_original_response(content=chunks[0])
+                        for chunk in chunks[1:]:
                             await interaction.followup.send(content=chunk)
                 except Exception as send_err:
                     await func.report_error(send_err, f"search_command send followup failed: {send_err}")
                     try:
                         short = (result[:1900] + "...") if len(result) > 1900 else result
-                        await interaction.followup.send(content=short)
+                        await interaction.edit_original_response(content=short)
                     except Exception:
                         pass
             else:
@@ -163,7 +164,7 @@ class InternetSearchCog(commands.Cog):
                         ) if self.lang_manager else f"Search for '{query}' completed."
                         if len(confirmation) > 1900:
                             confirmation = confirmation[:1897] + "..."
-                        await interaction.followup.send(content=confirmation)
+                        await interaction.edit_original_response(content=confirmation)
                 except Exception as notify_err:
                     await func.report_error(notify_err, f"search_command confirmation send failed: {notify_err}")
                     pass
@@ -178,9 +179,9 @@ class InternetSearchCog(commands.Cog):
                     ) if self.lang_manager else "❌ 搜尋服務暫時不可用，請稍後再試。(Search service is temporarily unavailable, please try again later.)"
                     if blocked_msg.startswith("[Translation not found"):
                         blocked_msg = "❌ 搜尋服務暫時不可用，請稍後再試。(Search service is temporarily unavailable, please try again later.)"
-                    await interaction.followup.send(content=blocked_msg)
+                    await interaction.edit_original_response(content=blocked_msg)
                 else:
-                    await interaction.followup.send(content=f"Search failed: {e}")
+                    await interaction.edit_original_response(content=f"Search failed: {e}")
             except Exception:
                 pass
 

--- a/cogs/schedule.py
+++ b/cogs/schedule.py
@@ -51,13 +51,13 @@ class ScheduleManager(commands.Cog):
             success_msg = self.lang_manager.translate(
                 guild_id, "commands", "upload_schedule", "responses", "success"
             ) if self.lang_manager else "行程表已成功上傳！"
-            await interaction.followup.send(success_msg)
+            await interaction.edit_original_response(content=success_msg)
         except Exception as e:
             await func.report_error(e, "uploading schedule")
             error_msg = self.lang_manager.translate(
                 guild_id, "commands", "upload_schedule", "responses", "error", error=str(e)
             ) if self.lang_manager else f"上傳行程表時發生錯誤：{str(e)}"
-            await interaction.followup.send(error_msg)
+            await interaction.edit_original_response(content=error_msg)
 
     async def _core_upload_schedule(self, user_id: int, channel_id: int, yaml_data: bytes):
         try:
@@ -95,13 +95,13 @@ class ScheduleManager(commands.Cog):
         try:
             target_user_id = target_user.id if target_user else interaction.user.id
             result = await self._core_query_schedule(interaction, query_type.value, target_user_id, time, day.value if day else None)
-            await interaction.followup.send(result)
+            await interaction.edit_original_response(content=result)
         except Exception as e:
             await func.report_error(e, "querying schedule")
             error_msg = self.lang_manager.translate(
                 guild_id, "commands", "query_schedule", "responses", "error", error=str(e)
             ) if self.lang_manager else f"查詢行程表時發生錯誤：{str(e)}"
-            await interaction.followup.send(error_msg)
+            await interaction.edit_original_response(content=error_msg)
 
     async def _core_query_schedule(self, interaction_or_ctx, query_type: str, target_user_id:int, time: str = None, day: str = None):
         guild_id = str(interaction_or_ctx.guild_id) if hasattr(interaction_or_ctx, 'guild_id') and interaction_or_ctx.guild_id else str(interaction_or_ctx.guild.id) if hasattr(interaction_or_ctx, 'guild') else "0"
@@ -307,13 +307,13 @@ class ScheduleManager(commands.Cog):
             success_msg = self.lang_manager.translate(
                 guild_id, "commands", "update_schedule", "responses", "success"
             ) if self.lang_manager else "行程表已成功更新或創建！"
-            await interaction.followup.send(success_msg)
+            await interaction.edit_original_response(content=success_msg)
         except Exception as e:
             await func.report_error(e, "updating schedule")
             error_msg = self.lang_manager.translate(
                 guild_id, "commands", "update_schedule", "responses", "error", error=str(e)
             ) if self.lang_manager else f"更新或創建行程表時發生錯誤：{str(e)}"
-            await interaction.followup.send(error_msg)
+            await interaction.edit_original_response(content=error_msg)
 
     async def _core_update_schedule(self, user_id: int, day: str, time: str, description: str):
         filepath = os.path.join(self.schedule_dir, f"{user_id}.yaml")

--- a/cogs/summarizer.py
+++ b/cogs/summarizer.py
@@ -119,7 +119,7 @@ class SummarizerCog(commands.Cog):
 
             if not dialogue_history or human_msg_count == 0:
                 no_msg_text = self.lang_manager.translate(guild_id, "commands", "summarize", "responses", "no_messages") if self.lang_manager else "No messages to summarize."
-                await interaction.followup.send(no_msg_text, ephemeral=True)
+                await interaction.edit_original_response(content=no_msg_text)
                 return
 
             # Localization for AI prompt
@@ -187,7 +187,7 @@ class SummarizerCog(commands.Cog):
                 footer_text = f"Analyzed {human_msg_count} messages. {current_char_count}/{self.MAX_CHAR_COUNT} chars."
                 
             main_embed.set_footer(text=footer_text)
-            await interaction.followup.send(embed=main_embed)
+            await interaction.edit_original_response(embed=main_embed)
             
             if len(summary_chunks) > 1:
                 log.info(f"Summary long, splitting into {len(summary_chunks)} messages.")
@@ -207,11 +207,11 @@ class SummarizerCog(commands.Cog):
             error_text = self.lang_manager.translate(
                 guild_id, "commands", "summarize", "responses", "bot_forbidden"
             ) if self.lang_manager else "❌ 機器人缺少讀取此頻道或讀取訊息歷史紀錄的權限。(The bot is missing permission to read this channel or its message history.)"
-            await interaction.followup.send(error_text, ephemeral=True)
+            await interaction.edit_original_response(content=error_text)
         except Exception as e:
             await func.report_error(e, "summarizing channel")
             error_text = self.lang_manager.translate(guild_id, "commands", "summarize", "responses", "error", error=str(e)) if self.lang_manager else f"Error: {e}"
-            await interaction.followup.send(error_text, ephemeral=True)
+            await interaction.edit_original_response(content=error_text)
 
 
 async def setup(bot: commands.Bot):


### PR DESCRIPTION
1. **What was found**: Across multiple cogs, commands that defer their response with `interaction.response.defer(thinking=True)` were later responding via `interaction.followup.send()`. This sends a *new* message and leaves the original "Bot is thinking..." message hanging permanently in the Discord channel, causing severe UX friction.
2. **Where it is**: `cogs/schedule.py` (lines 54, 60, 98, 104, 310, 316), `cogs/botinfo.py` (line 201), `cogs/gen_img.py` (lines 224, 239, 241), `cogs/internet_search.py` (line 141, 144 fallback logic, 167, 182, 184), and `cogs/summarizer.py` (lines 122, 190, 210, 214).
3. **Why it matters**: Discord users see a hanging "Bot is thinking..." message indefinitely after using the bot, which causes confusion and makes the bot look broken or unresponsive, highly impacting the perceived response latency and general UX.
4. **What was done**: Replaced `interaction.followup.send` with `interaction.edit_original_response` for the first response payload following a deferral across all these cogs. Removed `ephemeral=True` arguments where invalid for `edit_original_response` (as visibility is locked by the `defer` command). Corrected the kwargs mapping for `gen_img.py` (using `attachments` instead of `files`). Tested the changes using Pytest and confirmed no regressions were introduced.

---
*PR created automatically by Jules for task [15352275196898840551](https://jules.google.com/task/15352275196898840551) started by @starpig1129*