### PR TITLE
[Perf] Fetch guild and channel knowledge concurrently in KnowledgeMemoryProvider

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -45,11 +45,15 @@ class KnowledgeMemoryProvider:
         Returns:
             KnowledgeMemory object containing both levels of knowledge.
         """
-        guild_knowledge = None
-        if guild_id:
-            guild_knowledge = await self._get_single("guild", guild_id)
+        async def fetch_guild() -> Optional[str]:
+            if guild_id:
+                return await self._get_single("guild", guild_id)
+            return None
             
-        channel_knowledge = await self._get_single("channel", channel_id)
+        guild_knowledge, channel_knowledge = await asyncio.gather(
+            fetch_guild(),
+            self._get_single("channel", channel_id)
+        )
         
         return KnowledgeMemory(
             guild_knowledge=guild_knowledge,


### PR DESCRIPTION
1. **What was found**: In `llm/memory/knowledge.py`, `KnowledgeMemoryProvider.get()` retrieves guild knowledge and channel knowledge sequentially (awaiting guild knowledge, then awaiting channel knowledge).
2. **Where it is**: `llm/memory/knowledge.py`, lines 45-53.
3. **Why it matters**: Awaiting these database lookups sequentially introduces an unnecessary I/O bottleneck directly affecting the latency of the bot's response handling pipeline, since both tasks are independent. 
4. **What was done**: Wrapped the optional `guild_id` condition in an asynchronous helper function, then utilized `asyncio.gather()` to fetch both levels of knowledge concurrently.

---
*PR created automatically by Jules for task [7200649631593894587](https://jules.google.com/task/7200649631593894587) started by @starpig1129*