### PR TITLE
[Feature] Add view_channel_config command to ChannelManager

### DIFF
--- a/cogs/channel_manager.py
+++ b/cogs/channel_manager.py
@@ -277,6 +277,45 @@ class ChannelManager(commands.Cog):
         
         await interaction.followup.send(success_message, ephemeral=True)
 
+    @app_commands.command(name="view_channel_config", description="View the current channel and server configurations")
+    async def view_channel_config(self, interaction: discord.Interaction):
+        """View the current global and per-channel response settings."""
+        if not await self.check_admin_permissions(interaction, defer=True):
+            return
+
+        guild_id = str(interaction.guild_id)
+        config = self.load_config(guild_id)
+
+        embed = discord.Embed(title="Channel Configuration", color=discord.Color.blue())
+
+        # Server Mode
+        server_mode = config.get("mode", "unrestricted")
+        embed.add_field(name="Server Mode", value=server_mode.capitalize(), inline=False)
+
+        # Whitelist
+        whitelist = config.get("whitelist", [])
+        whitelist_val = " ".join([f"<#{c}>" for c in whitelist]) if whitelist else "None"
+        embed.add_field(name="Whitelist", value=whitelist_val, inline=False)
+
+        # Blacklist
+        blacklist = config.get("blacklist", [])
+        blacklist_val = " ".join([f"<#{c}>" for c in blacklist]) if blacklist else "None"
+        embed.add_field(name="Blacklist", value=blacklist_val, inline=False)
+
+        # Channel Modes
+        channel_modes = config.get("channel_modes", {})
+        modes_list = [f"<#{c}>: {m}" for c, m in channel_modes.items()]
+        modes_val = "\n".join(modes_list) if modes_list else "None"
+        embed.add_field(name="Special Channel Modes", value=modes_val, inline=False)
+
+        # Auto Responses
+        auto_responses = config.get("auto_response", {})
+        auto_list = [f"<#{c}>" for c, enabled in auto_responses.items() if enabled]
+        auto_val = " ".join(auto_list) if auto_list else "None"
+        embed.add_field(name="Auto Response Enabled", value=auto_val, inline=False)
+
+        await interaction.edit_original_response(embed=embed)
+
     def is_allowed_channel(self, channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread], guild_id: str) -> Tuple[bool, bool, Optional[str]]:
         """
         Determine if the bot is allowed to respond in a channel and get its effective mode.


### PR DESCRIPTION
1. **What was found:** The `cogs/channel_manager.py` lacked a command for administrators to view the current channel configuration (whitelists, blacklists, server mode). Admins were flying blind after setting these configurations.
2. **Where it is:** In `cogs/channel_manager.py`, the `ChannelManager` class.
3. **Why it matters:** Without this feature, administrators cannot easily audit or verify the current active configuration for their server's bot usage permissions, leading to confusion and reduced usability.
4. **What was done:** Implemented the `view_channel_config` slash command which strictly enforces admin permissions (`check_admin_permissions`), safely reads the server config via `load_config`, and cleanly presents the global and channel-specific settings using a `discord.Embed` using `interaction.edit_original_response`.

---
*PR created automatically by Jules for task [16130134545247481557](https://jules.google.com/task/16130134545247481557) started by @starpig1129*