### PR TITLE
[Privacy] Delete episodic vectors during clear_user_data requests

### DIFF
--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -1034,6 +1034,14 @@ class UserDataCog(commands.Cog):
 
             success = await self.user_manager.delete_user_data(user_id)
             if success:
+                # Also explicitly delete episodic memory vectors for compliance
+                try:
+                    vector_manager = getattr(self.bot, "vector_manager", None)
+                    if vector_manager and hasattr(vector_manager, "store"):
+                        await vector_manager.store.delete_vectors_by_user(user_id)
+                except Exception as vm_err:
+                    self.logger.warning(f"Failed to delete episodic memory vectors for {user_id}: {vm_err}")
+
                 # Invalidate ProceduralMemoryProvider cache
                 try:
                     orchestrator = getattr(self.bot, "orchestrator", None)


### PR DESCRIPTION
**What was found:** 
When users clear their personal data (via `/memory clear` or `clear_user_memory` tool), the bot correctly deleted their procedural SQLite data. However, it failed to trigger vector deletions for their episodic memories stored in Qdrant (or any other vector backend). This meant users' semantically searchable chat history remained in the vector database even after asking to be forgotten.

**Where it is:** 
`cogs/userdata.py` lines ~1035 within `UserDataCog._clear_user_data()`.

**Why it matters:** 
This causes a GDPR/Privacy compliance failure. When a user issues a clear command, all identifiable data they produced that is explicitly tied to their user ID needs to be stripped from the knowledge graphs and stores. Without deleting vector fragments mapped to their IDs, past quotes and personal information could still be brought back up by the bot's RAG system.

**What was done:** 
Modified `UserDataCog._clear_user_data` to explicitly check if `bot.vector_manager` exists and call `await vector_manager.store.delete_vectors_by_user(user_id)`. This utilizes the `delete_vectors_by_user` interface recently implemented across backends without crashing the flow if the vector manager is disabled.

---
*PR created automatically by Jules for task [14447688523384542826](https://jules.google.com/task/14447688523384542826) started by @starpig1129*