### PR TITLE
[Perf] Use asyncio.gather for concurrent knowledge fetch

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -45,11 +45,17 @@ class KnowledgeMemoryProvider:
         Returns:
             KnowledgeMemory object containing both levels of knowledge.
         """
-        guild_knowledge = None
-        if guild_id:
-            guild_knowledge = await self._get_single("guild", guild_id)
-            
-        channel_knowledge = await self._get_single("channel", channel_id)
+        guild_task = self._get_single("guild", guild_id) if guild_id else None
+        channel_task = self._get_single("channel", channel_id)
+
+        if guild_task:
+            guild_knowledge, channel_knowledge = await asyncio.gather(
+                guild_task,
+                channel_task
+            )
+        else:
+            guild_knowledge = None
+            channel_knowledge = await channel_task
         
         return KnowledgeMemory(
             guild_knowledge=guild_knowledge,


### PR DESCRIPTION
1. **What**: Guild and channel knowledge in `KnowledgeMemoryProvider.get` were being fetched sequentially using `await`.
2. **Where**: `llm/memory/knowledge.py` within the `KnowledgeMemoryProvider.get` method.
3. **Why**: Fetching them sequentially introduces unnecessary latency into the bot's response generation by waiting for one DB/cache call to finish before starting the next.
4. **What was done**: Replaced the sequential `await` calls with `asyncio.gather`, allowing both `guild_knowledge` and `channel_knowledge` to be fetched concurrently, thus reducing the overall latency of the pipeline.

---
*PR created automatically by Jules for task [5296739103861549595](https://jules.google.com/task/5296739103861549595) started by @starpig1129*