### PR TITLE
[Privacy] Delete user episodic memory vectors upon memory clear

### DIFF
--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -1034,6 +1034,15 @@ class UserDataCog(commands.Cog):
 
             success = await self.user_manager.delete_user_data(user_id)
             if success:
+                # Also delete episodic memory vectors for the user
+                try:
+                    vector_manager = getattr(self.bot, "vector_manager", None)
+                    if vector_manager and hasattr(vector_manager, "store") and hasattr(vector_manager.store, "delete_vectors_by_user"):
+                        deleted_count = await vector_manager.store.delete_vectors_by_user(user_id)
+                        self.logger.info(f"Deleted {deleted_count} episodic memory vectors for user {user_id}.")
+                except Exception as vm_err:
+                    self.logger.warning(f"Failed to delete episodic memory vectors for user {user_id}: {vm_err}")
+
                 # Invalidate ProceduralMemoryProvider cache
                 try:
                     orchestrator = getattr(self.bot, "orchestrator", None)


### PR DESCRIPTION
1. **What was found**: When clearing a user's memory (e.g., via `/memory clear` or "forget me" tool commands), only procedural memory (SQLite) was deleted. Their episodic memory (vector embeddings in Qdrant) was left behind.
2. **Where it is**: `cogs/userdata.py` within `UserDataCog._clear_user_data`.
3. **Why it matters**: This is a privacy and data compliance issue. If a user explicitly asks the bot to forget them, all identifiable interaction data should be purged.
4. **What was done**: Updated `UserDataCog._clear_user_data` to retrieve the active `vector_manager` and invoke its `delete_vectors_by_user` method when a user's data is cleared, ensuring a complete wipe.

---
*PR created automatically by Jules for task [16972284852258675587](https://jules.google.com/task/16972284852258675587) started by @starpig1129*