### PR TITLE
[Perf] Optimize KnowledgeMemoryProvider concurrent fetching

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -45,11 +45,20 @@ class KnowledgeMemoryProvider:
         Returns:
             KnowledgeMemory object containing both levels of knowledge.
         """
-        guild_knowledge = None
+        tasks = []
         if guild_id:
-            guild_knowledge = await self._get_single("guild", guild_id)
-            
-        channel_knowledge = await self._get_single("channel", channel_id)
+            tasks.append(self._get_single("guild", guild_id))
+
+        tasks.append(self._get_single("channel", channel_id))
+
+        results = await asyncio.gather(*tasks)
+
+        if guild_id:
+            guild_knowledge = results[0]
+            channel_knowledge = results[1]
+        else:
+            guild_knowledge = None
+            channel_knowledge = results[0]
         
         return KnowledgeMemory(
             guild_knowledge=guild_knowledge,


### PR DESCRIPTION
1. **What**: The sequential fetching of guild and channel knowledge in `KnowledgeMemoryProvider.get()` was optimized to run concurrently using `asyncio.gather`.
2. **Where**: In `llm/memory/knowledge.py`, specifically lines 45-64 in the `KnowledgeMemoryProvider.get()` method.
3. **Why**: Fetching these memory sources sequentially introduces artificial I/O-bound latency when building context for the LLM pipeline, slowing down the bot's response to users. Running these network/DB fetches concurrently minimizes this latency bottleneck.
4. **What was done**: Replaced the sequential `await` calls for `_get_single` with an array of tasks that are executed in parallel using `asyncio.gather`, then mapping the results back to `guild_knowledge` and `channel_knowledge`.

---
*PR created automatically by Jules for task [3755242099950574417](https://jules.google.com/task/3755242099950574417) started by @zi-yue-1129*