### PR TITLE
[Perf] Optimize parallel memory provider fetches in ContextManager

### DIFF
--- a/llm/context_manager.py
+++ b/llm/context_manager.py
@@ -104,53 +104,57 @@ class ContextManager:
                 _LOGGER.error("procedural_provider.get failed", exception=e)
                 return ProceduralMemory(user_info={})
 
-        async def _fetch_short_term_and_procedural() -> Tuple[List[BaseMessage], ProceduralMemory]:
-            # 1. Extract author ID to start their procedural memory fetch immediately
-            author_ids = []
-            try:
-                fallback_author_id = getattr(getattr(message, "author", None), "id", None)
-                if fallback_author_id is not None:
-                    author_ids.append(str(fallback_author_id))
-            except Exception:
-                pass
+        # 1. Extract author ID to start their procedural memory fetch immediately
+        author_ids = []
+        try:
+            fallback_author_id = getattr(getattr(message, "author", None), "id", None)
+            if fallback_author_id is not None:
+                author_ids.append(str(fallback_author_id))
+        except Exception:
+            pass
 
-            # 2. Fetch short-term and author procedural in parallel
-            short_term_msgs, author_procedural = await asyncio.gather(
-                _fetch_short_term(),
-                _fetch_procedural(author_ids),
+        # 2. Launch independent slow queries as background tasks
+        task_episodic = asyncio.create_task(_fetch_episodic())
+        task_knowledge = asyncio.create_task(_fetch_knowledge())
+        task_author_proc = asyncio.create_task(_fetch_procedural(author_ids))
+
+        # 3. Await short-term memory FIRST, so we can extract additional IDs ASAP
+        short_term_msgs = await _fetch_short_term()
+
+        # 4. Extract any additional user IDs from the fetched short-term messages
+        try:
+            extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
+        except Exception as e:
+            asyncio.create_task(
+                func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
             )
+            _LOGGER.error("extract_user_ids failed", exception=e)
+            extracted_ids = []
 
-            # 3. Extract any additional user IDs from the fetched short-term messages
-            try:
-                extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
-            except Exception as e:
-                asyncio.create_task(
-                    func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
-                )
-                _LOGGER.error("extract_user_ids failed", exception=e)
-                extracted_ids = []
+        additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
 
-            # 4. Fetch procedural memory for any additional users
-            additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
-            if additional_ids:
-                additional_procedural = await _fetch_procedural(additional_ids)
-                # Merge procedural memories
-                merged_info = dict(getattr(author_procedural, "user_info", {}))
-                merged_info.update(getattr(additional_procedural, "user_info", {}))
-                procedural_memory = ProceduralMemory(user_info=merged_info)
-            else:
-                procedural_memory = author_procedural
+        # 5. Launch additional procedural memory fetch if necessary
+        task_additional_proc = None
+        if additional_ids:
+            task_additional_proc = asyncio.create_task(_fetch_procedural(additional_ids))
 
-            return short_term_msgs, procedural_memory
-
-        # 5. Fetch episodic, knowledge, and combined short-term/procedural memory in parallel
-        (short_term_msgs, procedural_memory), episodic_str, knowledge = await asyncio.gather(
-            _fetch_short_term_and_procedural(),
-            _fetch_episodic(),
-            _fetch_knowledge(),
+        # 6. Gather all background tasks
+        episodic_str, knowledge, author_procedural = await asyncio.gather(
+            task_episodic,
+            task_knowledge,
+            task_author_proc,
         )
 
-        # 6. Format procedural memory into string (no STM serialization here)
+        # 7. Merge procedural memories if we had additional IDs
+        if task_additional_proc:
+            additional_procedural = await task_additional_proc
+            merged_info = dict(getattr(author_procedural, "user_info", {}))
+            merged_info.update(getattr(additional_procedural, "user_info", {}))
+            procedural_memory = ProceduralMemory(user_info=merged_info)
+        else:
+            procedural_memory = author_procedural
+
+        # 8. Format procedural memory into string (no STM serialization here)
         try:
             channel_name = getattr(message.channel, "name", str(getattr(message.channel, "id", "")))
         except Exception:


### PR DESCRIPTION
**What:** Found a sequential bottleneck in `ContextManager.get_context()` within `llm/context_manager.py` where the primary thread awaited independent asynchronous fetches (`_fetch_short_term` and `_fetch_procedural` for authors) sequentially via gather before launching additional ID fetches.

**Where:** `llm/context_manager.py`, inside the `ContextManager.get_context()` method.

**Why:** Because `_fetch_short_term_and_procedural` grouped short-term and procedural fetches, the extraction of additional mentioned user IDs from the short-term memory was unnecessarily delayed by the procedural fetch of the author. This increased overall pipeline latency.

**What was done:** Refactored `ContextManager.get_context()` to immediately spawn background tasks (`asyncio.create_task`) for the independent slow queries (`_fetch_episodic`, `_fetch_knowledge`, and `_fetch_procedural` for the author). `_fetch_short_term` is awaited first so that additional IDs can be extracted as early as possible, launching their procedural fetches while the other independent tasks are still running concurrently. Finally, gathered all tasks together. Tested to ensure no functional regressions.

---
*PR created automatically by Jules for task [889154081431399119](https://jules.google.com/task/889154081431399119) started by @starpig1129*