### PR TITLE
[Perf] Optimize ContextManager pipeline with task-based concurrency

### DIFF
--- a/llm/context_manager.py
+++ b/llm/context_manager.py
@@ -104,51 +104,52 @@ class ContextManager:
                 _LOGGER.error("procedural_provider.get failed", exception=e)
                 return ProceduralMemory(user_info={})
 
-        async def _fetch_short_term_and_procedural() -> Tuple[List[BaseMessage], ProceduralMemory]:
-            # 1. Extract author ID to start their procedural memory fetch immediately
-            author_ids = []
-            try:
-                fallback_author_id = getattr(getattr(message, "author", None), "id", None)
-                if fallback_author_id is not None:
-                    author_ids.append(str(fallback_author_id))
-            except Exception:
-                pass
+        # 1. Start independent background fetches immediately
+        episodic_task = asyncio.create_task(_fetch_episodic())
+        knowledge_task = asyncio.create_task(_fetch_knowledge())
 
-            # 2. Fetch short-term and author procedural in parallel
-            short_term_msgs, author_procedural = await asyncio.gather(
-                _fetch_short_term(),
-                _fetch_procedural(author_ids),
+        # 2. Extract author ID and start its fetch
+        author_ids = []
+        try:
+            fallback_author_id = getattr(getattr(message, "author", None), "id", None)
+            if fallback_author_id is not None:
+                author_ids.append(str(fallback_author_id))
+        except Exception:
+            pass
+        author_procedural_task = asyncio.create_task(_fetch_procedural(author_ids))
+
+        # 3. Await the slow short-term memory fetch FIRST
+        short_term_msgs = await _fetch_short_term()
+
+        # 4. Once short-term is ready, quickly extract additional IDs
+        try:
+            extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
+        except Exception as e:
+            asyncio.create_task(
+                func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
             )
+            _LOGGER.error("extract_user_ids failed", exception=e)
+            extracted_ids = []
 
-            # 3. Extract any additional user IDs from the fetched short-term messages
-            try:
-                extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
-            except Exception as e:
-                asyncio.create_task(
-                    func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
-                )
-                _LOGGER.error("extract_user_ids failed", exception=e)
-                extracted_ids = []
+        additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
 
-            # 4. Fetch procedural memory for any additional users
-            additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
-            if additional_ids:
-                additional_procedural = await _fetch_procedural(additional_ids)
-                # Merge procedural memories
-                merged_info = dict(getattr(author_procedural, "user_info", {}))
-                merged_info.update(getattr(additional_procedural, "user_info", {}))
-                procedural_memory = ProceduralMemory(user_info=merged_info)
-            else:
-                procedural_memory = author_procedural
+        # 5. Start additional procedural fetch if needed
+        additional_procedural_task = None
+        if additional_ids:
+            additional_procedural_task = asyncio.create_task(_fetch_procedural(additional_ids))
 
-            return short_term_msgs, procedural_memory
+        # 6. Await all pending tasks concurrently
+        author_procedural = await author_procedural_task
+        episodic_str = await episodic_task
+        knowledge = await knowledge_task
 
-        # 5. Fetch episodic, knowledge, and combined short-term/procedural memory in parallel
-        (short_term_msgs, procedural_memory), episodic_str, knowledge = await asyncio.gather(
-            _fetch_short_term_and_procedural(),
-            _fetch_episodic(),
-            _fetch_knowledge(),
-        )
+        if additional_procedural_task:
+            additional_procedural = await additional_procedural_task
+            merged_info = dict(getattr(author_procedural, "user_info", {}))
+            merged_info.update(getattr(additional_procedural, "user_info", {}))
+            procedural_memory = ProceduralMemory(user_info=merged_info)
+        else:
+            procedural_memory = author_procedural
 
         # 6. Format procedural memory into string (no STM serialization here)
         try:


### PR DESCRIPTION
1. **What was found:** The `ContextManager.get_context()` pipeline used nested blocking `asyncio.gather()` calls. It waited for both the slow short-term memory fetch and the author's procedural memory fetch to complete before it extracted any additional user IDs and fetched their procedural memory. 
2. **Where it is:** `llm/context_manager.py` lines ~107-152 (`_fetch_short_term_and_procedural` block).
3. **Why it matters:** This created an artificial concurrency barrier. If the author's DB fetch took longer than the Discord I/O to fetch short-term memory (or vice versa), the subsequent extraction and fetching of other users' data was unnecessarily delayed, adding linear latency to the bot's response time for every message.
4. **What was done:** Refactored the control flow to use `asyncio.create_task`. `episodic`, `knowledge`, and the author's `procedural` fetches are launched instantly. The pipeline then awaits only the `short-term` fetch first. The instant short-term memory is ready, additional user IDs are extracted and their fetches begin, completely independent of whether the other background tasks have finished. All tasks are then awaited concurrently at the end.

---
*PR created automatically by Jules for task [287450419335953730](https://jules.google.com/task/287450419335953730) started by @zi-yue-1129*