### PR TITLE
[Privacy] Add episodic vector deletion to user data clearance

### DIFF
--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -1034,6 +1034,14 @@ class UserDataCog(commands.Cog):
 
             success = await self.user_manager.delete_user_data(user_id)
             if success:
+                # Delete episodic memory vectors
+                try:
+                    vector_manager = getattr(self.bot, "vector_manager", None)
+                    if vector_manager and hasattr(vector_manager, "store") and hasattr(vector_manager.store, "delete_vectors_by_user"):
+                        await vector_manager.store.delete_vectors_by_user(str(user_id))
+                except Exception as vector_err:
+                    self.logger.warning(f"Failed to delete episodic vectors for {user_id}: {vector_err}")
+
                 # Invalidate ProceduralMemoryProvider cache
                 try:
                     orchestrator = getattr(self.bot, "orchestrator", None)


### PR DESCRIPTION
What was found:
When a user cleared their user data via `manage_user_data(action='clear')`, only their procedural memory was being deleted, leaving episodic vector embeddings untouched.

Where it is:
`cogs/userdata.py` inside `_clear_user_data` (around line ~1037).

Why it matters:
Failing to delete episodic memory vectors when a user requests their data to be cleared violates data privacy principles (e.g., Right to be Forgotten).

What was done:
Added a step to call `self.bot.vector_manager.store.delete_vectors_by_user(str(user_id))` immediately after successful procedural data deletion, wrapped in a safe `try...except` block checking for module existence to prevent crashing on systems without vector memory enabled.

---
*PR created automatically by Jules for task [11455888051058934875](https://jules.google.com/task/11455888051058934875) started by @starpig1129*