### PR TITLE
[Privacy] Clear user episodic vectors on user data deletion

### DIFF
--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -1048,6 +1048,13 @@ class UserDataCog(commands.Cog):
                 except Exception as cache_err:
                     self.logger.warning(f"Failed to invalidate procedural cache for {user_id}: {cache_err}")
 
+                # explicitly delete the user's episodic vectors from the vector store
+                try:
+                    vector_manager = getattr(self.bot, "vector_manager", None)
+                    if vector_manager and hasattr(vector_manager, "store"):
+                        await vector_manager.store.delete_vectors_by_user(user_id)
+                except Exception as vec_err:
+                    self.logger.warning(f"Failed to delete episodic vectors for {user_id}: {vec_err}")
 
                 return self._translate(
                     guild_id,


### PR DESCRIPTION
**What was found:** The `/clear_user_data` command in `UserDataCog` successfully deleted a user's procedural profile (`SQLiteUserManager`) and invalidated the in-memory cache, but left their episodic vector memory fragments intact in the vector store.
**Where it is:** `cogs/userdata.py` inside the `_clear_user_data` method.
**Why it matters:** Leaving vector fragments behind creates a potential data privacy/GDPR compliance issue when a user explicitly requests to have their personalized memory cleared.
**What was done:** Explicitly invoked `vector_manager.store.delete_vectors_by_user(user_id)` inside a safe `try...except` block right after the procedural deletion completes. This cleans up their episodic presence without crashing the system if the vector store backend is temporarily unavailable or unsupported.

---
*PR created automatically by Jules for task [3473885657906533047](https://jules.google.com/task/3473885657906533047) started by @zi-yue-1129*