### PR TITLE
[Perf] Fetch guild and channel knowledge concurrently

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -45,12 +45,15 @@ class KnowledgeMemoryProvider:
         Returns:
             KnowledgeMemory object containing both levels of knowledge.
         """
-        guild_knowledge = None
-        if guild_id:
-            guild_knowledge = await self._get_single("guild", guild_id)
-            
-        channel_knowledge = await self._get_single("channel", channel_id)
+        guild_task = self._get_single("guild", guild_id) if guild_id else None
+        channel_task = self._get_single("channel", channel_id)
         
+        if guild_task:
+            guild_knowledge, channel_knowledge = await asyncio.gather(guild_task, channel_task)
+        else:
+            guild_knowledge = None
+            channel_knowledge = await channel_task
+
         return KnowledgeMemory(
             guild_knowledge=guild_knowledge,
             channel_knowledge=channel_knowledge


### PR DESCRIPTION
1. **What was found**: `KnowledgeMemoryProvider.get` in `llm/memory/knowledge.py` was awaiting `guild_knowledge` and `channel_knowledge` fetches sequentially.
2. **Where it is**: `llm/memory/knowledge.py` at line ~48.
3. **Why it matters**: These two fetches are independent I/O-bound operations fetching cache or querying the database. Executing them sequentially doubles the latency for this part of the context gathering. Since `KnowledgeMemoryProvider.get` is called on the critical path of the orchestrator responding to users, this adds unnecessary latency.
4. **What was done**: Modified the function to execute `guild_task` and `channel_task` concurrently using `asyncio.gather` if `guild_id` is present, otherwise just awaits the channel task. This directly cuts the fetch time for this step roughly in half.

---
*PR created automatically by Jules for task [13154958104589765802](https://jules.google.com/task/13154958104589765802) started by @starpig1129*