### PR TITLE
[UX] Fix hanging Thinking state in channel manager commands

### DIFF
--- a/cogs/channel_manager.py
+++ b/cogs/channel_manager.py
@@ -91,7 +91,7 @@ class ChannelManager(commands.Cog):
             error_message = "You do not have permission to perform this action. Restricted to administrators."
         
         if interaction.response.is_done():
-            await interaction.followup.send(error_message, ephemeral=True)
+            await interaction.edit_original_response(content=error_message)
         else:
             await interaction.response.send_message(error_message, ephemeral=True)
         return False
@@ -122,7 +122,7 @@ class ChannelManager(commands.Cog):
         else:
             response = f"Set **Server-wide** response mode to: {mode.name}"
 
-        await interaction.followup.send(response, ephemeral=True)
+        await interaction.edit_original_response(content=response)
 
     @app_commands.command(name="set_channel_mode", description="Set a special mode for a specific channel (e.g., Story Mode)")
     @app_commands.describe(channel="The channel to set", mode="The mode to set for this channel")
@@ -168,7 +168,7 @@ class ChannelManager(commands.Cog):
                 message = f"Set mode for {channel.mention} to: **{mode.name}**."
 
         self.save_config(guild_id, config)
-        await interaction.followup.send(message, ephemeral=True)
+        await interaction.edit_original_response(content=message)
 
     @app_commands.command(name="add_channel", description="Add channel to whitelist or blacklist")
     @app_commands.choices(list_type=[
@@ -202,7 +202,7 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"Added <#{channel_id}> to {list_type_name}"
             
-            await interaction.followup.send(success_message, ephemeral=True)
+            await interaction.edit_original_response(content=success_message)
         else:
             if self.lang_manager:
                 exists_message = self.lang_manager.translate(
@@ -211,7 +211,7 @@ class ChannelManager(commands.Cog):
             else:
                 exists_message = f"<#{channel_id}> already exists in {list_type_name}"
             
-            await interaction.followup.send(exists_message, ephemeral=True)
+            await interaction.edit_original_response(content=exists_message)
 
     @app_commands.command(name="remove_channel", description="Remove channel from whitelist or blacklist")
     @app_commands.choices(list_type=[
@@ -245,7 +245,7 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"Removed <#{channel_id}> from {list_type_name}"
             
-            await interaction.followup.send(success_message, ephemeral=True)
+            await interaction.edit_original_response(content=success_message)
         else:
             if self.lang_manager:
                 not_found_message = self.lang_manager.translate(
@@ -254,7 +254,7 @@ class ChannelManager(commands.Cog):
             else:
                 not_found_message = f"<#{channel_id}> does not exist in {list_type_name}"
             
-            await interaction.followup.send(not_found_message, ephemeral=True)
+            await interaction.edit_original_response(content=not_found_message)
 
     @app_commands.command(name="auto_response", description="Set channel auto-response")
     async def auto_response_command(self, interaction: discord.Interaction, channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread], enabled: bool):
@@ -275,7 +275,7 @@ class ChannelManager(commands.Cog):
         else:
             success_message = f"Set auto-response for <#{channel_id}> to: {enabled}"
         
-        await interaction.followup.send(success_message, ephemeral=True)
+        await interaction.edit_original_response(content=success_message)
 
     def is_allowed_channel(self, channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread], guild_id: str) -> Tuple[bool, bool, Optional[str]]:
         """


### PR DESCRIPTION
**What was found:** 
In `cogs/channel_manager.py`, several commands defer the interaction response (displaying "Bot is thinking...") but later respond using `await interaction.followup.send()`. When an interaction is deferred, using `followup.send()` creates a separate message and leaves the original "Thinking..." UI state hanging indefinitely on the user's client.

**Where it is:** 
`cogs/channel_manager.py` across multiple command response handlers:
- `check_admin_permissions` (line 94)
- `set_server_mode` (line 125)
- `set_channel_mode` (line 171)
- `add_channel_command` (lines 205, 214)
- `remove_channel_command` (lines 248, 257)
- `auto_response_command` (line 278)

**Why it matters:** 
This causes a severe UX friction point because users are presented with a perpetual loading state even after the command has successfully executed and responded. This creates confusion regarding whether the bot is stuck or still processing background tasks.

**What was done:** 
I replaced all instances of `interaction.followup.send(..., ephemeral=True)` with `interaction.edit_original_response(content=...)` in the affected locations where the interaction is guaranteed to be deferred (i.e. `interaction.response.is_done()` is True). This properly resolves the deferred interaction into the final message and clears the loading state.

---
*PR created automatically by Jules for task [12645977555401046890](https://jules.google.com/task/12645977555401046890) started by @starpig1129*