### PR TITLE
[UX] Fix hanging Thinking states by using edit_original_response

### DIFF
--- a/cogs/botinfo.py
+++ b/cogs/botinfo.py
@@ -198,7 +198,7 @@ class BotInfo(commands.Cog):
                 icon_url=avatar_url
             )
 
-            await interaction.followup.send(embed=main_embed)
+            await interaction.edit_original_response(embed=main_embed)
         except Exception as e:
             await func.report_error(e, "getting bot info")
 

--- a/cogs/channel_manager.py
+++ b/cogs/channel_manager.py
@@ -91,7 +91,7 @@ class ChannelManager(commands.Cog):
             error_message = "You do not have permission to perform this action. Restricted to administrators."
         
         if interaction.response.is_done():
-            await interaction.followup.send(error_message, ephemeral=True)
+            await interaction.edit_original_response(content=error_message)
         else:
             await interaction.response.send_message(error_message, ephemeral=True)
         return False
@@ -122,7 +122,7 @@ class ChannelManager(commands.Cog):
         else:
             response = f"Set **Server-wide** response mode to: {mode.name}"
 
-        await interaction.followup.send(response, ephemeral=True)
+        await interaction.edit_original_response(content=response)
 
     @app_commands.command(name="set_channel_mode", description="Set a special mode for a specific channel (e.g., Story Mode)")
     @app_commands.describe(channel="The channel to set", mode="The mode to set for this channel")
@@ -168,7 +168,7 @@ class ChannelManager(commands.Cog):
                 message = f"Set mode for {channel.mention} to: **{mode.name}**."
 
         self.save_config(guild_id, config)
-        await interaction.followup.send(message, ephemeral=True)
+        await interaction.edit_original_response(content=message)
 
     @app_commands.command(name="add_channel", description="Add channel to whitelist or blacklist")
     @app_commands.choices(list_type=[
@@ -202,7 +202,7 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"Added <#{channel_id}> to {list_type_name}"
             
-            await interaction.followup.send(success_message, ephemeral=True)
+            await interaction.edit_original_response(content=success_message)
         else:
             if self.lang_manager:
                 exists_message = self.lang_manager.translate(
@@ -211,7 +211,7 @@ class ChannelManager(commands.Cog):
             else:
                 exists_message = f"<#{channel_id}> already exists in {list_type_name}"
             
-            await interaction.followup.send(exists_message, ephemeral=True)
+            await interaction.edit_original_response(content=exists_message)
 
     @app_commands.command(name="remove_channel", description="Remove channel from whitelist or blacklist")
     @app_commands.choices(list_type=[
@@ -245,7 +245,7 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"Removed <#{channel_id}> from {list_type_name}"
             
-            await interaction.followup.send(success_message, ephemeral=True)
+            await interaction.edit_original_response(content=success_message)
         else:
             if self.lang_manager:
                 not_found_message = self.lang_manager.translate(
@@ -254,7 +254,7 @@ class ChannelManager(commands.Cog):
             else:
                 not_found_message = f"<#{channel_id}> does not exist in {list_type_name}"
             
-            await interaction.followup.send(not_found_message, ephemeral=True)
+            await interaction.edit_original_response(content=not_found_message)
 
     @app_commands.command(name="auto_response", description="Set channel auto-response")
     async def auto_response_command(self, interaction: discord.Interaction, channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread], enabled: bool):
@@ -275,7 +275,7 @@ class ChannelManager(commands.Cog):
         else:
             success_message = f"Set auto-response for <#{channel_id}> to: {enabled}"
         
-        await interaction.followup.send(success_message, ephemeral=True)
+        await interaction.edit_original_response(content=success_message)
 
     def is_allowed_channel(self, channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread], guild_id: str) -> Tuple[bool, bool, Optional[str]]:
         """

--- a/cogs/gen_img.py
+++ b/cogs/gen_img.py
@@ -221,7 +221,7 @@ class ImageGenerationCog(commands.Cog, name="ImageGenerationCog"):
 
         # Slash command still uses immediate reply but supports attachments (base64 → discord.File)
         if "error" in result:
-            await interaction.followup.send(result["error"])
+            await interaction.edit_original_response(content=result["error"])
         else:
             files = []
             attachments = result.get("attachments") or []
@@ -236,9 +236,9 @@ class ImageGenerationCog(commands.Cog, name="ImageGenerationCog"):
                     self.logger.error(f"Slash reply conversion failed: {e}")
             content = result.get("content")
             if files:
-                await interaction.followup.send(content=content, files=files)
+                await interaction.edit_original_response(content=content, attachments=files)
             else:
-                await interaction.followup.send(content=content)
+                await interaction.edit_original_response(content=content)
 
     def _image_to_base64(self, image: Image.Image) -> str:
         """Convert a PIL Image to a base64-encoded string"""

--- a/cogs/gif_tools.py
+++ b/cogs/gif_tools.py
@@ -119,12 +119,12 @@ class GifTools(commands.Cog):
         gifs = await self.search_gif(query)
         if gifs:
             gif_url = random.choice(gifs)
-            await interaction.followup.send(gif_url)
+            await interaction.edit_original_response(content=gif_url)
         else:
             not_found_message = self.lang_manager.translate(
                 guild_id, "commands", "search_gif", "responses", "not_found"
             ) if self.lang_manager else "找不到相關的 GIF。"
-            await interaction.followup.send(not_found_message)
+            await interaction.edit_original_response(content=not_found_message)
 
     async def get_gif_url(self, query: str, guild_id: str = "0") -> str:
         """取得隨機一個符合搜尋條件的 GIF URL。

--- a/cogs/internet_search.py
+++ b/cogs/internet_search.py
@@ -138,15 +138,18 @@ class InternetSearchCog(commands.Cog):
                 chunks = _split_markdown(result, limit=1900)
                 try:
                     if not chunks:
-                        await interaction.followup.send(content=result[:1900])
+                        await interaction.edit_original_response(content=result[:1900])
                     else:
-                        for chunk in chunks:
-                            await interaction.followup.send(content=chunk)
+                        for i, chunk in enumerate(chunks):
+                            if i == 0:
+                                await interaction.edit_original_response(content=chunk)
+                            else:
+                                await interaction.followup.send(content=chunk)
                 except Exception as send_err:
                     await func.report_error(send_err, f"search_command send followup failed: {send_err}")
                     try:
                         short = (result[:1900] + "...") if len(result) > 1900 else result
-                        await interaction.followup.send(content=short)
+                        await interaction.edit_original_response(content=short)
                     except Exception:
                         pass
             else:
@@ -163,7 +166,7 @@ class InternetSearchCog(commands.Cog):
                         ) if self.lang_manager else f"Search for '{query}' completed."
                         if len(confirmation) > 1900:
                             confirmation = confirmation[:1897] + "..."
-                        await interaction.followup.send(content=confirmation)
+                        await interaction.edit_original_response(content=confirmation)
                 except Exception as notify_err:
                     await func.report_error(notify_err, f"search_command confirmation send failed: {notify_err}")
                     pass
@@ -178,9 +181,9 @@ class InternetSearchCog(commands.Cog):
                     ) if self.lang_manager else "❌ 搜尋服務暫時不可用，請稍後再試。(Search service is temporarily unavailable, please try again later.)"
                     if blocked_msg.startswith("[Translation not found"):
                         blocked_msg = "❌ 搜尋服務暫時不可用，請稍後再試。(Search service is temporarily unavailable, please try again later.)"
-                    await interaction.followup.send(content=blocked_msg)
+                    await interaction.edit_original_response(content=blocked_msg)
                 else:
-                    await interaction.followup.send(content=f"Search failed: {e}")
+                    await interaction.edit_original_response(content=f"Search failed: {e}")
             except Exception:
                 pass
 

--- a/cogs/schedule.py
+++ b/cogs/schedule.py
@@ -51,13 +51,13 @@ class ScheduleManager(commands.Cog):
             success_msg = self.lang_manager.translate(
                 guild_id, "commands", "upload_schedule", "responses", "success"
             ) if self.lang_manager else "行程表已成功上傳！"
-            await interaction.followup.send(success_msg)
+            await interaction.edit_original_response(content=success_msg)
         except Exception as e:
             await func.report_error(e, "uploading schedule")
             error_msg = self.lang_manager.translate(
                 guild_id, "commands", "upload_schedule", "responses", "error", error=str(e)
             ) if self.lang_manager else f"上傳行程表時發生錯誤：{str(e)}"
-            await interaction.followup.send(error_msg)
+            await interaction.edit_original_response(content=error_msg)
 
     async def _core_upload_schedule(self, user_id: int, channel_id: int, yaml_data: bytes):
         try:
@@ -95,13 +95,13 @@ class ScheduleManager(commands.Cog):
         try:
             target_user_id = target_user.id if target_user else interaction.user.id
             result = await self._core_query_schedule(interaction, query_type.value, target_user_id, time, day.value if day else None)
-            await interaction.followup.send(result)
+            await interaction.edit_original_response(content=result)
         except Exception as e:
             await func.report_error(e, "querying schedule")
             error_msg = self.lang_manager.translate(
                 guild_id, "commands", "query_schedule", "responses", "error", error=str(e)
             ) if self.lang_manager else f"查詢行程表時發生錯誤：{str(e)}"
-            await interaction.followup.send(error_msg)
+            await interaction.edit_original_response(content=error_msg)
 
     async def _core_query_schedule(self, interaction_or_ctx, query_type: str, target_user_id:int, time: str = None, day: str = None):
         guild_id = str(interaction_or_ctx.guild_id) if hasattr(interaction_or_ctx, 'guild_id') and interaction_or_ctx.guild_id else str(interaction_or_ctx.guild.id) if hasattr(interaction_or_ctx, 'guild') else "0"
@@ -307,13 +307,13 @@ class ScheduleManager(commands.Cog):
             success_msg = self.lang_manager.translate(
                 guild_id, "commands", "update_schedule", "responses", "success"
             ) if self.lang_manager else "行程表已成功更新或創建！"
-            await interaction.followup.send(success_msg)
+            await interaction.edit_original_response(content=success_msg)
         except Exception as e:
             await func.report_error(e, "updating schedule")
             error_msg = self.lang_manager.translate(
                 guild_id, "commands", "update_schedule", "responses", "error", error=str(e)
             ) if self.lang_manager else f"更新或創建行程表時發生錯誤：{str(e)}"
-            await interaction.followup.send(error_msg)
+            await interaction.edit_original_response(content=error_msg)
 
     async def _core_update_schedule(self, user_id: int, day: str, time: str, description: str):
         filepath = os.path.join(self.schedule_dir, f"{user_id}.yaml")


### PR DESCRIPTION
### What was found
In multiple cogs (`channel_manager`, `schedule`, `gen_img`, `gif_tools`, `botinfo`, `internet_search`), slash commands defer their responses using `await interaction.response.defer()` but subsequently reply using `await interaction.followup.send(...)` for their first message.

### Where it is
- `cogs/channel_manager.py`: Various command error and success handlers.
- `cogs/schedule.py`: Upload, query, and update command handlers.
- `cogs/gen_img.py`: The main image generation slash command handler.
- `cogs/gif_tools.py`: The `search_gif` command handler.
- `cogs/botinfo.py`: The `botinfo` command handler.
- `cogs/internet_search.py`: The main search response handler, specifically affecting the first chunk of text.

### Why it matters
Using `followup.send` after a deferral creates a brand new webhook message in Discord, rather than updating the original deferred message. This leaves the original "Bot is thinking..." or "Bot is typing..." state hanging in the user's UI indefinitely, creating a confusing and unpolished user experience.

### What was done
Replaced the initial `await interaction.followup.send(...)` calls with `await interaction.edit_original_response(...)` across the affected files. 
- In `cogs/gen_img.py`, updated the `files=` kwarg to `attachments=` to match the signature of `edit_original_response`. 
- In `cogs/internet_search.py`, updated the chunking logic to use `edit_original_response` for the first chunk and `followup.send` for subsequent chunks.

---
*PR created automatically by Jules for task [9700142952915135030](https://jules.google.com/task/9700142952915135030) started by @starpig1129*