### PR TITLE
[UX] Fix lingering 'Bot is thinking...' state in channel manager commands

### DIFF
--- a/cogs/channel_manager.py
+++ b/cogs/channel_manager.py
@@ -91,7 +91,10 @@ class ChannelManager(commands.Cog):
             error_message = "You do not have permission to perform this action. Restricted to administrators."
         
         if interaction.response.is_done():
-            await interaction.followup.send(error_message, ephemeral=True)
+            try:
+                await interaction.edit_original_response(content=error_message)
+            except discord.NotFound:
+                await interaction.followup.send(error_message, ephemeral=True)
         else:
             await interaction.response.send_message(error_message, ephemeral=True)
         return False
@@ -122,7 +125,7 @@ class ChannelManager(commands.Cog):
         else:
             response = f"Set **Server-wide** response mode to: {mode.name}"
 
-        await interaction.followup.send(response, ephemeral=True)
+        await interaction.edit_original_response(content=response)
 
     @app_commands.command(name="set_channel_mode", description="Set a special mode for a specific channel (e.g., Story Mode)")
     @app_commands.describe(channel="The channel to set", mode="The mode to set for this channel")
@@ -168,7 +171,7 @@ class ChannelManager(commands.Cog):
                 message = f"Set mode for {channel.mention} to: **{mode.name}**."
 
         self.save_config(guild_id, config)
-        await interaction.followup.send(message, ephemeral=True)
+        await interaction.edit_original_response(content=message)
 
     @app_commands.command(name="add_channel", description="Add channel to whitelist or blacklist")
     @app_commands.choices(list_type=[
@@ -202,7 +205,7 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"Added <#{channel_id}> to {list_type_name}"
             
-            await interaction.followup.send(success_message, ephemeral=True)
+            await interaction.edit_original_response(content=success_message)
         else:
             if self.lang_manager:
                 exists_message = self.lang_manager.translate(
@@ -211,7 +214,7 @@ class ChannelManager(commands.Cog):
             else:
                 exists_message = f"<#{channel_id}> already exists in {list_type_name}"
             
-            await interaction.followup.send(exists_message, ephemeral=True)
+            await interaction.edit_original_response(content=exists_message)
 
     @app_commands.command(name="remove_channel", description="Remove channel from whitelist or blacklist")
     @app_commands.choices(list_type=[
@@ -245,7 +248,7 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"Removed <#{channel_id}> from {list_type_name}"
             
-            await interaction.followup.send(success_message, ephemeral=True)
+            await interaction.edit_original_response(content=success_message)
         else:
             if self.lang_manager:
                 not_found_message = self.lang_manager.translate(
@@ -254,7 +257,7 @@ class ChannelManager(commands.Cog):
             else:
                 not_found_message = f"<#{channel_id}> does not exist in {list_type_name}"
             
-            await interaction.followup.send(not_found_message, ephemeral=True)
+            await interaction.edit_original_response(content=not_found_message)
 
     @app_commands.command(name="auto_response", description="Set channel auto-response")
     async def auto_response_command(self, interaction: discord.Interaction, channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread], enabled: bool):
@@ -275,7 +278,7 @@ class ChannelManager(commands.Cog):
         else:
             success_message = f"Set auto-response for <#{channel_id}> to: {enabled}"
         
-        await interaction.followup.send(success_message, ephemeral=True)
+        await interaction.edit_original_response(content=success_message)
 
     def is_allowed_channel(self, channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread], guild_id: str) -> Tuple[bool, bool, Optional[str]]:
         """


### PR DESCRIPTION
1. **What was found**: Several slash commands in the Channel Manager cog (`set_server_mode`, `set_channel_mode`, `add_channel`, `remove_channel`, `auto_response`) resulted in a permanent "Bot is thinking..." state in the Discord UI. This occurred because the central permission check (`check_admin_permissions`) defers the interaction, but the subsequent success or error messages were sent using `interaction.followup.send()`. In Discord.py, `followup.send()` creates a new webhook message, failing to clear the original deferred "thinking" placeholder.
2. **Where it is**: `cogs/channel_manager.py` (specifically in `check_admin_permissions` error handling and all the slash command handlers).
3. **Why it matters**: A permanently lingering "Bot is thinking..." state is highly confusing to users. It degrades the UX by making it look like the bot is frozen or has failed, even when the command has successfully executed or gracefully handled a permission error.
4. **What was done**: Modified the code to use `await interaction.edit_original_response(content=...)` instead of `await interaction.followup.send(...)`. This correctly clears the thinking state by replacing it with the final message. In `check_admin_permissions`, this was wrapped in a `try...except discord.NotFound` block to fall back to `followup.send` if the original response was deleted or took too long to process.

---
*PR created automatically by Jules for task [16041449355344048162](https://jules.google.com/task/16041449355344048162) started by @starpig1129*