### PR TITLE
[Perf] Optimize parallel fetching in ContextManager

### DIFF
--- a/llm/context_manager.py
+++ b/llm/context_manager.py
@@ -104,51 +104,53 @@ class ContextManager:
                 _LOGGER.error("procedural_provider.get failed", exception=e)
                 return ProceduralMemory(user_info={})
 
-        async def _fetch_short_term_and_procedural() -> Tuple[List[BaseMessage], ProceduralMemory]:
-            # 1. Extract author ID to start their procedural memory fetch immediately
-            author_ids = []
-            try:
-                fallback_author_id = getattr(getattr(message, "author", None), "id", None)
-                if fallback_author_id is not None:
-                    author_ids.append(str(fallback_author_id))
-            except Exception:
-                pass
+        # Start independent fetches immediately
+        episodic_task = asyncio.create_task(_fetch_episodic())
+        knowledge_task = asyncio.create_task(_fetch_knowledge())
 
-            # 2. Fetch short-term and author procedural in parallel
-            short_term_msgs, author_procedural = await asyncio.gather(
-                _fetch_short_term(),
-                _fetch_procedural(author_ids),
+        # Extract author ID to start their procedural memory fetch immediately
+        author_ids = []
+        try:
+            fallback_author_id = getattr(getattr(message, "author", None), "id", None)
+            if fallback_author_id is not None:
+                author_ids.append(str(fallback_author_id))
+        except Exception:
+            pass
+
+        author_procedural_task = asyncio.create_task(_fetch_procedural(author_ids))
+
+        # Await the slow short-term fetch first
+        short_term_msgs = await _fetch_short_term()
+
+        # Extract additional user IDs from the fetched short-term messages
+        try:
+            extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
+        except Exception as e:
+            asyncio.create_task(
+                func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
             )
+            _LOGGER.error("extract_user_ids failed", exception=e)
+            extracted_ids = []
 
-            # 3. Extract any additional user IDs from the fetched short-term messages
-            try:
-                extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
-            except Exception as e:
-                asyncio.create_task(
-                    func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
-                )
-                _LOGGER.error("extract_user_ids failed", exception=e)
-                extracted_ids = []
+        # Fetch procedural memory for any additional users
+        additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
+        additional_procedural_task = None
+        if additional_ids:
+            additional_procedural_task = asyncio.create_task(_fetch_procedural(additional_ids))
 
-            # 4. Fetch procedural memory for any additional users
-            additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
-            if additional_ids:
-                additional_procedural = await _fetch_procedural(additional_ids)
-                # Merge procedural memories
-                merged_info = dict(getattr(author_procedural, "user_info", {}))
-                merged_info.update(getattr(additional_procedural, "user_info", {}))
-                procedural_memory = ProceduralMemory(user_info=merged_info)
-            else:
-                procedural_memory = author_procedural
+        # Await all remaining independent tasks
+        episodic_str = await episodic_task
+        knowledge = await knowledge_task
+        author_procedural = await author_procedural_task
 
-            return short_term_msgs, procedural_memory
-
-        # 5. Fetch episodic, knowledge, and combined short-term/procedural memory in parallel
-        (short_term_msgs, procedural_memory), episodic_str, knowledge = await asyncio.gather(
-            _fetch_short_term_and_procedural(),
-            _fetch_episodic(),
-            _fetch_knowledge(),
-        )
+        if additional_procedural_task:
+            additional_procedural = await additional_procedural_task
+            # Merge procedural memories
+            merged_info = dict(getattr(author_procedural, "user_info", {}))
+            merged_info.update(getattr(additional_procedural, "user_info", {}))
+            procedural_memory = ProceduralMemory(user_info=merged_info)
+        else:
+            procedural_memory = author_procedural
 
         # 6. Format procedural memory into string (no STM serialization here)
         try:


### PR DESCRIPTION
**1. What was found:** 
In `llm/context_manager.py`, the `ContextManager.get_context()` method was using a single nested `asyncio.gather` call that grouped `_fetch_short_term()` and `_fetch_procedural(author_ids)`. Because short-term fetching is slow (I/O-heavy for attachments), it artificially delayed the extraction of additional user IDs, blocking subsequent parallel procedural fetches from starting early.

**2. Where it is:** 
`llm/context_manager.py` (lines 104-142 in `ContextManager.get_context()`).

**3. Why it matters:** 
This runs in the absolute hottest path of the application (every single Discord message orchestrator handles). Bundling these tasks together into sequential gather blocks wastes idle CPU and network cycles waiting for the slow attachment processor, contributing to higher user-facing response latency.

**4. What was done:** 
Refactored `get_context()` to use `asyncio.create_task` to immediately begin independent concurrent fetches (episodic, knowledge, and author procedural memory). The slow `_fetch_short_term()` is then explicitly awaited first, immediately enabling the extraction of additional user IDs so their procedural fetches can begin without artificial blocking. All remaining independent background tasks are finally awaited simultaneously.

---
*PR created automatically by Jules for task [2257197121548613485](https://jules.google.com/task/2257197121548613485) started by @zi-yue-1129*