### PR TITLE
[Perf] Optimize context manager fetch concurrency

### DIFF
--- a/llm/context_manager.py
+++ b/llm/context_manager.py
@@ -104,51 +104,52 @@ class ContextManager:
                 _LOGGER.error("procedural_provider.get failed", exception=e)
                 return ProceduralMemory(user_info={})
 
-        async def _fetch_short_term_and_procedural() -> Tuple[List[BaseMessage], ProceduralMemory]:
-            # 1. Extract author ID to start their procedural memory fetch immediately
-            author_ids = []
-            try:
-                fallback_author_id = getattr(getattr(message, "author", None), "id", None)
-                if fallback_author_id is not None:
-                    author_ids.append(str(fallback_author_id))
-            except Exception:
-                pass
+        # 1. Start independent fetches
+        author_ids = []
+        try:
+            fallback_author_id = getattr(getattr(message, "author", None), "id", None)
+            if fallback_author_id is not None:
+                author_ids.append(str(fallback_author_id))
+        except Exception:
+            pass
 
-            # 2. Fetch short-term and author procedural in parallel
-            short_term_msgs, author_procedural = await asyncio.gather(
-                _fetch_short_term(),
-                _fetch_procedural(author_ids),
+        episodic_task = asyncio.create_task(_fetch_episodic())
+        knowledge_task = asyncio.create_task(_fetch_knowledge())
+        author_procedural_task = asyncio.create_task(_fetch_procedural(author_ids))
+
+        # 2. Await short-term first so additional mentions can be extracted
+        short_term_msgs = await _fetch_short_term()
+
+        # 3. Extract additional IDs
+        try:
+            extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
+        except Exception as e:
+            asyncio.create_task(
+                func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
             )
+            _LOGGER.error("extract_user_ids failed", exception=e)
+            extracted_ids = []
 
-            # 3. Extract any additional user IDs from the fetched short-term messages
-            try:
-                extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
-            except Exception as e:
-                asyncio.create_task(
-                    func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
-                )
-                _LOGGER.error("extract_user_ids failed", exception=e)
-                extracted_ids = []
+        # 4. Start additional procedural fetch if needed
+        additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
+        additional_procedural_task = None
+        if additional_ids:
+            additional_procedural_task = asyncio.create_task(_fetch_procedural(additional_ids))
 
-            # 4. Fetch procedural memory for any additional users
-            additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
-            if additional_ids:
-                additional_procedural = await _fetch_procedural(additional_ids)
-                # Merge procedural memories
-                merged_info = dict(getattr(author_procedural, "user_info", {}))
-                merged_info.update(getattr(additional_procedural, "user_info", {}))
-                procedural_memory = ProceduralMemory(user_info=merged_info)
-            else:
-                procedural_memory = author_procedural
-
-            return short_term_msgs, procedural_memory
-
-        # 5. Fetch episodic, knowledge, and combined short-term/procedural memory in parallel
-        (short_term_msgs, procedural_memory), episodic_str, knowledge = await asyncio.gather(
-            _fetch_short_term_and_procedural(),
-            _fetch_episodic(),
-            _fetch_knowledge(),
+        # 5. Await remaining tasks
+        episodic_str, knowledge, author_procedural = await asyncio.gather(
+            episodic_task,
+            knowledge_task,
+            author_procedural_task,
         )
+
+        if additional_procedural_task:
+            additional_procedural = await additional_procedural_task
+            merged_info = dict(getattr(author_procedural, "user_info", {}))
+            merged_info.update(getattr(additional_procedural, "user_info", {}))
+            procedural_memory = ProceduralMemory(user_info=merged_info)
+        else:
+            procedural_memory = author_procedural
 
         # 6. Format procedural memory into string (no STM serialization here)
         try:


### PR DESCRIPTION
**What was found**: The context manager (`llm/context_manager.py`) had a sequential bottleneck in `_fetch_short_term_and_procedural()`. It awaited both the slow `_fetch_short_term()` and `_fetch_procedural(author_ids)` using `asyncio.gather()` *before* it could analyze the short term messages to extract mentioned user IDs for additional procedural fetches. This meant the additional fetches were unnecessarily blocked.
**Where it is**: `llm/context_manager.py` within `ContextManager.get_context()`.
**Why it matters**: `_fetch_short_term()` is slow due to processing and downloading attachments from Discord. Blocking independent procedural and episodic fetches, or delaying the discovery of additional mentions, adds unnecessary latency to the LLM agent's time-to-first-token.
**What was done**: Rewrote the `get_context` method to remove `_fetch_short_term_and_procedural()`. Independent fetches (`episodic`, `knowledge`, `author_procedural`) are now started immediately using `asyncio.create_task`. `_fetch_short_term()` is awaited directly first, allowing the background tasks to run concurrently. Additional user IDs are then extracted and fetched, minimizing the critical path and improving parallelization.

---
*PR created automatically by Jules for task [1663278459297815540](https://jules.google.com/task/1663278459297815540) started by @starpig1129*