### PR TITLE
[UX] Fix hanging Thinking state in channel manager commands

### DIFF
--- a/cogs/channel_manager.py
+++ b/cogs/channel_manager.py
@@ -91,7 +91,10 @@ class ChannelManager(commands.Cog):
             error_message = "You do not have permission to perform this action. Restricted to administrators."
         
         if interaction.response.is_done():
-            await interaction.followup.send(error_message, ephemeral=True)
+            try:
+                await interaction.edit_original_response(content=error_message)
+            except discord.NotFound:
+                await interaction.followup.send(error_message, ephemeral=True)
         else:
             await interaction.response.send_message(error_message, ephemeral=True)
         return False
@@ -122,7 +125,10 @@ class ChannelManager(commands.Cog):
         else:
             response = f"Set **Server-wide** response mode to: {mode.name}"
 
-        await interaction.followup.send(response, ephemeral=True)
+        try:
+            await interaction.edit_original_response(content=response)
+        except discord.NotFound:
+            await interaction.followup.send(response, ephemeral=True)
 
     @app_commands.command(name="set_channel_mode", description="Set a special mode for a specific channel (e.g., Story Mode)")
     @app_commands.describe(channel="The channel to set", mode="The mode to set for this channel")
@@ -168,7 +174,10 @@ class ChannelManager(commands.Cog):
                 message = f"Set mode for {channel.mention} to: **{mode.name}**."
 
         self.save_config(guild_id, config)
-        await interaction.followup.send(message, ephemeral=True)
+        try:
+            await interaction.edit_original_response(content=message)
+        except discord.NotFound:
+            await interaction.followup.send(message, ephemeral=True)
 
     @app_commands.command(name="add_channel", description="Add channel to whitelist or blacklist")
     @app_commands.choices(list_type=[
@@ -202,7 +211,10 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"Added <#{channel_id}> to {list_type_name}"
             
-            await interaction.followup.send(success_message, ephemeral=True)
+            try:
+                await interaction.edit_original_response(content=success_message)
+            except discord.NotFound:
+                await interaction.followup.send(success_message, ephemeral=True)
         else:
             if self.lang_manager:
                 exists_message = self.lang_manager.translate(
@@ -211,7 +223,10 @@ class ChannelManager(commands.Cog):
             else:
                 exists_message = f"<#{channel_id}> already exists in {list_type_name}"
             
-            await interaction.followup.send(exists_message, ephemeral=True)
+            try:
+                await interaction.edit_original_response(content=exists_message)
+            except discord.NotFound:
+                await interaction.followup.send(exists_message, ephemeral=True)
 
     @app_commands.command(name="remove_channel", description="Remove channel from whitelist or blacklist")
     @app_commands.choices(list_type=[
@@ -245,7 +260,10 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"Removed <#{channel_id}> from {list_type_name}"
             
-            await interaction.followup.send(success_message, ephemeral=True)
+            try:
+                await interaction.edit_original_response(content=success_message)
+            except discord.NotFound:
+                await interaction.followup.send(success_message, ephemeral=True)
         else:
             if self.lang_manager:
                 not_found_message = self.lang_manager.translate(
@@ -254,7 +272,10 @@ class ChannelManager(commands.Cog):
             else:
                 not_found_message = f"<#{channel_id}> does not exist in {list_type_name}"
             
-            await interaction.followup.send(not_found_message, ephemeral=True)
+            try:
+                await interaction.edit_original_response(content=not_found_message)
+            except discord.NotFound:
+                await interaction.followup.send(not_found_message, ephemeral=True)
 
     @app_commands.command(name="auto_response", description="Set channel auto-response")
     async def auto_response_command(self, interaction: discord.Interaction, channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread], enabled: bool):
@@ -275,7 +296,10 @@ class ChannelManager(commands.Cog):
         else:
             success_message = f"Set auto-response for <#{channel_id}> to: {enabled}"
         
-        await interaction.followup.send(success_message, ephemeral=True)
+        try:
+            await interaction.edit_original_response(content=success_message)
+        except discord.NotFound:
+            await interaction.followup.send(success_message, ephemeral=True)
 
     def is_allowed_channel(self, channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread], guild_id: str) -> Tuple[bool, bool, Optional[str]]:
         """


### PR DESCRIPTION
**What was found:** In `cogs/channel_manager.py` (lines 94, 128, 177, 214, 226, 263, 275, 299), slash commands for channel configurations (like `set_server_mode`, `set_channel_mode`, `add_channel`, `remove_channel`, and `auto_response`) defer their interaction with `thinking=True` inside `check_admin_permissions`, but later respond using `await interaction.followup.send(...)` instead of `await interaction.edit_original_response(...)`.

**Where it is:** Multiple lines throughout `cogs/channel_manager.py`.

**Why it matters:** Using `followup.send()` after a deferred response without editing the original interaction causes the "Thinking..." state to hang indefinitely on the user's screen (the Discord UI), leading to a frustrating UX where it seems like the command never finished processing despite receiving a successful followup message.

**What was done:** Replaced the `await interaction.followup.send(..., ephemeral=True)` calls with a block that first attempts `await interaction.edit_original_response(content=...)` and catches `discord.NotFound` to fall back to `await interaction.followup.send(...)`. This resolves the "Thinking..." state natively while remaining robust against deleted interactions. The ephemeral state is preserved because it's set natively during the deferral inside `check_admin_permissions`.

---
*PR created automatically by Jules for task [12792114799263846418](https://jules.google.com/task/12792114799263846418) started by @zi-yue-1129*