### PR TITLE
[Privacy] Ensure episodic memories are deleted when user clears data

### DIFF
--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -1033,6 +1033,16 @@ class UserDataCog(commands.Cog):
                 )
 
             success = await self.user_manager.delete_user_data(user_id)
+
+            # Also delete episodic memory vectors for privacy compliance
+            try:
+                vector_manager = getattr(self.bot, "vector_manager", None)
+                if vector_manager and hasattr(vector_manager, "store"):
+                    await vector_manager.store.delete_vectors_by_user(user_id)
+                    self.logger.info(f"Cleared episodic memory vectors for user {user_id}")
+            except Exception as vector_err:
+                self.logger.warning(f"Failed to clear episodic memory vectors for user {user_id}: {vector_err}")
+
             if success:
                 # Invalidate ProceduralMemoryProvider cache
                 try:


### PR DESCRIPTION
**What was found:** When a user executes the `/memory clear` command, the bot successfully deletes their procedural memory from SQLite (`user_manager.delete_user_data`), but it does not delete their episodic memories (vector embeddings stored via `QdrantStore`).

**Where it is:** `cogs/userdata.py` inside `UserDataCog._clear_user_data` (around line 1030).

**Why it matters:** This is a data privacy and compliance issue. If a user explicitly requests the bot to "forget everything" about them, leaving their conversation vectors embedded and retrievable in the vector store violates their intent and exposes private data to future context injections.

**What was done:** I modified the `UserDataCog._clear_user_data` function to safely check for the existence of `bot.vector_manager` and its underlying `store`, and then call `await bot.vector_manager.store.delete_vectors_by_user(user_id)`. This ensures that both relational and vector data are purged, maintaining proper data privacy compliance. The call is wrapped in a dedicated `try/except` block to ensure failures in vector deletion only log a warning and do not halt the overall data deletion process.

---
*PR created automatically by Jules for task [10969540340858239459](https://jules.google.com/task/10969540340858239459) started by @zi-yue-1129*