### PR TITLE
[Privacy] Clear episodic memory vectors on /memory clear

### DIFF
--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -1034,6 +1034,14 @@ class UserDataCog(commands.Cog):
 
             success = await self.user_manager.delete_user_data(user_id)
             if success:
+                # Clear episodic vectors
+                try:
+                    vector_manager = getattr(self.bot, "vector_manager", None)
+                    if vector_manager and hasattr(vector_manager, "store"):
+                        await vector_manager.store.delete_vectors_by_user(str(user_id))
+                except Exception as vector_err:
+                    self.logger.warning(f"Failed to delete episodic vectors for {user_id}: {vector_err}")
+
                 # Invalidate ProceduralMemoryProvider cache
                 try:
                     orchestrator = getattr(self.bot, "orchestrator", None)


### PR DESCRIPTION
1. **What was found**: The `UserDataCog._clear_user_data` method correctly deleted procedural memory but failed to clear the user's semantic vectors from the vector store (Qdrant).
2. **Where it is**: In `cogs/userdata.py` inside the `_clear_user_data` function.
3. **Why it matters**: This caused a privacy issue/data leak where user's past episodic memories were retained even after they explicitly asked to clear their personal memory.
4. **What was done**: Added a defensive `try...except` block inside `_clear_user_data` that calls `vector_manager.store.delete_vectors_by_user(user_id)` upon a successful procedural data deletion, thereby completely clearing the user's memory traces.

---
*PR created automatically by Jules for task [269926412363062329](https://jules.google.com/task/269926412363062329) started by @starpig1129*