### PR TITLE
[Security] Fix unauthorized channel personality modification bypass

### DIFF
--- a/cogs/system_prompt/commands.py
+++ b/cogs/system_prompt/commands.py
@@ -217,13 +217,21 @@ class SystemPromptCommands(commands.Cog):
         user_id = str(interaction.user.id)
         scope_value = scope.value
 
-        # Permission check for server scope
+        # Permission check for server and channel scope
+        from .permissions import PermissionValidator
+        validator = PermissionValidator(self.bot)
+
         if scope_value == "server":
-            from .permissions import PermissionValidator
-            validator = PermissionValidator(self.bot)
             if not validator.can_modify_server_prompt(interaction.user, interaction.guild):
                 await interaction.followup.send(
                     "❌ You need administrator permissions to modify the server-level personality.",
+                    ephemeral=True,
+                )
+                return
+        else:
+            if not validator.can_modify_channel_prompt(interaction.user, interaction.channel):
+                await interaction.followup.send(
+                    "❌ You do not have permission to modify the channel-level personality.",
                     ephemeral=True,
                 )
                 return

--- a/llm/tools/system_prompt_tools.py
+++ b/llm/tools/system_prompt_tools.py
@@ -100,8 +100,9 @@ class SystemPromptTools:
                 merged_prompt: The complete merged system prompt text — your current
                     personality with the requested changes incorporated. Must be a
                     full system prompt, not just the changed part.
-                scope: "channel" applies only to the current channel (any user may
-                    do this). "server" applies to the entire server (admin only).
+                scope: "channel" applies only to the current channel (requires
+                    channel manage permission). "server" applies to the entire
+                    server (admin only).
 
             Returns:
                 Confirmation message or an error description.
@@ -122,13 +123,20 @@ class SystemPromptTools:
             user_id = str(author.id)
             bot = getattr(runtime, "bot", None)
 
+            from cogs.system_prompt.permissions import PermissionValidator
+            validator = PermissionValidator(bot)
+
             if scope == "server":
-                from cogs.system_prompt.permissions import PermissionValidator
-                validator = PermissionValidator(bot)
                 if not validator.can_modify_server_prompt(author, guild):
                     return (
                         "Error: You need administrator permissions to modify the "
                         "server-level personality."
+                    )
+            else:
+                if not validator.can_modify_channel_prompt(author, channel):
+                    return (
+                        "Error: You do not have permission to modify the "
+                        "channel-level personality."
                     )
 
             return await write_personality(guild_id, channel_id, merged_prompt, scope, bot, user_id)


### PR DESCRIPTION
1. **What was found**: The `set_personality` command (in `cogs/system_prompt/commands.py`) and the `update_personality` LangChain tool (in `llm/tools/system_prompt_tools.py`) were silently lacking permission checks when users specified `scope="channel"`.
2. **Where it is**: `cogs/system_prompt/commands.py` (lines 217-234) and `llm/tools/system_prompt_tools.py` (lines 126-140).
3. **Why it matters**: A malicious Discord user could exploit this to execute prompt injections or manipulate the bot's core rules and logic within a given channel by simply requesting a channel-level personality change, bypassing intended administration boundaries.
4. **What was done**: Added explicit checks utilizing `PermissionValidator(bot).can_modify_channel_prompt(user, channel)` to strictly enforce access controls for channel-level scope changes in both the slash command and the automated LLM tool. The tool docstring was also updated to reflect this limitation to the LLM agent. Tests in `test_system_prompt_tools.py` have been verified.

---
*PR created automatically by Jules for task [5149095936578439074](https://jules.google.com/task/5149095936578439074) started by @zi-yue-1129*