### PR TITLE
[Perf] Optimize parallel context pipeline with independent tasks

### DIFF
--- a/llm/context_manager.py
+++ b/llm/context_manager.py
@@ -104,51 +104,51 @@ class ContextManager:
                 _LOGGER.error("procedural_provider.get failed", exception=e)
                 return ProceduralMemory(user_info={})
 
-        async def _fetch_short_term_and_procedural() -> Tuple[List[BaseMessage], ProceduralMemory]:
-            # 1. Extract author ID to start their procedural memory fetch immediately
-            author_ids = []
-            try:
-                fallback_author_id = getattr(getattr(message, "author", None), "id", None)
-                if fallback_author_id is not None:
-                    author_ids.append(str(fallback_author_id))
-            except Exception:
-                pass
+        # 1. Start independent fetches immediately
+        episodic_task = asyncio.create_task(_fetch_episodic())
+        knowledge_task = asyncio.create_task(_fetch_knowledge())
 
-            # 2. Fetch short-term and author procedural in parallel
-            short_term_msgs, author_procedural = await asyncio.gather(
-                _fetch_short_term(),
-                _fetch_procedural(author_ids),
+        author_ids = []
+        try:
+            fallback_author_id = getattr(getattr(message, "author", None), "id", None)
+            if fallback_author_id is not None:
+                author_ids.append(str(fallback_author_id))
+        except Exception:
+            pass
+
+        author_procedural_task = asyncio.create_task(_fetch_procedural(author_ids))
+
+        # 2. Await short-term memory first, since it is the bottleneck
+        short_term_msgs = await _fetch_short_term()
+
+        # 3. Extract any additional user IDs from the fetched short-term messages
+        try:
+            extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
+        except Exception as e:
+            asyncio.create_task(
+                func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
             )
+            _LOGGER.error("extract_user_ids failed", exception=e)
+            extracted_ids = []
 
-            # 3. Extract any additional user IDs from the fetched short-term messages
-            try:
-                extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
-            except Exception as e:
-                asyncio.create_task(
-                    func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
-                )
-                _LOGGER.error("extract_user_ids failed", exception=e)
-                extracted_ids = []
+        # 4. Fetch procedural memory for any additional users concurrently with previous tasks
+        additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
+        additional_procedural_task = None
+        if additional_ids:
+            additional_procedural_task = asyncio.create_task(_fetch_procedural(additional_ids))
 
-            # 4. Fetch procedural memory for any additional users
-            additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
-            if additional_ids:
-                additional_procedural = await _fetch_procedural(additional_ids)
-                # Merge procedural memories
-                merged_info = dict(getattr(author_procedural, "user_info", {}))
-                merged_info.update(getattr(additional_procedural, "user_info", {}))
-                procedural_memory = ProceduralMemory(user_info=merged_info)
-            else:
-                procedural_memory = author_procedural
+        # 5. Await all pending tasks
+        author_procedural = await author_procedural_task
+        if additional_procedural_task:
+            additional_procedural = await additional_procedural_task
+            merged_info = dict(getattr(author_procedural, "user_info", {}))
+            merged_info.update(getattr(additional_procedural, "user_info", {}))
+            procedural_memory = ProceduralMemory(user_info=merged_info)
+        else:
+            procedural_memory = author_procedural
 
-            return short_term_msgs, procedural_memory
-
-        # 5. Fetch episodic, knowledge, and combined short-term/procedural memory in parallel
-        (short_term_msgs, procedural_memory), episodic_str, knowledge = await asyncio.gather(
-            _fetch_short_term_and_procedural(),
-            _fetch_episodic(),
-            _fetch_knowledge(),
-        )
+        episodic_str = await episodic_task
+        knowledge = await knowledge_task
 
         # 6. Format procedural memory into string (no STM serialization here)
         try:


### PR DESCRIPTION
1. **What was found**: The `ContextManager.get_context()` implementation grouped the slow `_fetch_short_term()` call together with the `_fetch_procedural()` call for the message author using `asyncio.gather()`. It then awaited this combined group *in parallel* with the episodic and knowledge fetches.
2. **Where it is**: `llm/context_manager.py` (specifically within the `get_context` method).
3. **Why it matters**: `_fetch_short_term()` makes Discord API calls and processes attachments, making it the slowest operation in the hot-path. Grouping it tightly with the author's procedural fetch meant that we couldn't parse the short-term results to extract *additional* mentioned users and fetch their procedural memory until the author's fetch also completed. Similarly, we artificially delayed starting the episodic and knowledge fetches until we entered the `gather` block. This resulted in an inefficient critical path.
4. **What was done**: Refactored `get_context()` to flatten the execution graph. Independent tasks (`episodic`, `knowledge`, `author_procedural`) are now started immediately using `asyncio.create_task`. The function then immediately `await`s the slow `_fetch_short_term()` operation. As soon as it returns, additional user IDs are extracted, and their procedural fetch is kicked off immediately, running concurrently alongside the other tasks. All remaining tasks are then cleanly awaited before returning the results, minimizing blocking and improving hot-path latency.

---
*PR created automatically by Jules for task [16321520961811717166](https://jules.google.com/task/16321520961811717166) started by @starpig1129*