### PR TITLE
[Security] Add channel permission check for system prompt modifications

### DIFF
--- a/cogs/system_prompt/commands.py
+++ b/cogs/system_prompt/commands.py
@@ -227,6 +227,15 @@ class SystemPromptCommands(commands.Cog):
                     ephemeral=True,
                 )
                 return
+        elif scope_value == "channel":
+            from .permissions import PermissionValidator
+            validator = PermissionValidator(self.bot)
+            if not validator.can_modify_channel_prompt(interaction.user, interaction.channel):
+                await interaction.followup.send(
+                    "❌ You do not have permission to modify the channel-level personality.",
+                    ephemeral=True,
+                )
+                return
 
         # Get current effective system prompt to merge with
         sp_cog = self.bot.get_cog("SystemPromptManagerCog")

--- a/llm/tools/system_prompt_tools.py
+++ b/llm/tools/system_prompt_tools.py
@@ -130,6 +130,14 @@ class SystemPromptTools:
                         "Error: You need administrator permissions to modify the "
                         "server-level personality."
                     )
+            elif scope == "channel":
+                from cogs.system_prompt.permissions import PermissionValidator
+                validator = PermissionValidator(bot)
+                if not validator.can_modify_channel_prompt(author, channel):
+                    return (
+                        "Error: You do not have permission to modify the "
+                        "channel-level personality."
+                    )
 
             return await write_personality(guild_id, channel_id, merged_prompt, scope, bot, user_id)
 

--- a/tests/test_system_prompt_tools.py
+++ b/tests/test_system_prompt_tools.py
@@ -139,7 +139,9 @@ class TestUpdatePersonalityChannel:
         self.runtime = _make_runtime(bot=self.mock_bot)
         self.tool = SystemPromptTools(self.runtime).get_tools()[0]
 
-    def test_calls_set_channel_prompt_with_correct_args(self):
+    @patch("cogs.system_prompt.permissions.PermissionValidator")
+    def test_calls_set_channel_prompt_with_correct_args(self, MockV):
+        MockV.return_value.can_modify_channel_prompt.return_value = True
         asyncio.get_event_loop().run_until_complete(
             self.tool.coroutine(merged_prompt="Be funny.", scope="channel")
         )
@@ -147,17 +149,29 @@ class TestUpdatePersonalityChannel:
             "111", "222", {"prompt": "Be funny.", "enabled": True}, "333"
         )
 
-    def test_returns_success_message(self):
+    @patch("cogs.system_prompt.permissions.PermissionValidator")
+    def test_returns_success_message(self, MockV):
+        MockV.return_value.can_modify_channel_prompt.return_value = True
         result = asyncio.get_event_loop().run_until_complete(
             self.tool.coroutine(merged_prompt="Be funny.", scope="channel")
         )
         assert "success" in result.lower() or "updated" in result.lower()
 
-    def test_invalidates_cache_after_write(self):
+    @patch("cogs.system_prompt.permissions.PermissionValidator")
+    def test_invalidates_cache_after_write(self, MockV):
+        MockV.return_value.can_modify_channel_prompt.return_value = True
         asyncio.get_event_loop().run_until_complete(
             self.tool.coroutine(merged_prompt="Be funny.", scope="channel")
         )
         self.mock_manager.cache.invalidate.assert_called()
+
+    @patch("cogs.system_prompt.permissions.PermissionValidator")
+    def test_blocks_non_admin_from_channel_scope(self, MockV):
+        MockV.return_value.can_modify_channel_prompt.return_value = False
+        result = asyncio.get_event_loop().run_until_complete(
+            self.tool.coroutine(merged_prompt="...", scope="channel")
+        )
+        assert "permission" in result.lower()
 
 
 class TestUpdatePersonalityServer:


### PR DESCRIPTION
1. **What was found**: The `update_personality` Langchain tool and `set_personality` Discord slash command lacked a permission check when updating channel-level system prompts (`scope == "channel"`).
2. **Where it is**: `llm/tools/system_prompt_tools.py` in `update_personality` and `cogs/system_prompt/commands.py` in `set_personality`.
3. **Why it matters**: Without this check, any user could potentially bypass access controls and modify a channel's personality/system prompt via slash commands or conversational LLM prompt injection, leading to unauthorized bot behavior modification.
4. **What was done**: Added checks for `PermissionValidator.can_modify_channel_prompt(user, channel)` to ensure only authorized users (e.g. server admins or those with manage channel permissions) can modify the channel system prompt. Updated unit tests in `tests/test_system_prompt_tools.py` with proper mocking to prevent failures.

---
*PR created automatically by Jules for task [6337620357830699786](https://jules.google.com/task/6337620357830699786) started by @zi-yue-1129*