### PR TITLE
[Perf] Optimize parallel fetching in ContextManager

### DIFF
--- a/llm/context_manager.py
+++ b/llm/context_manager.py
@@ -104,51 +104,52 @@ class ContextManager:
                 _LOGGER.error("procedural_provider.get failed", exception=e)
                 return ProceduralMemory(user_info={})
 
-        async def _fetch_short_term_and_procedural() -> Tuple[List[BaseMessage], ProceduralMemory]:
-            # 1. Extract author ID to start their procedural memory fetch immediately
-            author_ids = []
-            try:
-                fallback_author_id = getattr(getattr(message, "author", None), "id", None)
-                if fallback_author_id is not None:
-                    author_ids.append(str(fallback_author_id))
-            except Exception:
-                pass
+        # 1. Start independent fetches immediately
+        episodic_task = asyncio.create_task(_fetch_episodic())
+        knowledge_task = asyncio.create_task(_fetch_knowledge())
 
-            # 2. Fetch short-term and author procedural in parallel
-            short_term_msgs, author_procedural = await asyncio.gather(
-                _fetch_short_term(),
-                _fetch_procedural(author_ids),
+        author_ids = []
+        try:
+            fallback_author_id = getattr(getattr(message, "author", None), "id", None)
+            if fallback_author_id is not None:
+                author_ids.append(str(fallback_author_id))
+        except Exception:
+            pass
+
+        author_procedural_task = asyncio.create_task(_fetch_procedural(author_ids))
+
+        # 2. Await the slow short-term memory fetch (I/O bound with attachments)
+        short_term_msgs = await _fetch_short_term()
+
+        # 3. Extract any additional user IDs from the fetched short-term messages
+        try:
+            extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
+        except Exception as e:
+            asyncio.create_task(
+                func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
             )
+            _LOGGER.error("extract_user_ids failed", exception=e)
+            extracted_ids = []
 
-            # 3. Extract any additional user IDs from the fetched short-term messages
-            try:
-                extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
-            except Exception as e:
-                asyncio.create_task(
-                    func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
-                )
-                _LOGGER.error("extract_user_ids failed", exception=e)
-                extracted_ids = []
+        # 4. Start procedural memory fetch for any additional users
+        additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
+        additional_procedural_task = None
+        if additional_ids:
+            additional_procedural_task = asyncio.create_task(_fetch_procedural(additional_ids))
 
-            # 4. Fetch procedural memory for any additional users
-            additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
-            if additional_ids:
-                additional_procedural = await _fetch_procedural(additional_ids)
-                # Merge procedural memories
-                merged_info = dict(getattr(author_procedural, "user_info", {}))
-                merged_info.update(getattr(additional_procedural, "user_info", {}))
-                procedural_memory = ProceduralMemory(user_info=merged_info)
-            else:
-                procedural_memory = author_procedural
+        # 5. Await remaining parallel tasks
+        author_procedural = await author_procedural_task
+        if additional_procedural_task:
+            additional_procedural = await additional_procedural_task
+            # Merge procedural memories
+            merged_info = dict(getattr(author_procedural, "user_info", {}))
+            merged_info.update(getattr(additional_procedural, "user_info", {}))
+            procedural_memory = ProceduralMemory(user_info=merged_info)
+        else:
+            procedural_memory = author_procedural
 
-            return short_term_msgs, procedural_memory
-
-        # 5. Fetch episodic, knowledge, and combined short-term/procedural memory in parallel
-        (short_term_msgs, procedural_memory), episodic_str, knowledge = await asyncio.gather(
-            _fetch_short_term_and_procedural(),
-            _fetch_episodic(),
-            _fetch_knowledge(),
-        )
+        episodic_str = await episodic_task
+        knowledge = await knowledge_task
 
         # 6. Format procedural memory into string (no STM serialization here)
         try:


### PR DESCRIPTION
**What was found:**
In `llm/context_manager.py`, the `ContextManager.get_context()` method was fetching procedural memory and short-term memory for the author using a nested `asyncio.gather()` block (`_fetch_short_term_and_procedural`). 

**Where it is:**
File `llm/context_manager.py`, specifically lines ~107-151 where the `_fetch_short_term_and_procedural()` function was defined and awaited.

**Why it matters:**
This structure created a strict sequential barrier. Extracting additional user IDs from `short_term_msgs` was blocked until the *author's* procedural memory fetch also completely finished. Furthermore, the overall gather (`_fetch_short_term_and_procedural`, `_fetch_episodic`, `_fetch_knowledge`) delayed the start of the additional users' procedural fetch unnecessarily and artificially tied the completion times of completely independent fetches together, increasing overall bot latency for multi-user context parsing.

**What was done:**
Refactored the method to use `asyncio.create_task()` to flatten the task execution flow. Independent fetches (`episodic`, `knowledge`, and `procedural` for the author) start immediately. The slow `short_term` fetch is explicitly awaited first. Once short-term messages are available, any extracted additional user IDs trigger their own procedural memory fetches as background tasks. Finally, all pending parallel tasks are independently awaited and merged, dramatically reducing overall pipeline latency.

---
*PR created automatically by Jules for task [6013824492361593262](https://jules.google.com/task/6013824492361593262) started by @zi-yue-1129*