### PR TITLE
[UX] Fix hanging Thinking state in ChannelManager commands

### DIFF
--- a/cogs/channel_manager.py
+++ b/cogs/channel_manager.py
@@ -91,7 +91,10 @@ class ChannelManager(commands.Cog):
             error_message = "You do not have permission to perform this action. Restricted to administrators."
         
         if interaction.response.is_done():
-            await interaction.followup.send(error_message, ephemeral=True)
+            try:
+                await interaction.edit_original_response(content=error_message, embeds=[], attachments=[])
+            except discord.NotFound:
+                await interaction.followup.send(error_message, ephemeral=True)
         else:
             await interaction.response.send_message(error_message, ephemeral=True)
         return False
@@ -122,7 +125,10 @@ class ChannelManager(commands.Cog):
         else:
             response = f"Set **Server-wide** response mode to: {mode.name}"
 
-        await interaction.followup.send(response, ephemeral=True)
+        try:
+            await interaction.edit_original_response(content=response, embeds=[], attachments=[])
+        except discord.NotFound:
+            await interaction.followup.send(response, ephemeral=True)
 
     @app_commands.command(name="set_channel_mode", description="Set a special mode for a specific channel (e.g., Story Mode)")
     @app_commands.describe(channel="The channel to set", mode="The mode to set for this channel")
@@ -168,7 +174,10 @@ class ChannelManager(commands.Cog):
                 message = f"Set mode for {channel.mention} to: **{mode.name}**."
 
         self.save_config(guild_id, config)
-        await interaction.followup.send(message, ephemeral=True)
+        try:
+            await interaction.edit_original_response(content=message, embeds=[], attachments=[])
+        except discord.NotFound:
+            await interaction.followup.send(message, ephemeral=True)
 
     @app_commands.command(name="add_channel", description="Add channel to whitelist or blacklist")
     @app_commands.choices(list_type=[
@@ -202,7 +211,10 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"Added <#{channel_id}> to {list_type_name}"
             
-            await interaction.followup.send(success_message, ephemeral=True)
+            try:
+                await interaction.edit_original_response(content=success_message, embeds=[], attachments=[])
+            except discord.NotFound:
+                await interaction.followup.send(success_message, ephemeral=True)
         else:
             if self.lang_manager:
                 exists_message = self.lang_manager.translate(
@@ -211,7 +223,10 @@ class ChannelManager(commands.Cog):
             else:
                 exists_message = f"<#{channel_id}> already exists in {list_type_name}"
             
-            await interaction.followup.send(exists_message, ephemeral=True)
+            try:
+                await interaction.edit_original_response(content=exists_message, embeds=[], attachments=[])
+            except discord.NotFound:
+                await interaction.followup.send(exists_message, ephemeral=True)
 
     @app_commands.command(name="remove_channel", description="Remove channel from whitelist or blacklist")
     @app_commands.choices(list_type=[
@@ -245,7 +260,10 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"Removed <#{channel_id}> from {list_type_name}"
             
-            await interaction.followup.send(success_message, ephemeral=True)
+            try:
+                await interaction.edit_original_response(content=success_message, embeds=[], attachments=[])
+            except discord.NotFound:
+                await interaction.followup.send(success_message, ephemeral=True)
         else:
             if self.lang_manager:
                 not_found_message = self.lang_manager.translate(
@@ -254,7 +272,10 @@ class ChannelManager(commands.Cog):
             else:
                 not_found_message = f"<#{channel_id}> does not exist in {list_type_name}"
             
-            await interaction.followup.send(not_found_message, ephemeral=True)
+            try:
+                await interaction.edit_original_response(content=not_found_message, embeds=[], attachments=[])
+            except discord.NotFound:
+                await interaction.followup.send(not_found_message, ephemeral=True)
 
     @app_commands.command(name="auto_response", description="Set channel auto-response")
     async def auto_response_command(self, interaction: discord.Interaction, channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread], enabled: bool):
@@ -275,7 +296,10 @@ class ChannelManager(commands.Cog):
         else:
             success_message = f"Set auto-response for <#{channel_id}> to: {enabled}"
         
-        await interaction.followup.send(success_message, ephemeral=True)
+        try:
+            await interaction.edit_original_response(content=success_message, embeds=[], attachments=[])
+        except discord.NotFound:
+            await interaction.followup.send(success_message, ephemeral=True)
 
     def is_allowed_channel(self, channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread], guild_id: str) -> Tuple[bool, bool, Optional[str]]:
         """


### PR DESCRIPTION
**What was found:** 
When slash commands in `cogs/channel_manager.py` (like `/set_server_mode`, `/add_channel`, etc.) are executed, they defer the interaction to show a "Bot is thinking..." state while performing checks and operations. However, they previously resolved this state using `await interaction.followup.send()`, which creates a new message but often leaves the original "Thinking..." message hanging indefinitely in the Discord client.

**Where it is:** 
`cogs/channel_manager.py` in `check_admin_permissions` and all command handlers (`set_server_mode`, `set_channel_mode`, `add_channel_command`, `remove_channel_command`, `auto_response_command`).

**Why it matters:** 
A hanging "Bot is thinking..." message causes significant user confusion, making them think the bot is stuck, crashed, or still processing the request even after it has completed. This was identified as a major, high-frequency UX friction point.

**What was done:** 
Replaced `interaction.followup.send` with a robust `try...except` block that attempts to use `await interaction.edit_original_response(content=...)`. This correctly overwrites the initial "Thinking..." loading state. If `discord.NotFound` is caught (e.g., if the original interaction expired or was deleted before the edit could happen), it safely falls back to `await interaction.followup.send(...)`. This pattern was applied consistently across all command handlers in the cog.

---
*PR created automatically by Jules for task [2332384597400567358](https://jules.google.com/task/2332384597400567358) started by @zi-yue-1129*