### PR TITLE
[Perf] Use asyncio.gather for concurrent event summarization

### DIFF
--- a/cogs/memory/services/event_summarization_service.py
+++ b/cogs/memory/services/event_summarization_service.py
@@ -266,12 +266,24 @@ class EventSummarizationService:
             # Group messages into events (initial implementation treats all as single event)
             grouped_messages = await self._group_messages(messages)
             
-            # Process each group into event summaries
+            # Process each group into event summaries concurrently
             event_summaries = []
-            for message_group in grouped_messages:
-                summary_list = await self._process_message_group(message_group, previous_summary)
-                if summary_list:
-                    event_summaries.extend(summary_list)
+
+            # Create tasks for all message groups
+            tasks = [
+                self._process_message_group(message_group, previous_summary)
+                for message_group in grouped_messages
+            ]
+
+            if tasks:
+                # Run all tasks concurrently
+                # No return_exceptions=True, so it fails fast just like the original sequential loop
+                results = await asyncio.gather(*tasks)
+
+                # Process results
+                for result in results:
+                    if result:  # Check if result is not None and not empty list
+                        event_summaries.extend(result)
             
             return event_summaries
             


### PR DESCRIPTION
1. What was found: The summarize_events method processes message groups sequentially.
2. Where it is: cogs/memory/services/event_summarization_service.py line 271-274.
3. Why it matters: Sequential LLM calls for multiple message groups create a significant I/O-bound performance bottleneck, increasing latency.
4. What was done: Replaced the sequential for loop with asyncio.gather to process message groups concurrently.

---
*PR created automatically by Jules for task [2738551802728560944](https://jules.google.com/task/2738551802728560944) started by @zi-yue-1129*