### PR TITLE
[Perf] Remove artificial blocking latency in context pipeline

### DIFF
--- a/llm/context_manager.py
+++ b/llm/context_manager.py
@@ -104,51 +104,52 @@ class ContextManager:
                 _LOGGER.error("procedural_provider.get failed", exception=e)
                 return ProceduralMemory(user_info={})
 
-        async def _fetch_short_term_and_procedural() -> Tuple[List[BaseMessage], ProceduralMemory]:
-            # 1. Extract author ID to start their procedural memory fetch immediately
-            author_ids = []
-            try:
-                fallback_author_id = getattr(getattr(message, "author", None), "id", None)
-                if fallback_author_id is not None:
-                    author_ids.append(str(fallback_author_id))
-            except Exception:
-                pass
+        # 1. Start independent fetches immediately to maximize parallelism
+        episodic_task = asyncio.create_task(_fetch_episodic())
+        knowledge_task = asyncio.create_task(_fetch_knowledge())
 
-            # 2. Fetch short-term and author procedural in parallel
-            short_term_msgs, author_procedural = await asyncio.gather(
-                _fetch_short_term(),
-                _fetch_procedural(author_ids),
+        author_ids = []
+        try:
+            fallback_author_id = getattr(getattr(message, "author", None), "id", None)
+            if fallback_author_id is not None:
+                author_ids.append(str(fallback_author_id))
+        except Exception:
+            pass
+
+        author_procedural_task = asyncio.create_task(_fetch_procedural(author_ids))
+
+        # 2. Await short-term memory which is the slow path, blocking extraction of additional IDs
+        short_term_msgs = await _fetch_short_term()
+
+        # 3. Extract additional IDs
+        try:
+            extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
+        except Exception as e:
+            asyncio.create_task(
+                func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
             )
+            _LOGGER.error("extract_user_ids failed", exception=e)
+            extracted_ids = []
 
-            # 3. Extract any additional user IDs from the fetched short-term messages
-            try:
-                extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
-            except Exception as e:
-                asyncio.create_task(
-                    func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
-                )
-                _LOGGER.error("extract_user_ids failed", exception=e)
-                extracted_ids = []
+        additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
 
-            # 4. Fetch procedural memory for any additional users
-            additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
-            if additional_ids:
-                additional_procedural = await _fetch_procedural(additional_ids)
-                # Merge procedural memories
-                merged_info = dict(getattr(author_procedural, "user_info", {}))
-                merged_info.update(getattr(additional_procedural, "user_info", {}))
-                procedural_memory = ProceduralMemory(user_info=merged_info)
-            else:
-                procedural_memory = author_procedural
+        if additional_ids:
+            additional_procedural_task = asyncio.create_task(_fetch_procedural(additional_ids))
+        else:
+            additional_procedural_task = None
 
-            return short_term_msgs, procedural_memory
+        # 4. Await remaining tasks
+        episodic_str = await episodic_task
+        knowledge = await knowledge_task
+        author_procedural = await author_procedural_task
 
-        # 5. Fetch episodic, knowledge, and combined short-term/procedural memory in parallel
-        (short_term_msgs, procedural_memory), episodic_str, knowledge = await asyncio.gather(
-            _fetch_short_term_and_procedural(),
-            _fetch_episodic(),
-            _fetch_knowledge(),
-        )
+        if additional_procedural_task:
+            additional_procedural = await additional_procedural_task
+            merged_info = dict(getattr(author_procedural, "user_info", {}))
+            merged_info.update(getattr(additional_procedural, "user_info", {}))
+            procedural_memory = ProceduralMemory(user_info=merged_info)
+        else:
+            procedural_memory = author_procedural
 
         # 6. Format procedural memory into string (no STM serialization here)
         try:


### PR DESCRIPTION
1. **What was found:** `ContextManager.get_context` grouped `_fetch_short_term` and `_fetch_procedural(author_ids)` in a single `asyncio.gather`. This artificially coupled their execution, meaning extraction of `additional_ids` (and their subsequent background fetch) was blocked until *both* author procedural data and short-term messages were resolved. Since short term messages involve fetching message history and downloading attachments concurrently, they are often slower, but if author fetch is delayed it also blocked the short term.
2. **Where it is:** `llm/context_manager.py` inside the nested functions within `get_context`.
3. **Why it matters:** This sequential bottleneck unnecessarily increases the end-to-end latency before the full contextual prompt can be assembled for the LLM agents, slowing down the bot's reaction time. 
4. **What was done:** Refactored the method to create independent `asyncio.Task`s immediately for `episodic`, `knowledge`, and `author_procedural`. It then awaits `_fetch_short_term` to unblock ID extraction for any `additional_ids`. This minimizes blocking operations and allows tasks to execute truly concurrently. Tests confirm the logic changes do not break downstream functionality.

---
*PR created automatically by Jules for task [4448520360761975567](https://jules.google.com/task/4448520360761975567) started by @starpig1129*