### PR TITLE
[Feature] Delete episodic memory vectors when clearing user data

### DIFF
--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -1048,6 +1048,15 @@ class UserDataCog(commands.Cog):
                 except Exception as cache_err:
                     self.logger.warning(f"Failed to invalidate procedural cache for {user_id}: {cache_err}")
 
+                # Also delete episodic memory vectors for the user
+                try:
+                    vector_manager = getattr(self.bot, "vector_manager", None)
+                    if vector_manager and hasattr(vector_manager, "store") and hasattr(vector_manager.store, "delete_vectors_by_user"):
+                        await vector_manager.store.delete_vectors_by_user(user_id)
+                        self.logger.info(f"Successfully deleted episodic vectors for {user_id}")
+                except Exception as vec_err:
+                    self.logger.warning(f"Failed to delete episodic vectors for {user_id}: {vec_err}")
+
 
                 return self._translate(
                     guild_id,


### PR DESCRIPTION
1. **What was found**: When a user clears their personal memory (e.g. via `/memory clear` or the `clear_user_memory` tool), only their procedural memory (SQLite) is deleted. Their episodic memory fragments (vector store) are left orphaned, potentially violating data privacy expectations.
2. **Where it is**: `cogs/userdata.py` in the `_clear_user_data` method (around line 1048).
3. **Why it matters**: If a user explicitly requests to forget their data, all historical chat fragments tied to their identity must also be removed to comply with standard data privacy practices.
4. **What was done**: Added a call to `self.bot.vector_manager.store.delete_vectors_by_user(user_id)` inside `_clear_user_data` to ensure episodic vectors are successfully deleted when the user clears their data. Defensive checks were also included in case the vector manager is disabled or unavailable.

---
*PR created automatically by Jules for task [321494572102248359](https://jules.google.com/task/321494572102248359) started by @zi-yue-1129*