### PR TITLE
[Privacy] Delete episodic memory vectors when clearing user data

### DIFF
--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -1048,6 +1048,16 @@ class UserDataCog(commands.Cog):
                 except Exception as cache_err:
                     self.logger.warning(f"Failed to invalidate procedural cache for {user_id}: {cache_err}")
 
+                # Delete episodic memory vectors for the user
+                try:
+                    vector_manager = getattr(self.bot, "vector_manager", None)
+                    if vector_manager and hasattr(vector_manager, "store"):
+                        store = vector_manager.store
+                        if hasattr(store, "delete_vectors_by_user"):
+                            await store.delete_vectors_by_user(str(user_id))
+                            self.logger.info(f"Deleted episodic memory vectors for user {user_id}")
+                except Exception as vector_err:
+                    self.logger.warning(f"Failed to delete episodic memory vectors for {user_id}: {vector_err}")
 
                 return self._translate(
                     guild_id,


### PR DESCRIPTION
1. What was found:
When a user requests to clear their personal memory via `UserDataCog._clear_user_data`, only their procedural memory (preferences/background) was being deleted from the SQLite database. Their episodic memory fragments (vector embeddings of past conversations) remained in the vector store.

2. Where it is:
`cogs/userdata.py` inside `UserDataCog._clear_user_data` (around line 1051)

3. Why it matters:
Failing to delete episodic memories when a user explicitly requests a memory wipe violates data privacy expectations. The bot would continue to retain and potentially recall past conversation fragments involving that user even after they asked to be forgotten.

4. What was done:
Added a step in `UserDataCog._clear_user_data` to explicitly call `delete_vectors_by_user(str(user_id))` on the bot's vector store manager if it is available. This ensures that both procedural and episodic memories are completely wiped upon request.

---
*PR created automatically by Jules for task [12057356525868820391](https://jules.google.com/task/12057356525868820391) started by @starpig1129*