### PR TITLE
[Fix] Delete episodic memory vectors when clearing user data

### DIFF
--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -1048,6 +1048,13 @@ class UserDataCog(commands.Cog):
                 except Exception as cache_err:
                     self.logger.warning(f"Failed to invalidate procedural cache for {user_id}: {cache_err}")
 
+                # Delete episodic memory vectors
+                try:
+                    vector_manager = getattr(self.bot, "vector_manager", None)
+                    if vector_manager and hasattr(vector_manager, "store"):
+                        await vector_manager.store.delete_vectors_by_user(str(user_id))
+                except Exception as vector_err:
+                    self.logger.warning(f"Failed to delete episodic memory vectors for {user_id}: {vector_err}")
 
                 return self._translate(
                     guild_id,


### PR DESCRIPTION
1. **What was found**: `UserDataCog._clear_user_data` did not delete episodic memory vectors when clearing user data. It only deleted procedural user data from SQLite.
2. **Where it is**: `cogs/userdata.py`, around line 1045 inside `_clear_user_data`.
3. **Why it matters**: Data privacy compliance is critical. If episodic vectors are not deleted, deleted users' conversational segments may persist and be searchable in the Qdrant store.
4. **What was done**: Added defensive logic to fetch `self.bot.vector_manager.store` and call `await store.delete_vectors_by_user(user_id)`. Wrapped it in a `try...except` to prevent failing the entire function if `vector_manager` is not available or if the database fails to respond.

---
*PR created automatically by Jules for task [9678849595947178273](https://jules.google.com/task/9678849595947178273) started by @zi-yue-1129*