### PR TITLE
[Privacy] Explicitly delete episodic vectors when clearing user data

### DIFF
--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -1048,6 +1048,13 @@ class UserDataCog(commands.Cog):
                 except Exception as cache_err:
                     self.logger.warning(f"Failed to invalidate procedural cache for {user_id}: {cache_err}")
 
+                # Delete episodic memory vectors
+                try:
+                    vector_manager = getattr(self.bot, "vector_manager", None)
+                    if vector_manager and hasattr(vector_manager, "store") and hasattr(vector_manager.store, "delete_vectors_by_user"):
+                        await vector_manager.store.delete_vectors_by_user(str(user_id))
+                except Exception as vector_err:
+                    self.logger.warning(f"Failed to delete episodic vectors for {user_id}: {vector_err}")
 
                 return self._translate(
                     guild_id,


### PR DESCRIPTION
1. **What was found**: When users ask the bot to clear their user data (using the `/userdata` slash command or the underlying tools), only their procedural memory and background info (stored in SQLite) are deleted. Their raw conversation snippets (episodic memory fragments) remain in the Qdrant vector database.
2. **Where it is**: `cogs/userdata.py` inside the `_clear_user_data` function.
3. **Why it matters**: This is a potential privacy and compliance gap. If a user expects the bot to "forget" them, it should delete their semantic history as well, not just their profile preferences. Leaving vectors behind can cause the bot to inadvertently reference past conversations from a user who opted out.
4. **What was done**: Modified the `_clear_user_data` method to safely invoke `bot.vector_manager.store.delete_vectors_by_user(str(user_id))` inside a `try...except` block after successfully clearing the procedural data. This leverages the existing `delete_vectors_by_user` method in `QdrantStore` to wipe their episodic memories.

---
*PR created automatically by Jules for task [18348212615548739570](https://jules.google.com/task/18348212615548739570) started by @zi-yue-1129*