### PR TITLE
[Feature] Add LLM music playback tool

### DIFF
--- a/llm/tools/music.py
+++ b/llm/tools/music.py
@@ -1,0 +1,116 @@
+# MIT License
+# Music playback tools for LLM integration.
+
+from typing import Optional, Any, TYPE_CHECKING
+from langchain_core.tools import tool
+from addons.logging import get_logger
+from function import func
+import discord
+import asyncio
+
+if TYPE_CHECKING:
+    from llm.schema import OrchestratorRequest
+
+_logger = get_logger(server_id="Bot", source="llm.tools.music")
+
+class MusicTools:
+    """Tools for interacting with the Music bot features."""
+
+    def __init__(self, runtime: "OrchestratorRequest"):
+        self.runtime = runtime
+        self.logger = getattr(self.runtime, "logger", _logger)
+
+    def get_tools(self) -> list:
+        runtime = self.runtime
+
+        @tool
+        async def play_music(query: str) -> str:
+            """
+            Plays music based on a search query or a YouTube URL.
+
+            Use this tool when the user asks to play a song, start music, or
+            provides a song name/link.
+
+            Args:
+                query: The song name or YouTube URL to play.
+            """
+            bot = getattr(runtime, "bot", None)
+            if not bot:
+                return "Error: Bot runtime is not available."
+
+            cog = bot.get_cog("YTMusic")
+            if not cog:
+                return "Error: Music system (YTMusic) is not loaded."
+
+            message = getattr(runtime, "message", None)
+            if not message or not message.guild or not isinstance(message.author, discord.Member):
+                return "Error: Must be used in a server."
+
+            # Check if user is in voice channel
+            if not message.author.voice:
+                return "Error: User is not in a voice channel. Tell them to join one first."
+
+            try:
+                # We need an interaction to call play. Let's create a dummy one
+                # The _create_dummy_interaction is available on the cog
+                dummy_interaction = await cog._create_dummy_interaction(
+                    message.channel, message.guild, message
+                )
+
+                # We need to adapt it since the method expects an original_interaction
+                # We'll just patch the dummy interaction response methods to use the message channel
+                class DummyResponse:
+                    def __init__(self):
+                        self.is_done = lambda: True
+                    async def send_message(self, *args, **kwargs):
+                        pass
+                    async def defer(self, *args, **kwargs):
+                        pass
+
+                dummy_interaction.response = DummyResponse()
+
+                class DummyFollowup:
+                    async def send(self, content=None, embed=None, *args, **kwargs):
+                        # Capture output to return to LLM
+                        result = content or (embed.title if embed else "Action completed.")
+                        return result
+
+                dummy_interaction.followup = DummyFollowup()
+
+                # Connect to VC if needed
+                voice_client = message.guild.voice_client
+                if voice_client is None:
+                    await message.author.voice.channel.connect()
+
+                if "youtube.com" in query or "youtu.be" in query:
+                    if "list=" in query:
+                        # Schedule playlist handling
+                        asyncio.create_task(cog._handle_playlist(dummy_interaction, query))
+                        return f"Added playlist to queue: {query}"
+                    else:
+                        success = await cog._handle_single_video(dummy_interaction, query)
+                        if success:
+                            return f"Added video to queue: {query}"
+                        else:
+                            return f"Failed to add video: {query}"
+                else:
+                    # Handle search
+                    await cog._handle_search(dummy_interaction, query)
+                    return f"Searched and added to queue: {query}"
+
+            except Exception as e:
+                # Consistent error reporting
+                try:
+                    await func.report_error(e, "play_music failed")
+                except Exception:
+                    pass
+                return f"An error occurred while playing music: {e}"
+
+        # Mark as action tool for the message agent
+        play_music.__dict__["target_agent_mode"] = "message"
+
+        return [play_music]
+
+def get_tools(runtime: Any) -> list:
+    """Return music tools."""
+    return MusicTools(runtime).get_tools()

--- a/tests/test_music_tool.py
+++ b/tests/test_music_tool.py
@@ -1,0 +1,52 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+import discord
+from llm.tools.music import MusicTools
+from llm.schema import OrchestratorRequest
+
+@pytest.fixture
+def mock_runtime():
+    runtime = MagicMock(spec=OrchestratorRequest)
+    bot = MagicMock()
+    cog = MagicMock()
+    bot.get_cog.return_value = cog
+    runtime.bot = bot
+
+    msg = MagicMock()
+    guild = MagicMock()
+    guild.id = 123
+    author = MagicMock(spec=discord.Member)
+    author.voice = MagicMock()
+    author.voice.channel = MagicMock()
+    author.voice.channel.connect = AsyncMock()
+    msg.guild = guild
+    msg.author = author
+    msg.channel = MagicMock()
+
+    runtime.message = msg
+    return runtime, bot, cog
+
+@pytest.mark.asyncio
+async def test_music_tools_play_success(mock_runtime):
+    runtime, bot, cog = mock_runtime
+
+    dummy_interaction = MagicMock()
+    cog._create_dummy_interaction = AsyncMock(return_value=dummy_interaction)
+    cog._handle_search = AsyncMock(return_value=True)
+    cog._handle_single_video = AsyncMock(return_value=True)
+    cog._handle_playlist = AsyncMock(return_value=True)
+
+    tools = MusicTools(runtime).get_tools()
+    play_music = tools[0]
+
+    # Test normal search
+    res = await play_music.ainvoke({"query": "some song"})
+    assert "Searched and added" in res
+
+    # Test single video URL
+    res = await play_music.ainvoke({"query": "https://youtube.com/watch?v=123"})
+    assert "Added video" in res
+
+    # Test playlist
+    res = await play_music.ainvoke({"query": "https://youtube.com/playlist?list=123"})
+    assert "Added playlist" in res


### PR DESCRIPTION
1. **What was found**: The bot lacked a capability for the LLM agent to interact directly with the existing music features provided by the `YTMusic` cog, preventing users from asking the bot in natural language to play songs.
2. **Where it is**: `llm/tools/music.py` (newly added file).
3. **Why it matters**: Allowing the LLM agent to understand natural language requests to play music significantly improves the bot's multi-modal, user-centric functionality. Users can now casually request "play some jazz" and the bot can use its tool to delegate to the `YTMusic` cog. This utilizes existing robust features (`YTMusic`) without reinventing the wheel or requiring external dependencies.
4. **What was done**: Implemented `MusicTools` with a `play_music` LangChain-compatible tool. The tool uses the existing `YTMusic._create_dummy_interaction` helper to map the `runtime.message` (standard text message) to a dummy interaction structure necessary to interface with the cog's internal methods like `_handle_playlist`, `_handle_single_video`, and `_handle_search`. The new tool is targeted to the `message` agent mode. Tests were created to cover all three interaction routes.

---
*PR created automatically by Jules for task [17023355473359256954](https://jules.google.com/task/17023355473359256954) started by @starpig1129*