### PR TITLE
[Perf] Optimize context fetch pipeline with create_task

### DIFF
--- a/llm/context_manager.py
+++ b/llm/context_manager.py
@@ -104,51 +104,53 @@ class ContextManager:
                 _LOGGER.error("procedural_provider.get failed", exception=e)
                 return ProceduralMemory(user_info={})
 
-        async def _fetch_short_term_and_procedural() -> Tuple[List[BaseMessage], ProceduralMemory]:
-            # 1. Extract author ID to start their procedural memory fetch immediately
-            author_ids = []
-            try:
-                fallback_author_id = getattr(getattr(message, "author", None), "id", None)
-                if fallback_author_id is not None:
-                    author_ids.append(str(fallback_author_id))
-            except Exception:
-                pass
+        # 1. Extract author ID to start their procedural memory fetch immediately
+        author_ids = []
+        try:
+            fallback_author_id = getattr(getattr(message, "author", None), "id", None)
+            if fallback_author_id is not None:
+                author_ids.append(str(fallback_author_id))
+        except Exception:
+            pass
 
-            # 2. Fetch short-term and author procedural in parallel
-            short_term_msgs, author_procedural = await asyncio.gather(
-                _fetch_short_term(),
-                _fetch_procedural(author_ids),
+        # 2. Start independent fetches immediately
+        episodic_task = asyncio.create_task(_fetch_episodic())
+        knowledge_task = asyncio.create_task(_fetch_knowledge())
+        author_procedural_task = asyncio.create_task(_fetch_procedural(author_ids))
+
+        # 3. Await the slow short-term fetch first
+        short_term_msgs = await _fetch_short_term()
+
+        # 4. Extract any additional user IDs from the fetched short-term messages
+        try:
+            extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
+        except Exception as e:
+            asyncio.create_task(
+                func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
             )
+            _LOGGER.error("extract_user_ids failed", exception=e)
+            extracted_ids = []
 
-            # 3. Extract any additional user IDs from the fetched short-term messages
-            try:
-                extracted_ids = self._extract_user_ids_from_messages(short_term_msgs, message)
-            except Exception as e:
-                asyncio.create_task(
-                    func.report_error(e, "ContextManager.get_context: extract_user_ids failed")
-                )
-                _LOGGER.error("extract_user_ids failed", exception=e)
-                extracted_ids = []
+        # 5. Start procedural fetch for any additional users if needed
+        additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
+        additional_procedural_task = None
+        if additional_ids:
+            additional_procedural_task = asyncio.create_task(_fetch_procedural(additional_ids))
 
-            # 4. Fetch procedural memory for any additional users
-            additional_ids = [uid for uid in extracted_ids if uid not in author_ids]
-            if additional_ids:
-                additional_procedural = await _fetch_procedural(additional_ids)
-                # Merge procedural memories
-                merged_info = dict(getattr(author_procedural, "user_info", {}))
-                merged_info.update(getattr(additional_procedural, "user_info", {}))
-                procedural_memory = ProceduralMemory(user_info=merged_info)
-            else:
-                procedural_memory = author_procedural
+        # 6. Await all remaining tasks
+        author_procedural = await author_procedural_task
 
-            return short_term_msgs, procedural_memory
+        if additional_procedural_task:
+            additional_procedural = await additional_procedural_task
+            # Merge procedural memories
+            merged_info = dict(getattr(author_procedural, "user_info", {}))
+            merged_info.update(getattr(additional_procedural, "user_info", {}))
+            procedural_memory = ProceduralMemory(user_info=merged_info)
+        else:
+            procedural_memory = author_procedural
 
-        # 5. Fetch episodic, knowledge, and combined short-term/procedural memory in parallel
-        (short_term_msgs, procedural_memory), episodic_str, knowledge = await asyncio.gather(
-            _fetch_short_term_and_procedural(),
-            _fetch_episodic(),
-            _fetch_knowledge(),
-        )
+        episodic_str = await episodic_task
+        knowledge = await knowledge_task
 
         # 6. Format procedural memory into string (no STM serialization here)
         try:


### PR DESCRIPTION
1. **What was found**: A concurrency bottleneck in the memory fetch pipeline. The `_fetch_short_term_and_procedural` method used an `asyncio.gather` to wait for both short-term memory (which performs slow I/O attachments) and the author's procedural memory. Because it was grouped together, the pipeline could not extract additional users from the short-term messages and begin their procedural fetches until the original author's procedural fetch also finished.
2. **Where it is**: `llm/context_manager.py`, in the `ContextManager.get_context()` method, specifically inside the nested `_fetch_short_term_and_procedural` closure (lines 107-151).
3. **Why it matters**: This artificial grouping increased latency on the bot's critical path for every incoming message by forcing sequential execution blocks rather than full concurrency. 
4. **What was done**: Rewrote the `get_context()` method to replace the nested `gather` with direct `asyncio.create_task()` calls. Now, episodic, knowledge, and the author's procedural memory fetches are spawned immediately as independent tasks. The slow `_fetch_short_term()` is awaited first, and any additional procedural fetches are spawned instantly, maximizing concurrency and minimizing end-user latency.

---
*PR created automatically by Jules for task [11830938661812010264](https://jules.google.com/task/11830938661812010264) started by @zi-yue-1129*