### PR TITLE
[UX] Fix hanging Thinking state in channel manager admin commands

### DIFF
--- a/cogs/channel_manager.py
+++ b/cogs/channel_manager.py
@@ -91,7 +91,7 @@ class ChannelManager(commands.Cog):
             error_message = "You do not have permission to perform this action. Restricted to administrators."
         
         if interaction.response.is_done():
-            await interaction.followup.send(error_message, ephemeral=True)
+            await interaction.edit_original_response(content=error_message)
         else:
             await interaction.response.send_message(error_message, ephemeral=True)
         return False
@@ -122,7 +122,7 @@ class ChannelManager(commands.Cog):
         else:
             response = f"Set **Server-wide** response mode to: {mode.name}"
 
-        await interaction.followup.send(response, ephemeral=True)
+        await interaction.edit_original_response(content=response)
 
     @app_commands.command(name="set_channel_mode", description="Set a special mode for a specific channel (e.g., Story Mode)")
     @app_commands.describe(channel="The channel to set", mode="The mode to set for this channel")
@@ -168,7 +168,7 @@ class ChannelManager(commands.Cog):
                 message = f"Set mode for {channel.mention} to: **{mode.name}**."
 
         self.save_config(guild_id, config)
-        await interaction.followup.send(message, ephemeral=True)
+        await interaction.edit_original_response(content=message)
 
     @app_commands.command(name="add_channel", description="Add channel to whitelist or blacklist")
     @app_commands.choices(list_type=[
@@ -202,7 +202,7 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"Added <#{channel_id}> to {list_type_name}"
             
-            await interaction.followup.send(success_message, ephemeral=True)
+            await interaction.edit_original_response(content=success_message)
         else:
             if self.lang_manager:
                 exists_message = self.lang_manager.translate(
@@ -211,7 +211,7 @@ class ChannelManager(commands.Cog):
             else:
                 exists_message = f"<#{channel_id}> already exists in {list_type_name}"
             
-            await interaction.followup.send(exists_message, ephemeral=True)
+            await interaction.edit_original_response(content=exists_message)
 
     @app_commands.command(name="remove_channel", description="Remove channel from whitelist or blacklist")
     @app_commands.choices(list_type=[
@@ -245,7 +245,7 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"Removed <#{channel_id}> from {list_type_name}"
             
-            await interaction.followup.send(success_message, ephemeral=True)
+            await interaction.edit_original_response(content=success_message)
         else:
             if self.lang_manager:
                 not_found_message = self.lang_manager.translate(
@@ -254,7 +254,7 @@ class ChannelManager(commands.Cog):
             else:
                 not_found_message = f"<#{channel_id}> does not exist in {list_type_name}"
             
-            await interaction.followup.send(not_found_message, ephemeral=True)
+            await interaction.edit_original_response(content=not_found_message)
 
     @app_commands.command(name="auto_response", description="Set channel auto-response")
     async def auto_response_command(self, interaction: discord.Interaction, channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread], enabled: bool):
@@ -275,7 +275,7 @@ class ChannelManager(commands.Cog):
         else:
             success_message = f"Set auto-response for <#{channel_id}> to: {enabled}"
         
-        await interaction.followup.send(success_message, ephemeral=True)
+        await interaction.edit_original_response(content=success_message)
 
     def is_allowed_channel(self, channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread], guild_id: str) -> Tuple[bool, bool, Optional[str]]:
         """


### PR DESCRIPTION
**What was found**
In `cogs/channel_manager.py`, several admin slash commands (`set_server_mode`, `set_channel_mode`, `add_channel_command`, `remove_channel_command`, `auto_response_command`) use `await self.check_admin_permissions(interaction, defer=True)`. This permission check uses `await interaction.response.defer(ephemeral=True, thinking=True)` to place the bot in a "Thinking..." state. Later, the commands respond using `await interaction.followup.send(..., ephemeral=True)`.

**Where it is**
`cogs/channel_manager.py` (Lines 94, 125, 171, 205, 214, 248, 257, 278).

**Why it matters**
When a discord.py interaction is deferred with `thinking=True`, using `interaction.followup.send()` creates a new message but leaves the original "bot is thinking..." message hanging indefinitely in the channel UI. This is a confusing UX friction point because users see the bot as permanently processing the command, even though it already responded.

**What was done**
Replaced the `interaction.followup.send(..., ephemeral=True)` calls with `interaction.edit_original_response(content=...)`. `edit_original_response` correctly updates the initial "Thinking..." message to the final content without requiring the `ephemeral` flag (since the ephemeral state is inherited from the initial `defer()` call). This cleanly resolves the thinking state and provides accurate feedback to the user.

---
*PR created automatically by Jules for task [6096281862482524464](https://jules.google.com/task/6096281862482524464) started by @zi-yue-1129*