### PR TITLE
[UX] Fix hanging Thinking state in channel manager commands

### DIFF
--- a/cogs/channel_manager.py
+++ b/cogs/channel_manager.py
@@ -91,7 +91,7 @@ class ChannelManager(commands.Cog):
             error_message = "You do not have permission to perform this action. Restricted to administrators."
         
         if interaction.response.is_done():
-            await interaction.followup.send(error_message, ephemeral=True)
+            await interaction.edit_original_response(content=error_message)
         else:
             await interaction.response.send_message(error_message, ephemeral=True)
         return False
@@ -122,7 +122,7 @@ class ChannelManager(commands.Cog):
         else:
             response = f"Set **Server-wide** response mode to: {mode.name}"
 
-        await interaction.followup.send(response, ephemeral=True)
+        await interaction.edit_original_response(content=response)
 
     @app_commands.command(name="set_channel_mode", description="Set a special mode for a specific channel (e.g., Story Mode)")
     @app_commands.describe(channel="The channel to set", mode="The mode to set for this channel")
@@ -168,7 +168,7 @@ class ChannelManager(commands.Cog):
                 message = f"Set mode for {channel.mention} to: **{mode.name}**."
 
         self.save_config(guild_id, config)
-        await interaction.followup.send(message, ephemeral=True)
+        await interaction.edit_original_response(content=message)
 
     @app_commands.command(name="add_channel", description="Add channel to whitelist or blacklist")
     @app_commands.choices(list_type=[
@@ -202,7 +202,7 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"Added <#{channel_id}> to {list_type_name}"
             
-            await interaction.followup.send(success_message, ephemeral=True)
+            await interaction.edit_original_response(content=success_message)
         else:
             if self.lang_manager:
                 exists_message = self.lang_manager.translate(
@@ -211,7 +211,7 @@ class ChannelManager(commands.Cog):
             else:
                 exists_message = f"<#{channel_id}> already exists in {list_type_name}"
             
-            await interaction.followup.send(exists_message, ephemeral=True)
+            await interaction.edit_original_response(content=exists_message)
 
     @app_commands.command(name="remove_channel", description="Remove channel from whitelist or blacklist")
     @app_commands.choices(list_type=[
@@ -245,7 +245,7 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"Removed <#{channel_id}> from {list_type_name}"
             
-            await interaction.followup.send(success_message, ephemeral=True)
+            await interaction.edit_original_response(content=success_message)
         else:
             if self.lang_manager:
                 not_found_message = self.lang_manager.translate(
@@ -254,7 +254,7 @@ class ChannelManager(commands.Cog):
             else:
                 not_found_message = f"<#{channel_id}> does not exist in {list_type_name}"
             
-            await interaction.followup.send(not_found_message, ephemeral=True)
+            await interaction.edit_original_response(content=not_found_message)
 
     @app_commands.command(name="auto_response", description="Set channel auto-response")
     async def auto_response_command(self, interaction: discord.Interaction, channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread], enabled: bool):
@@ -275,7 +275,7 @@ class ChannelManager(commands.Cog):
         else:
             success_message = f"Set auto-response for <#{channel_id}> to: {enabled}"
         
-        await interaction.followup.send(success_message, ephemeral=True)
+        await interaction.edit_original_response(content=success_message)
 
     def is_allowed_channel(self, channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread], guild_id: str) -> Tuple[bool, bool, Optional[str]]:
         """

--- a/fix_all.py
+++ b/fix_all.py
@@ -1,0 +1,14 @@
+import os
+import re
+
+def fix_file(filepath):
+    with open(filepath, 'r') as f:
+        content = f.read()
+
+    # We want to replace await interaction.followup.send(...) with await interaction.edit_original_response(content=...)
+    # But only if it's the first message after a defer. This is tricky to do globally with a regex without breaking
+    # things that legitimately need followup (like sending multiple messages).
+    # Since the codebase is large, and this PR is about "Identify the single most impactful UX friction point, and fix or propose a fix",
+    # and the PR rules state "If the change requires significant refactoring... open a PR with a detailed proposal... and implement only a minimal proof-of-concept".
+    # The channel_manager changes serve as the proof of concept. I will submit the PR as-is with a proposal for the rest.
+    pass


### PR DESCRIPTION
### 1. What was found
When users (specifically admins) run deferred slash commands, the bot correctly processes the command but often leaves a perpetual "Bot is thinking..." message hanging in the Discord UI.

### 2. Where it is
This pattern is widespread across the bot, but is specifically fixed in this PR within `cogs/channel_manager.py` (lines ~94, 125, 171, 205, 214, 248, 257, 278). The root cause is calling `await interaction.followup.send(message, ephemeral=True)` after having called `await interaction.response.defer(ephemeral=True, thinking=True)`.

### 3. Why it matters
This is a highly visible UX friction point. Users (especially new admins configuring the bot) see a permanent "Thinking..." state and assume the bot crashed, timed out, or failed to process their command, even when a separate success message is sent. This causes confusion and degrades trust in the bot's reliability.

### 4. What was done
**Implemented (Proof of Concept):**
In `cogs/channel_manager.py`, I replaced instances of `await interaction.followup.send(message, ephemeral=True)` with `await interaction.edit_original_response(content=message)`. This properly resolves the initial deferred state and replaces the "Thinking..." message with the actual result.

**Proposed Next Steps (Full Refactor):**
A codebase-wide search reveals over 90 other instances of `interaction.followup.send` being used across various cogs (like `story_manager`, `system_prompt_manager`, `music`, `gen_img`, etc.), many of which immediately follow a `defer()` call. 
Because globally replacing `followup.send` with `edit_original_response` requires careful manual verification for each command (e.g. handling unsupported kwargs like `ephemeral=True` which must be set during `defer()`, or handling commands that legitimately send multiple followups), I have kept this PR focused on `channel_manager.py` as a minimal proof-of-concept. 
I propose a follow-up refactoring effort to audit all deferred slash commands and systematically replace the first `followup.send()` with `edit_original_response()` to ensure a clean UI state bot-wide.

---
*PR created automatically by Jules for task [11865539219279926815](https://jules.google.com/task/11865539219279926815) started by @starpig1129*