### PR TITLE
[Perf] Optimize context manager pipeline latency with independent tasks

### DIFF
--- a/llm/context_manager.py
+++ b/llm/context_manager.py
@@ -104,51 +104,51 @@ class ContextManager:
                 _LOGGER.error("procedural_provider.get failed", exception=e)
                 return ProceduralMemory(user_info={})
 
-        async def _fetch_short_term_and_procedural() -> Tuple[List[BaseMessage], ProceduralMemory]:
-            # 1. Extract author ID to start their procedural memory fetch immediately
-            author_ids = []
-            try:
-                fallback_author_id = getattr(getattr(message, "author", None), "id", None)
-                if fallback_author_id is not None:
-                    author_ids.append(str(fallback_author_id))
-            except Exception:
-                pass
+        # 1. Start long-running independent tasks immediately
+        episodic_task = asyncio.create_task(_fetch_episodic())
+        knowledge_task = asyncio.create_task(_fetch_knowledge())
 
-            # 2. Fetch short-term and author procedural in parallel
-            short_term_msgs, author_procedural = await asyncio.gather(
-                _fetch_short_term(),
-                _fetch_procedural(author_ids),
+        # 2. Start initial procedural fetch for the author
+        author_ids = []
+        try:
+            fallback_author_id = getattr(getattr(message, "author", None), "id", None)
+            if fallback_author_id is not None:
+                author_ids.append(str(fallback_author_id))
+        except Exception:
+            pass
+        author_procedural_task = asyncio.create_task(_fetch_procedural(author_ids))
+
+        # 3. Await short-term messages first (usually the bottleneck)
+        # This allows us to extract additional user IDs without waiting on episodic/knowledge/procedural
+        short_term_msgs = await _fetch_short_term()
+
+        # 4. Extract additional user IDs and launch secondary procedural fetch immediately if needed
+        try:
+            extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
+        except Exception as e:
+            asyncio.create_task(
+                func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
             )
+            _LOGGER.error("extract_user_ids failed", exception=e)
+            extracted_ids = []
 
-            # 3. Extract any additional user IDs from the fetched short-term messages
-            try:
-                extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
-            except Exception as e:
-                asyncio.create_task(
-                    func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
-                )
-                _LOGGER.error("extract_user_ids failed", exception=e)
-                extracted_ids = []
+        additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
+        additional_procedural_task = None
+        if additional_ids:
+            additional_procedural_task = asyncio.create_task(_fetch_procedural(additional_ids))
 
-            # 4. Fetch procedural memory for any additional users
-            additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
-            if additional_ids:
-                additional_procedural = await _fetch_procedural(additional_ids)
-                # Merge procedural memories
-                merged_info = dict(getattr(author_procedural, "user_info", {}))
-                merged_info.update(getattr(additional_procedural, "user_info", {}))
-                procedural_memory = ProceduralMemory(user_info=merged_info)
-            else:
-                procedural_memory = author_procedural
+        # 5. Await remaining tasks
+        episodic_str = await episodic_task
+        knowledge = await knowledge_task
+        author_procedural = await author_procedural_task
 
-            return short_term_msgs, procedural_memory
-
-        # 5. Fetch episodic, knowledge, and combined short-term/procedural memory in parallel
-        (short_term_msgs, procedural_memory), episodic_str, knowledge = await asyncio.gather(
-            _fetch_short_term_and_procedural(),
-            _fetch_episodic(),
-            _fetch_knowledge(),
-        )
+        if additional_procedural_task:
+            additional_procedural = await additional_procedural_task
+            merged_info = dict(getattr(author_procedural, "user_info", {}))
+            merged_info.update(getattr(additional_procedural, "user_info", {}))
+            procedural_memory = ProceduralMemory(user_info=merged_info)
+        else:
+            procedural_memory = author_procedural
 
         # 6. Format procedural memory into string (no STM serialization here)
         try:


### PR DESCRIPTION
1. **What was found:** The `get_context` method in `llm/context_manager.py` used a blocking `asyncio.gather` for fetching short-term memory and the author's procedural memory simultaneously. Crucially, it waited for both tasks to complete before extracting additional user IDs and launching their procedural memory fetches.
2. **Where it is:** `llm/context_manager.py` specifically in the nested `_fetch_short_term_and_procedural` method inside `get_context()`.
3. **Why it matters:** Short-term memory fetching is often the primary bottleneck due to downloading attachments. However, if the procedural DB query was slow, it delayed the ID extraction process. This sequential waiting pattern artificially inflated the time-to-first-byte (TTFB) and overall latency for the bot's response to user messages.
4. **What was done:** Refactored `get_context` by replacing the blocking `asyncio.gather` with independent `asyncio.create_task()` executions. The long-running tasks (episodic, knowledge, author procedural) are now launched immediately. The code then awaits the critical `short_term` task. The exact moment it completes, additional user IDs are extracted and their procedural fetch is kicked off asynchronously. Finally, all pending tasks are awaited and merged. This flattens the concurrency tree, ensuring no CPU or I/O time is wasted waiting sequentially. Tests run via `pytest tests/test_context_manager.py` pass cleanly.

---
*PR created automatically by Jules for task [6473456056701249233](https://jules.google.com/task/6473456056701249233) started by @zi-yue-1129*