### PR TITLE
[Perf] Use concurrent processing for event summarization

### DIFF
--- a/cogs/memory/services/event_summarization_service.py
+++ b/cogs/memory/services/event_summarization_service.py
@@ -266,12 +266,17 @@ class EventSummarizationService:
             # Group messages into events (initial implementation treats all as single event)
             grouped_messages = await self._group_messages(messages)
             
-            # Process each group into event summaries
+            # Process each group into event summaries concurrently
+            tasks = [self._process_message_group(group, previous_summary) for group in grouped_messages]
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+
             event_summaries = []
-            for message_group in grouped_messages:
-                summary_list = await self._process_message_group(message_group, previous_summary)
-                if summary_list:
-                    event_summaries.extend(summary_list)
+            for result in results:
+                if isinstance(result, Exception):
+                    log.error(f"Error processing message group: {result}", exc_info=True)
+                    await func.report_error(result, "EventSummarizationService/_process_message_group (gather)")
+                elif result:
+                    event_summaries.extend(result)
             
             return event_summaries
             


### PR DESCRIPTION
1. **What was found**: The `summarize_events` method in `EventSummarizationService` processed message groups sequentially using a `for` loop, awaiting each LLM call individually.
2. **Where it is**: `cogs/memory/services/event_summarization_service.py`, lines ~269-276.
3. **Why it matters**: Each `_process_message_group` involves an independent, I/O-bound LLM network request. Processing them sequentially introduces a significant performance bottleneck that scales linearly with the number of events/groups.
4. **What was done**: Replaced the sequential `for` loop with a concurrent approach using `asyncio.gather(..., return_exceptions=True)`. The results are then iterated over to log any errors per group while aggregating successful summaries, preserving chronological order and drastically improving performance for multiple groups.

---
*PR created automatically by Jules for task [14702903933931987624](https://jules.google.com/task/14702903933931987624) started by @zi-yue-1129*