### PR TITLE
[Feat] Add /channel_status command to ChannelManager

### DIFF
--- a/cogs/channel_manager.py
+++ b/cogs/channel_manager.py
@@ -256,6 +256,25 @@ class ChannelManager(commands.Cog):
             
             await interaction.followup.send(not_found_message, ephemeral=True)
 
+    @app_commands.command(name="channel_status", description="Check the current response mode and auto-response status for the channel")
+    async def channel_status_command(self, interaction: discord.Interaction):
+        """View the current response mode and auto-response settings for the current channel."""
+        guild_id = str(interaction.guild_id)
+        config = self.load_config(guild_id)
+        channel_id = str(interaction.channel_id)
+
+        is_allowed, auto_response_enabled, effective_mode = self.is_allowed_channel(interaction.channel, guild_id)
+
+        status_message = (
+            f"**Channel Status:** <#{channel_id}>\n"
+            f"**Effective Mode:** {effective_mode.capitalize()}\n"
+            f"**Bot Allowed to Respond:** {'Yes' if is_allowed else 'No'}\n"
+            f"**Auto-Response Enabled:** {'Yes' if auto_response_enabled else 'No'}\n\n"
+            f"**Server-wide Mode:** {config.get('mode', 'unrestricted').capitalize()}"
+        )
+
+        await interaction.response.send_message(status_message, ephemeral=True)
+
     @app_commands.command(name="auto_response", description="Set channel auto-response")
     async def auto_response_command(self, interaction: discord.Interaction, channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread], enabled: bool):
         """Enable or disable automatic bot responses in a specific channel."""


### PR DESCRIPTION
**What was found:**
Users previously had no simple way to check the current response mode, auto-response configuration, or whitelist/blacklist status for the channel they were in.

**Where it is:**
`cogs/channel_manager.py`

**Why it matters:**
Providing a `/channel_status` command drastically improves user experience by granting read-only visibility into how the bot interprets the channel's configuration, helping users quickly understand if the bot is ignoring them due to configuration rules.

**What was done:**
Implemented the `/channel_status` slash command which utilizes existing `self.load_config(guild_id)` and `self.is_allowed_channel(...)` methods to extract and return this information to the user ephemerally without modifying any public interfaces.

---
*PR created automatically by Jules for task [14307346878543002979](https://jules.google.com/task/14307346878543002979) started by @starpig1129*