### PR TITLE
[Privacy] Ensure complete episodic memory deletion on user clear

### DIFF
--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -1048,6 +1048,13 @@ class UserDataCog(commands.Cog):
                 except Exception as cache_err:
                     self.logger.warning(f"Failed to invalidate procedural cache for {user_id}: {cache_err}")
 
+                # Delete episodic memory vectors
+                try:
+                    vector_manager = getattr(self.bot, "vector_manager", None)
+                    if vector_manager and getattr(vector_manager, "store", None):
+                        await vector_manager.store.delete_vectors_by_user(user_id)
+                except Exception as vector_err:
+                    self.logger.warning(f"Failed to delete episodic memory vectors for {user_id}: {vector_err}")
 
                 return self._translate(
                     guild_id,


### PR DESCRIPTION
1. **What was found**: When users run `/memory clear`, only their procedural memory (SQLite) is deleted; their episodic memory vectors in Qdrant are left untouched.
2. **Where it is**: `cogs/userdata.py` inside the `_clear_user_data` function (around line ~1050).
3. **Why it matters**: This is a privacy compliance issue. If a user explicitly asks to be forgotten, all semantic memory traces tied to them in the episodic vector store should be purged as well to ensure data privacy.
4. **What was done**: Added a call to `vector_manager.store.delete_vectors_by_user(user_id)` inside `_clear_user_data`, properly wrapped in a try/except block to handle potential vector store errors gracefully without crashing the overall deletion flow.

---
*PR created automatically by Jules for task [15496188971915767892](https://jules.google.com/task/15496188971915767892) started by @starpig1129*