### PR TITLE
[Perf] Optimize memory provider fetch concurrency

### DIFF
--- a/llm/context_manager.py
+++ b/llm/context_manager.py
@@ -104,51 +104,53 @@ class ContextManager:
                 _LOGGER.error("procedural_provider.get failed", exception=e)
                 return ProceduralMemory(user_info={})
 
-        async def _fetch_short_term_and_procedural() -> Tuple[List[BaseMessage], ProceduralMemory]:
-            # 1. Extract author ID to start their procedural memory fetch immediately
-            author_ids = []
-            try:
-                fallback_author_id = getattr(getattr(message, "author", None), "id", None)
-                if fallback_author_id is not None:
-                    author_ids.append(str(fallback_author_id))
-            except Exception:
-                pass
+        # 1. Start episodic and knowledge fetches immediately since they are independent
+        episodic_task = asyncio.create_task(_fetch_episodic())
+        knowledge_task = asyncio.create_task(_fetch_knowledge())
 
-            # 2. Fetch short-term and author procedural in parallel
-            short_term_msgs, author_procedural = await asyncio.gather(
-                _fetch_short_term(),
-                _fetch_procedural(author_ids),
+        # 2. Extract author ID to start their procedural memory fetch immediately
+        author_ids = []
+        try:
+            fallback_author_id = getattr(getattr(message, "author", None), "id", None)
+            if fallback_author_id is not None:
+                author_ids.append(str(fallback_author_id))
+        except Exception:
+            pass
+
+        author_procedural_task = asyncio.create_task(_fetch_procedural(author_ids))
+
+        # 3. Await short-term memory first so we can extract additional user IDs
+        short_term_msgs = await _fetch_short_term()
+
+        # 4. Extract any additional user IDs from the fetched short-term messages
+        try:
+            extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
+        except Exception as e:
+            asyncio.create_task(
+                func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
             )
+            _LOGGER.error("extract_user_ids failed", exception=e)
+            extracted_ids = []
 
-            # 3. Extract any additional user IDs from the fetched short-term messages
-            try:
-                extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
-            except Exception as e:
-                asyncio.create_task(
-                    func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
-                )
-                _LOGGER.error("extract_user_ids failed", exception=e)
-                extracted_ids = []
+        # 5. Fetch procedural memory for any additional users
+        additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
+        additional_procedural_task = None
+        if additional_ids:
+            additional_procedural_task = asyncio.create_task(_fetch_procedural(additional_ids))
 
-            # 4. Fetch procedural memory for any additional users
-            additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
-            if additional_ids:
-                additional_procedural = await _fetch_procedural(additional_ids)
-                # Merge procedural memories
-                merged_info = dict(getattr(author_procedural, "user_info", {}))
-                merged_info.update(getattr(additional_procedural, "user_info", {}))
-                procedural_memory = ProceduralMemory(user_info=merged_info)
-            else:
-                procedural_memory = author_procedural
+        # 6. Await all pending tasks
+        episodic_str = await episodic_task
+        knowledge = await knowledge_task
+        author_procedural = await author_procedural_task
 
-            return short_term_msgs, procedural_memory
-
-        # 5. Fetch episodic, knowledge, and combined short-term/procedural memory in parallel
-        (short_term_msgs, procedural_memory), episodic_str, knowledge = await asyncio.gather(
-            _fetch_short_term_and_procedural(),
-            _fetch_episodic(),
-            _fetch_knowledge(),
-        )
+        if additional_procedural_task:
+            additional_procedural = await additional_procedural_task
+            # Merge procedural memories
+            merged_info = dict(getattr(author_procedural, "user_info", {}))
+            merged_info.update(getattr(additional_procedural, "user_info", {}))
+            procedural_memory = ProceduralMemory(user_info=merged_info)
+        else:
+            procedural_memory = author_procedural
 
         # 6. Format procedural memory into string (no STM serialization here)
         try:

--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -45,11 +45,15 @@ class KnowledgeMemoryProvider:
         Returns:
             KnowledgeMemory object containing both levels of knowledge.
         """
-        guild_knowledge = None
+        tasks = []
         if guild_id:
-            guild_knowledge = await self._get_single("guild", guild_id)
-            
-        channel_knowledge = await self._get_single("channel", channel_id)
+            tasks.append(self._get_single("guild", guild_id))
+        tasks.append(self._get_single("channel", channel_id))
+
+        results = await asyncio.gather(*tasks)
+
+        guild_knowledge = results[0] if guild_id else None
+        channel_knowledge = results[-1]
         
         return KnowledgeMemory(
             guild_knowledge=guild_knowledge,


### PR DESCRIPTION
1. **What was found**: Two concurrency bottlenecks were identified in the hot path of memory fetching. In `llm/context_manager.py`, the `_fetch_short_term_and_procedural` method used an `asyncio.gather` that effectively blocked extracting extra user IDs from the `short_term` fetch until the author's `procedural` memory fetch was also complete. In `llm/memory/knowledge.py`, the `get` method executed `await self._get_single` sequentially for guild and channel knowledge.
2. **Where it is**: `llm/context_manager.py` (lines ~100-160 in `get_context`) and `llm/memory/knowledge.py` (lines ~45-60 in `get`).
3. **Why it matters**: These two methods are called on every single message the bot processes. The previous sequential patterns artificially delayed I/O tasks and network responses, increasing the overall latency of the bot before the Langchain agent even receives the prompt.
4. **What was done**: In `llm/context_manager.py`, the fetches for independent tasks (episodic, knowledge, author_procedural) were converted to run via `asyncio.create_task()` immediately. This allows `_fetch_short_term` to be awaited first, meaning `extra_user` procedural fetches can begin without waiting for the slow author DB queries. In `llm/memory/knowledge.py`, the guild and channel fetches were aggregated into a task list and awaited concurrently with `asyncio.gather`.

---
*PR created automatically by Jules for task [16946896620914589609](https://jules.google.com/task/16946896620914589609) started by @starpig1129*