### PR TITLE
[Perf] Use asyncio.gather for concurrent knowledge retrieval

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -45,11 +45,15 @@ class KnowledgeMemoryProvider:
         Returns:
             KnowledgeMemory object containing both levels of knowledge.
         """
-        guild_knowledge = None
-        if guild_id:
-            guild_knowledge = await self._get_single("guild", guild_id)
+        async def fetch_guild() -> Optional[str]:
+            if guild_id:
+                return await self._get_single("guild", guild_id)
+            return None
             
-        channel_knowledge = await self._get_single("channel", channel_id)
+        guild_knowledge, channel_knowledge = await asyncio.gather(
+            fetch_guild(),
+            self._get_single("channel", channel_id)
+        )
         
         return KnowledgeMemory(
             guild_knowledge=guild_knowledge,


### PR DESCRIPTION
1. **What was found**: `KnowledgeMemoryProvider.get()` fetches `guild_knowledge` and `channel_knowledge` sequentially using separate `await` calls.
2. **Where it is**: `llm/memory/knowledge.py`, in the `get` method.
3. **Why it matters**: These two fetches are completely independent. Fetching them sequentially unnecessarily adds latency to the critical message processing pipeline.
4. **What was done**: Modified the `get` method to wrap the `guild_knowledge` fetch in an internal async helper and used `asyncio.gather` to execute both database/cache fetches concurrently.

---
*PR created automatically by Jules for task [13894378924535714186](https://jules.google.com/task/13894378924535714186) started by @starpig1129*