### PR TITLE
[UX] Fix hanging Thinking state in channel manager commands

### DIFF
--- a/cogs/channel_manager.py
+++ b/cogs/channel_manager.py
@@ -91,7 +91,10 @@ class ChannelManager(commands.Cog):
             error_message = "You do not have permission to perform this action. Restricted to administrators."
         
         if interaction.response.is_done():
-            await interaction.followup.send(error_message, ephemeral=True)
+            try:
+                await interaction.edit_original_response(content=error_message)
+            except discord.NotFound:
+                await interaction.followup.send(error_message, ephemeral=True)
         else:
             await interaction.response.send_message(error_message, ephemeral=True)
         return False
@@ -122,7 +125,10 @@ class ChannelManager(commands.Cog):
         else:
             response = f"Set **Server-wide** response mode to: {mode.name}"
 
-        await interaction.followup.send(response, ephemeral=True)
+        try:
+            await interaction.edit_original_response(content=response)
+        except discord.NotFound:
+            await interaction.followup.send(response, ephemeral=True)
 
     @app_commands.command(name="set_channel_mode", description="Set a special mode for a specific channel (e.g., Story Mode)")
     @app_commands.describe(channel="The channel to set", mode="The mode to set for this channel")
@@ -168,7 +174,10 @@ class ChannelManager(commands.Cog):
                 message = f"Set mode for {channel.mention} to: **{mode.name}**."
 
         self.save_config(guild_id, config)
-        await interaction.followup.send(message, ephemeral=True)
+        try:
+            await interaction.edit_original_response(content=message)
+        except discord.NotFound:
+            await interaction.followup.send(message, ephemeral=True)
 
     @app_commands.command(name="add_channel", description="Add channel to whitelist or blacklist")
     @app_commands.choices(list_type=[
@@ -202,7 +211,10 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"Added <#{channel_id}> to {list_type_name}"
             
-            await interaction.followup.send(success_message, ephemeral=True)
+            try:
+                await interaction.edit_original_response(content=success_message)
+            except discord.NotFound:
+                await interaction.followup.send(success_message, ephemeral=True)
         else:
             if self.lang_manager:
                 exists_message = self.lang_manager.translate(
@@ -211,7 +223,10 @@ class ChannelManager(commands.Cog):
             else:
                 exists_message = f"<#{channel_id}> already exists in {list_type_name}"
             
-            await interaction.followup.send(exists_message, ephemeral=True)
+            try:
+                await interaction.edit_original_response(content=exists_message)
+            except discord.NotFound:
+                await interaction.followup.send(exists_message, ephemeral=True)
 
     @app_commands.command(name="remove_channel", description="Remove channel from whitelist or blacklist")
     @app_commands.choices(list_type=[
@@ -245,7 +260,10 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"Removed <#{channel_id}> from {list_type_name}"
             
-            await interaction.followup.send(success_message, ephemeral=True)
+            try:
+                await interaction.edit_original_response(content=success_message)
+            except discord.NotFound:
+                await interaction.followup.send(success_message, ephemeral=True)
         else:
             if self.lang_manager:
                 not_found_message = self.lang_manager.translate(
@@ -254,7 +272,10 @@ class ChannelManager(commands.Cog):
             else:
                 not_found_message = f"<#{channel_id}> does not exist in {list_type_name}"
             
-            await interaction.followup.send(not_found_message, ephemeral=True)
+            try:
+                await interaction.edit_original_response(content=not_found_message)
+            except discord.NotFound:
+                await interaction.followup.send(not_found_message, ephemeral=True)
 
     @app_commands.command(name="auto_response", description="Set channel auto-response")
     async def auto_response_command(self, interaction: discord.Interaction, channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread], enabled: bool):
@@ -275,7 +296,10 @@ class ChannelManager(commands.Cog):
         else:
             success_message = f"Set auto-response for <#{channel_id}> to: {enabled}"
         
-        await interaction.followup.send(success_message, ephemeral=True)
+        try:
+            await interaction.edit_original_response(content=success_message)
+        except discord.NotFound:
+            await interaction.followup.send(success_message, ephemeral=True)
 
     def is_allowed_channel(self, channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread], guild_id: str) -> Tuple[bool, bool, Optional[str]]:
         """


### PR DESCRIPTION
### What was found
In `cogs/channel_manager.py`, several admin slash commands (such as `/set_server_mode`, `/set_channel_mode`, `/add_channel`, `/remove_channel`, and `/auto_response`) resulted in a hanging "Bot is thinking..." message in Discord after execution.

### Where it is
In `cogs/channel_manager.py`, the `check_admin_permissions` method optionally defers the interaction with `thinking=True`. However, in the subsequent command handlers (lines 94, 125, 171, 205, 214, 248, 257, 278), the responses are sent using `await interaction.followup.send(...)` instead of editing the original deferred response.

### Why it matters
Using `followup.send` after a `defer(thinking=True)` creates a new message but leaves the original "Bot is thinking..." message stuck indefinitely in the user's channel. This is highly confusing to users and degrades the overall polish and UX of the bot's interactions.

### What was done
Replaced occurrences of `await interaction.followup.send(..., ephemeral=True)` in `cogs/channel_manager.py` with the standard `discord.py` fallback pattern:
```python
try:
    await interaction.edit_original_response(content=...)
except discord.NotFound:
    await interaction.followup.send(..., ephemeral=True)
```
This safely updates the initial "Thinking..." message if it exists, and reliably falls back to sending a follow-up message if the original interaction timed out or was deleted.

---
*PR created automatically by Jules for task [3008051098612351155](https://jules.google.com/task/3008051098612351155) started by @zi-yue-1129*