### PR TITLE
[Feature] Add fetch_webpage tool for URL reading capability

### DIFF
--- a/llm/tools/fetch_webpage.py
+++ b/llm/tools/fetch_webpage.py
@@ -1,0 +1,90 @@
+"""Webpage fetching tools for LLM integration.
+
+This module provides a LangChain-compatible tool for fetching and extracting
+text content from a given URL using aiohttp and BeautifulSoup.
+"""
+
+from typing import TYPE_CHECKING
+import aiohttp
+from bs4 import BeautifulSoup
+from langchain_core.tools import tool
+
+from addons.logging import get_logger
+from function import func
+
+if TYPE_CHECKING:
+    from llm.schema import OrchestratorRequest
+
+_logger = get_logger(server_id="Bot", source="llm.tools.fetch_webpage")
+
+class FetchWebpageTools:
+    """Container class for webpage fetching tools."""
+
+    def __init__(self, runtime: "OrchestratorRequest"):
+        self.runtime = runtime
+        self.logger = getattr(self.runtime, "logger", _logger)
+
+    def get_tools(self) -> list:
+        runtime = self.runtime
+
+        @tool
+        async def fetch_webpage(url: str) -> str:
+            """Fetches and extracts the main text content from a given URL.
+
+            Use this tool when you need to read the contents of a specific webpage,
+            such as when a user asks you to summarize an article or extract information
+            from a link they provided.
+
+            Args:
+                url: The full HTTP/HTTPS URL to fetch.
+
+            Returns:
+                The extracted text content from the webpage, truncated to a reasonable
+                length if it's too large, or an error message if the fetch fails.
+            """
+            logger = getattr(runtime, "logger", _logger)
+            logger.info("Tool 'fetch_webpage' called", extra={"url": url})
+
+            try:
+                timeout = aiohttp.ClientTimeout(total=15.0)
+                async with aiohttp.ClientSession(timeout=timeout) as session:
+                    headers = {
+                        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36"
+                    }
+                    async with session.get(url, headers=headers) as response:
+                        response.raise_for_status()
+
+                        content_type = response.headers.get('Content-Type', '').lower()
+                        if 'text/html' not in content_type and 'text/plain' not in content_type:
+                            return f"Error: URL points to a non-text resource (Content-Type: {content_type}). This tool only supports HTML or plain text."
+
+                        html = await response.text()
+
+                        # Parse HTML and extract text
+                        soup = BeautifulSoup(html, 'html.parser')
+
+                        # Remove script and style elements
+                        for script in soup(["script", "style", "noscript", "meta", "link", "header", "footer", "nav"]):
+                            script.decompose()
+
+                        text = soup.get_text(separator=' ', strip=True)
+
+                        # Clean up multiple spaces and newlines
+                        lines = (line.strip() for line in text.splitlines())
+                        chunks = (phrase.strip() for line in lines for phrase in line.split("  "))
+                        text = '\n'.join(chunk for chunk in chunks if chunk)
+
+                        # Truncate to avoid context overflow (approx 10000 chars)
+                        max_chars = 10000
+                        if len(text) > max_chars:
+                            text = text[:max_chars] + "... [Content truncated]"
+
+                        return text if text else "Successfully fetched page, but no text content was found."
+
+            except aiohttp.ClientError as e:
+                return f"Failed to fetch webpage due to a network or client error: {str(e)}"
+            except Exception as e:
+                await func.report_error(e, f"fetch_webpage tool failed for URL '{url}'")
+                return f"An unexpected error occurred while fetching the webpage: {str(e)}"
+
+        return [fetch_webpage]


### PR DESCRIPTION
### What was found
The bot can perform general internet searches via `internet_search.py`, but it lacks a dedicated tool for directly fetching and reading the raw text content of arbitrary URLs (e.g., when a user pastes a link and asks the bot to summarize it).

### Where it is
A new file: `llm/tools/fetch_webpage.py`

### Why it matters
Giving the LangChain agent the ability to read webpages significantly boosts its capability to interact with external context, letting users paste links to news articles, blogs, or documentation for the bot to analyze. It aligns with the existing config/tools design pattern and requires no new API keys or schema changes.

### What was done
1. Created `llm/tools/fetch_webpage.py` following the `*Tools` class pattern with a `get_tools` factory method.
2. Implemented the `@tool`-decorated `fetch_webpage` async function using `aiohttp` and `BeautifulSoup` (which are already in `requirements.txt`).
3. Added HTML cleaning (removing scripts, styles, etc.) and text chunking to keep responses clean.
4. Added a 10,000-character truncation to protect the LLM context window from overflowing on massive pages.
5. The tool handles failures and HTTP statuses gracefully, returning an error string instead of crashing the LLM pipeline, and reports internal issues via `func.report_error`.

---
*PR created automatically by Jules for task [1431411233931180263](https://jules.google.com/task/1431411233931180263) started by @starpig1129*