### PR TITLE
[Perf] Optimize latency by maximizing concurrent fetching in ContextManager

### DIFF
--- a/llm/context_manager.py
+++ b/llm/context_manager.py
@@ -104,51 +104,51 @@ class ContextManager:
                 _LOGGER.error("procedural_provider.get failed", exception=e)
                 return ProceduralMemory(user_info={})
 
-        async def _fetch_short_term_and_procedural() -> Tuple[List[BaseMessage], ProceduralMemory]:
-            # 1. Extract author ID to start their procedural memory fetch immediately
-            author_ids = []
-            try:
-                fallback_author_id = getattr(getattr(message, "author", None), "id", None)
-                if fallback_author_id is not None:
-                    author_ids.append(str(fallback_author_id))
-            except Exception:
-                pass
+        # Start independent background tasks immediately
+        episodic_task = asyncio.create_task(_fetch_episodic())
+        knowledge_task = asyncio.create_task(_fetch_knowledge())
 
-            # 2. Fetch short-term and author procedural in parallel
-            short_term_msgs, author_procedural = await asyncio.gather(
-                _fetch_short_term(),
-                _fetch_procedural(author_ids),
+        author_ids = []
+        try:
+            fallback_author_id = getattr(getattr(message, "author", None), "id", None)
+            if fallback_author_id is not None:
+                author_ids.append(str(fallback_author_id))
+        except Exception:
+            pass
+
+        author_procedural_task = asyncio.create_task(_fetch_procedural(author_ids))
+
+        # Await the slow short-term fetch first
+        short_term_msgs = await _fetch_short_term()
+
+        # Extract any additional user IDs from the fetched short-term messages
+        try:
+            extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
+        except Exception as e:
+            asyncio.create_task(
+                func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
             )
+            _LOGGER.error("extract_user_ids failed", exception=e)
+            extracted_ids = []
 
-            # 3. Extract any additional user IDs from the fetched short-term messages
-            try:
-                extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
-            except Exception as e:
-                asyncio.create_task(
-                    func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
-                )
-                _LOGGER.error("extract_user_ids failed", exception=e)
-                extracted_ids = []
+        additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
+        additional_procedural_task = None
+        if additional_ids:
+            additional_procedural_task = asyncio.create_task(_fetch_procedural(additional_ids))
 
-            # 4. Fetch procedural memory for any additional users
-            additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
-            if additional_ids:
-                additional_procedural = await _fetch_procedural(additional_ids)
-                # Merge procedural memories
-                merged_info = dict(getattr(author_procedural, "user_info", {}))
-                merged_info.update(getattr(additional_procedural, "user_info", {}))
-                procedural_memory = ProceduralMemory(user_info=merged_info)
-            else:
-                procedural_memory = author_procedural
+        # Await remaining tasks
+        author_procedural = await author_procedural_task
 
-            return short_term_msgs, procedural_memory
+        if additional_procedural_task:
+            additional_procedural = await additional_procedural_task
+            merged_info = dict(getattr(author_procedural, "user_info", {}))
+            merged_info.update(getattr(additional_procedural, "user_info", {}))
+            procedural_memory = ProceduralMemory(user_info=merged_info)
+        else:
+            procedural_memory = author_procedural
 
-        # 5. Fetch episodic, knowledge, and combined short-term/procedural memory in parallel
-        (short_term_msgs, procedural_memory), episodic_str, knowledge = await asyncio.gather(
-            _fetch_short_term_and_procedural(),
-            _fetch_episodic(),
-            _fetch_knowledge(),
-        )
+        episodic_str = await episodic_task
+        knowledge = await knowledge_task
 
         # 6. Format procedural memory into string (no STM serialization here)
         try:


### PR DESCRIPTION
**What was found:**
In `llm/context_manager.py`, the `ContextManager.get_context()` pipeline used `asyncio.gather` blocks that caused unnecessary sequential waiting. Specifically, the system awaited the short-term memory fetch and the author's procedural memory fetch simultaneously, but blocked the extraction of additional user IDs from the short-term memory until the author's procedural memory fetch completed. 

**Where it is:**
`llm/context_manager.py` (lines 107-152)

**Why it matters:**
This creates a synthetic latency bottleneck in the hottest path of the application (message processing). If the author's procedural memory fetch takes longer than the short-term memory fetch, the processing of the short-term memory (and the subsequent fetch of additional user procedural memory) is artificially delayed, increasing overall time-to-response for end users.

**What was done:**
Refactored the execution flow in `ContextManager.get_context()` to use `asyncio.create_task()` for all independent background fetches (`episodic_task`, `knowledge_task`, and `author_procedural_task`). The system now immediately awaits the slow `_fetch_short_term()` directly. Once short-term memory is retrieved, it extracts the additional user IDs and immediately spawns the `additional_procedural_task` if needed. It then awaits the remaining tasks, guaranteeing the absolute minimum wall-clock time for context resolution.

---
*PR created automatically by Jules for task [16233489100461753644](https://jules.google.com/task/16233489100461753644) started by @zi-yue-1129*