### PR TITLE
[Perf] Optimize context manager fetch parallelism

### DIFF
--- a/llm/context_manager.py
+++ b/llm/context_manager.py
@@ -104,51 +104,52 @@ class ContextManager:
                 _LOGGER.error("procedural_provider.get failed", exception=e)
                 return ProceduralMemory(user_info={})
 
-        async def _fetch_short_term_and_procedural() -> Tuple[List[BaseMessage], ProceduralMemory]:
-            # 1. Extract author ID to start their procedural memory fetch immediately
-            author_ids = []
-            try:
-                fallback_author_id = getattr(getattr(message, "author", None), "id", None)
-                if fallback_author_id is not None:
-                    author_ids.append(str(fallback_author_id))
-            except Exception:
-                pass
+        # 1. Extract author ID to start their procedural memory fetch immediately
+        author_ids = []
+        try:
+            fallback_author_id = getattr(getattr(message, "author", None), "id", None)
+            if fallback_author_id is not None:
+                author_ids.append(str(fallback_author_id))
+        except Exception:
+            pass
 
-            # 2. Fetch short-term and author procedural in parallel
-            short_term_msgs, author_procedural = await asyncio.gather(
-                _fetch_short_term(),
-                _fetch_procedural(author_ids),
+        # 2. Start independent fetches immediately
+        episodic_task = asyncio.create_task(_fetch_episodic())
+        knowledge_task = asyncio.create_task(_fetch_knowledge())
+        author_procedural_task = asyncio.create_task(_fetch_procedural(author_ids))
+
+        # 3. Await the slow short-term fetch
+        short_term_msgs = await _fetch_short_term()
+
+        # 4. Extract any additional user IDs from the fetched short-term messages
+        try:
+            extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
+        except Exception as e:
+            asyncio.create_task(
+                func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
             )
+            _LOGGER.error("extract_user_ids failed", exception=e)
+            extracted_ids = []
 
-            # 3. Extract any additional user IDs from the fetched short-term messages
-            try:
-                extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
-            except Exception as e:
-                asyncio.create_task(
-                    func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
-                )
-                _LOGGER.error("extract_user_ids failed", exception=e)
-                extracted_ids = []
+        # 5. Fetch procedural memory for any additional users if needed
+        additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
+        additional_procedural_task = None
+        if additional_ids:
+            additional_procedural_task = asyncio.create_task(_fetch_procedural(additional_ids))
 
-            # 4. Fetch procedural memory for any additional users
-            additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
-            if additional_ids:
-                additional_procedural = await _fetch_procedural(additional_ids)
-                # Merge procedural memories
-                merged_info = dict(getattr(author_procedural, "user_info", {}))
-                merged_info.update(getattr(additional_procedural, "user_info", {}))
-                procedural_memory = ProceduralMemory(user_info=merged_info)
-            else:
-                procedural_memory = author_procedural
+        # 6. Await all remaining tasks
+        episodic_str = await episodic_task
+        knowledge = await knowledge_task
+        author_procedural = await author_procedural_task
 
-            return short_term_msgs, procedural_memory
-
-        # 5. Fetch episodic, knowledge, and combined short-term/procedural memory in parallel
-        (short_term_msgs, procedural_memory), episodic_str, knowledge = await asyncio.gather(
-            _fetch_short_term_and_procedural(),
-            _fetch_episodic(),
-            _fetch_knowledge(),
-        )
+        if additional_procedural_task:
+            additional_procedural = await additional_procedural_task
+            # Merge procedural memories
+            merged_info = dict(getattr(author_procedural, "user_info", {}))
+            merged_info.update(getattr(additional_procedural, "user_info", {}))
+            procedural_memory = ProceduralMemory(user_info=merged_info)
+        else:
+            procedural_memory = author_procedural
 
         # 6. Format procedural memory into string (no STM serialization here)
         try:


### PR DESCRIPTION
**What was found:**
In the LLM context manager pipeline, the `get_context()` function was inefficiently synchronizing its background fetches. Specifically, it grouped the slow `_fetch_short_term()` and the initial `_fetch_procedural(author_ids)` inside a single helper function (`_fetch_short_term_and_procedural`), which was then executed concurrently with `_fetch_episodic` and `_fetch_knowledge`. Because `_fetch_short_term()` is slow (often downloading attachments), it blocked the extraction of any `additional_ids` from those messages. Those additional procedural fetches were artificially delayed, waiting for the short-term fetch *and* the initial author procedural fetch to complete before even starting.

**Where it is:**
`llm/context_manager.py`, in the `ContextManager.get_context()` method, around lines 107-151.

**Why it matters:**
This architectural bottleneck increased the bot's overall latency. The procedural fetches for mentioned users (the `additional_ids`) were executed sequentially after the most I/O-heavy operation completed, extending the total time required to gather the necessary context before passing it to the LangChain agent.

**What was done:**
I flattened the nested `asyncio.gather` pattern by utilizing `asyncio.create_task`. Now:
1. `_fetch_episodic`, `_fetch_knowledge`, and the author's `_fetch_procedural` are immediately launched as background tasks.
2. The slow `_fetch_short_term` is awaited directly.
3. As soon as `_fetch_short_term` completes, `additional_ids` are extracted, and their procedural fetch is immediately dispatched as an additional background task.
4. Finally, all background tasks are awaited together. 

This ensures all independent I/O tasks start as early as possible, minimizing overall response latency.

---
*PR created automatically by Jules for task [13084750623431493097](https://jules.google.com/task/13084750623431493097) started by @starpig1129*