### PR TITLE
[Perf] Fetch guild and channel knowledge concurrently in KnowledgeMemoryProvider

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -45,11 +45,15 @@ class KnowledgeMemoryProvider:
         Returns:
             KnowledgeMemory object containing both levels of knowledge.
         """
-        guild_knowledge = None
-        if guild_id:
-            guild_knowledge = await self._get_single("guild", guild_id)
-            
-        channel_knowledge = await self._get_single("channel", channel_id)
+        async def fetch_guild():
+            if guild_id:
+                return await self._get_single("guild", guild_id)
+            return None
+
+        guild_knowledge, channel_knowledge = await asyncio.gather(
+            fetch_guild(),
+            self._get_single("channel", channel_id)
+        )
         
         return KnowledgeMemory(
             guild_knowledge=guild_knowledge,


### PR DESCRIPTION
1. **What was found**: In `KnowledgeMemoryProvider.get()`, `guild_knowledge` and `channel_knowledge` were being fetched sequentially using `await self._get_single(...)` twice in a row.
2. **Where it is**: `llm/memory/knowledge.py` (lines 48-52).
3. **Why it matters**: Sequential network or database I/O operations create unnecessary latency bottlenecks on the hot path (message context generation for the LLM). Fetching them concurrently reduces the total wait time to the duration of the slower of the two requests.
4. **What was done**: Modified the `get` method to use `asyncio.gather()` to fetch both `guild_knowledge` and `channel_knowledge` concurrently. A small local async function `fetch_guild()` was added to handle the conditional check for `guild_id`.

---
*PR created automatically by Jules for task [7216549243248735669](https://jules.google.com/task/7216549243248735669) started by @starpig1129*