### PR TITLE
[Security] Fix missing permission check for channel prompt modification

### DIFF
--- a/llm/tools/system_prompt_tools.py
+++ b/llm/tools/system_prompt_tools.py
@@ -122,13 +122,20 @@ class SystemPromptTools:
             user_id = str(author.id)
             bot = getattr(runtime, "bot", None)
 
+            from cogs.system_prompt.permissions import PermissionValidator
+            validator = PermissionValidator(bot)
+
             if scope == "server":
-                from cogs.system_prompt.permissions import PermissionValidator
-                validator = PermissionValidator(bot)
                 if not validator.can_modify_server_prompt(author, guild):
                     return (
                         "Error: You need administrator permissions to modify the "
                         "server-level personality."
+                    )
+            else:
+                if not validator.can_modify_channel_prompt(author, channel):
+                    return (
+                        "Error: You do not have permission to modify the "
+                        "channel-level personality."
                     )
 
             return await write_personality(guild_id, channel_id, merged_prompt, scope, bot, user_id)

--- a/tests/test_system_prompt_tools.py
+++ b/tests/test_system_prompt_tools.py
@@ -140,7 +140,7 @@ class TestUpdatePersonalityChannel:
         self.tool = SystemPromptTools(self.runtime).get_tools()[0]
 
     def test_calls_set_channel_prompt_with_correct_args(self):
-        asyncio.get_event_loop().run_until_complete(
+        asyncio.run(
             self.tool.coroutine(merged_prompt="Be funny.", scope="channel")
         )
         self.mock_manager.set_channel_prompt.assert_called_once_with(
@@ -148,13 +148,13 @@ class TestUpdatePersonalityChannel:
         )
 
     def test_returns_success_message(self):
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             self.tool.coroutine(merged_prompt="Be funny.", scope="channel")
         )
         assert "success" in result.lower() or "updated" in result.lower()
 
     def test_invalidates_cache_after_write(self):
-        asyncio.get_event_loop().run_until_complete(
+        asyncio.run(
             self.tool.coroutine(merged_prompt="Be funny.", scope="channel")
         )
         self.mock_manager.cache.invalidate.assert_called()
@@ -169,7 +169,7 @@ class TestUpdatePersonalityServer:
     def test_blocks_non_admin_from_server_scope(self):
         with patch("cogs.system_prompt.permissions.PermissionValidator") as MockV:
             MockV.return_value.can_modify_server_prompt.return_value = False
-            result = asyncio.get_event_loop().run_until_complete(
+            result = asyncio.run(
                 self.tool.coroutine(merged_prompt="...", scope="server")
             )
         assert "permission" in result.lower() or "administrator" in result.lower()
@@ -177,7 +177,7 @@ class TestUpdatePersonalityServer:
     def test_allows_admin_to_set_server_scope(self):
         with patch("cogs.system_prompt.permissions.PermissionValidator") as MockV:
             MockV.return_value.can_modify_server_prompt.return_value = True
-            result = asyncio.get_event_loop().run_until_complete(
+            result = asyncio.run(
                 self.tool.coroutine(merged_prompt="Be formal.", scope="server")
             )
         self.mock_manager.set_server_prompt.assert_called_once_with(
@@ -192,7 +192,7 @@ class TestUpdatePersonalityErrors:
         mock_bot.get_cog.return_value = None
         runtime = _make_runtime(bot=mock_bot)
         tool = SystemPromptTools(runtime).get_tools()[0]
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             tool.coroutine(merged_prompt="...", scope="channel")
         )
         assert "error" in result.lower()
@@ -201,7 +201,7 @@ class TestUpdatePersonalityErrors:
         runtime = MagicMock()
         runtime.message = None
         tool = SystemPromptTools(runtime).get_tools()[0]
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             tool.coroutine(merged_prompt="...", scope="channel")
         )
         assert "error" in result.lower()


### PR DESCRIPTION
1. **What**: The LangChain tool `update_personality` lacked a permission check when updating the channel-level system prompt (`scope == "channel"`).
2. **Where**: In `llm/tools/system_prompt_tools.py`, specifically inside the `update_personality` function.
3. **Why**: Without this check, any user interacting with the AI could instruct it to modify the system prompt for the channel, resulting in a severe prompt injection and privilege escalation vulnerability where the bot's core persona could be maliciously hijacked by unauthorized users.
4. **What was done**: I modified `llm/tools/system_prompt_tools.py` to instantiate the `PermissionValidator` for both scopes and explicitly invoke `validator.can_modify_channel_prompt(author, channel)` for the `channel` scope, returning an error message if the user lacks the proper permissions. I also updated the tests (`tests/test_system_prompt_tools.py`) to correctly use `asyncio.run()` avoiding `RuntimeError: There is no current event loop` and ensuring the suite runs safely.

---
*PR created automatically by Jules for task [14740119956906972109](https://jules.google.com/task/14740119956906972109) started by @zi-yue-1129*