### PR TITLE
[UX] Fix hanging Thinking states in music and channel commands

### DIFF
--- a/cogs/channel_manager.py
+++ b/cogs/channel_manager.py
@@ -91,7 +91,7 @@ class ChannelManager(commands.Cog):
             error_message = "You do not have permission to perform this action. Restricted to administrators."
         
         if interaction.response.is_done():
-            await interaction.followup.send(error_message, ephemeral=True)
+            await interaction.edit_original_response(content=error_message)
         else:
             await interaction.response.send_message(error_message, ephemeral=True)
         return False
@@ -122,7 +122,7 @@ class ChannelManager(commands.Cog):
         else:
             response = f"Set **Server-wide** response mode to: {mode.name}"
 
-        await interaction.followup.send(response, ephemeral=True)
+        await interaction.edit_original_response(content=response)
 
     @app_commands.command(name="set_channel_mode", description="Set a special mode for a specific channel (e.g., Story Mode)")
     @app_commands.describe(channel="The channel to set", mode="The mode to set for this channel")
@@ -168,7 +168,7 @@ class ChannelManager(commands.Cog):
                 message = f"Set mode for {channel.mention} to: **{mode.name}**."
 
         self.save_config(guild_id, config)
-        await interaction.followup.send(message, ephemeral=True)
+        await interaction.edit_original_response(content=message)
 
     @app_commands.command(name="add_channel", description="Add channel to whitelist or blacklist")
     @app_commands.choices(list_type=[
@@ -202,7 +202,7 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"Added <#{channel_id}> to {list_type_name}"
             
-            await interaction.followup.send(success_message, ephemeral=True)
+            await interaction.edit_original_response(content=success_message)
         else:
             if self.lang_manager:
                 exists_message = self.lang_manager.translate(
@@ -211,7 +211,7 @@ class ChannelManager(commands.Cog):
             else:
                 exists_message = f"<#{channel_id}> already exists in {list_type_name}"
             
-            await interaction.followup.send(exists_message, ephemeral=True)
+            await interaction.edit_original_response(content=exists_message)
 
     @app_commands.command(name="remove_channel", description="Remove channel from whitelist or blacklist")
     @app_commands.choices(list_type=[
@@ -245,7 +245,7 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"Removed <#{channel_id}> from {list_type_name}"
             
-            await interaction.followup.send(success_message, ephemeral=True)
+            await interaction.edit_original_response(content=success_message)
         else:
             if self.lang_manager:
                 not_found_message = self.lang_manager.translate(
@@ -254,7 +254,7 @@ class ChannelManager(commands.Cog):
             else:
                 not_found_message = f"<#{channel_id}> does not exist in {list_type_name}"
             
-            await interaction.followup.send(not_found_message, ephemeral=True)
+            await interaction.edit_original_response(content=not_found_message)
 
     @app_commands.command(name="auto_response", description="Set channel auto-response")
     async def auto_response_command(self, interaction: discord.Interaction, channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread], enabled: bool):
@@ -275,7 +275,7 @@ class ChannelManager(commands.Cog):
         else:
             success_message = f"Set auto-response for <#{channel_id}> to: {enabled}"
         
-        await interaction.followup.send(success_message, ephemeral=True)
+        await interaction.edit_original_response(content=success_message)
 
     def is_allowed_channel(self, channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread], guild_id: str) -> Tuple[bool, bool, Optional[str]]:
         """

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -117,7 +117,7 @@ class YTMusic(commands.Cog):
                 await func.report_error(e, "music.py/play/channel.connect")
                 title = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "voice_connect_failed")
                 embed = discord.Embed(title=f"❌ | {title}", color=discord.Color.red())
-                await interaction.followup.send(embed=embed, ephemeral=True)
+                await interaction.edit_original_response(embed=embed)
                 return
 
         # 如果沒有提供查詢，刷新UI
@@ -136,10 +136,10 @@ class YTMusic(commands.Cog):
                     self
                 )
                 refresh_message = self.lang_manager.translate(str(guild_id), "commands", "play", "responses", "refreshed_ui")
-                await interaction.followup.send(refresh_message, ephemeral=True)
+                await interaction.edit_original_response(content=refresh_message)
             else:
                 no_song_message = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "nothing_playing")
-                await interaction.followup.send(no_song_message, ephemeral=True)
+                await interaction.edit_original_response(content=no_song_message)
             return
 
         # 如果有提供查詢，將音樂加入播放清單
@@ -172,7 +172,7 @@ class YTMusic(commands.Cog):
         if error:
             title = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "playlist_download_failed", error=error)
             embed = discord.Embed(title=f"❌ | {title}", color=discord.Color.red())
-            await interaction.followup.send(embed=embed, ephemeral=True)
+            await interaction.edit_original_response(embed=embed)
             return
             
         # Attribute ownership to the user for all playlist items
@@ -202,7 +202,7 @@ class YTMusic(commands.Cog):
             description=description,
             color=discord.Color.blue()
         )
-        await interaction.followup.send(embed=embed, ephemeral=True)
+        await interaction.edit_original_response(embed=embed)
 
     async def _handle_single_video(self, interaction: discord.Interaction, url: str) -> bool:
         """Handle single video URL"""
@@ -221,7 +221,7 @@ class YTMusic(commands.Cog):
         if error:
             title = self.lang_manager.translate(guild_id_str, "commands", "play", "errors", "video_info_failed", error=error)
             embed = discord.Embed(title=f"❌ | {title}", color=discord.Color.red())
-            await interaction.followup.send(embed=embed, ephemeral=True)
+            await interaction.edit_original_response(embed=embed)
             return False
             
         video_info['added_by'] = interaction.user.id
@@ -232,7 +232,7 @@ class YTMusic(commands.Cog):
         if success:
             title = self.lang_manager.translate(guild_id_str, "commands", "play", "responses", "song_added", title=video_info['title'])
             embed = discord.Embed(title=f"✅ | {title}", color=discord.Color.blue())
-            await interaction.followup.send(embed=embed, ephemeral=True)
+            await interaction.edit_original_response(embed=embed)
             return True
         else:
             title = self.lang_manager.translate(guild_id_str, "commands", "play", "errors", "queue_full_title")
@@ -242,7 +242,7 @@ class YTMusic(commands.Cog):
                 description=desc,
                 color=discord.Color.red()
             )
-            await interaction.followup.send(embed=embed, ephemeral=True)
+            await interaction.edit_original_response(embed=embed)
             return False
 
     async def _handle_search(self, interaction: discord.Interaction, query: str):
@@ -252,7 +252,7 @@ class YTMusic(commands.Cog):
         if not results:
             title = self.lang_manager.translate(str(guild_id), "commands", "play", "errors", "no_results")
             embed = discord.Embed(title=f"❌ | {title}", color=discord.Color.red())
-            await interaction.followup.send(embed=embed, ephemeral=True)
+            await interaction.edit_original_response(embed=embed)
             return
         
         # Format durations properly
@@ -273,7 +273,7 @@ class YTMusic(commands.Cog):
             color=discord.Color.blue()
         )
         
-        await interaction.followup.send(embed=embed, view=view, ephemeral=True)
+        await interaction.edit_original_response(embed=embed, view=view)
 
     async def play_next(self, interaction: discord.Interaction, force_new: bool = False) -> None:
         """Play the next song in the queue.


### PR DESCRIPTION
**What was found**: Several critical user-facing commands (notably `/play` in `cogs/music.py` and various admin commands in `cogs/channel_manager.py`) start by deferring the interaction using `await interaction.response.defer(thinking=True)`. However, when sending the final response, the code used `await interaction.followup.send(...)` instead of `edit_original_response`. 

**Where it is**:
- `cogs/music.py`: Lines 120, 139, 142, 175, 205, 224, 235, 245, 255, and 276.
- `cogs/channel_manager.py`: Lines 94, 125, 171, 205, 214, 248, 257, and 278.

**Why it matters**: In `discord.py`, using `followup.send` after `defer` creates a brand new webhook message. The initial "Bot is thinking..." message (created by the deferral) is never edited or deleted, meaning it stays "hanging" indefinitely in the user's Discord client. This creates significant UX friction, as users think the bot broke, got stuck, or is still processing a request that has actually finished. 

**What was done**: 
- Replaced the offending `await interaction.followup.send(...)` calls with `await interaction.edit_original_response(...)`. 
- Dropped the redundant `ephemeral=True` kwarg from those lines since `edit_original_response` automatically inherits the ephemeral state locked in during the `defer` phase.
- Re-ran tests in `tests/test_system_prompt_tools.py` and `tests/test_version_storage.py` to ensure the core changes didn't affect command parsing regressions.

---
*PR created automatically by Jules for task [1109273954031714924](https://jules.google.com/task/1109273954031714924) started by @starpig1129*