### PR TITLE
[Perf] Process message groups concurrently in EventSummarizationService

### DIFF
--- a/cogs/memory/services/event_summarization_service.py
+++ b/cogs/memory/services/event_summarization_service.py
@@ -266,12 +266,19 @@ class EventSummarizationService:
             # Group messages into events (initial implementation treats all as single event)
             grouped_messages = await self._group_messages(messages)
             
-            # Process each group into event summaries
+            # Process each group into event summaries concurrently
             event_summaries = []
-            for message_group in grouped_messages:
-                summary_list = await self._process_message_group(message_group, previous_summary)
-                if summary_list:
-                    event_summaries.extend(summary_list)
+            tasks = [self._process_message_group(message_group, previous_summary) for message_group in grouped_messages]
+
+            if tasks:
+                import asyncio
+                results = await asyncio.gather(*tasks, return_exceptions=True)
+                for result in results:
+                    if isinstance(result, Exception):
+                        log.error(f"Error processing message group: {result}", exc_info=result)
+                        await func.report_error(result, "EventSummarizationService/_process_message_group_task")
+                    elif result:
+                        event_summaries.extend(result)
             
             return event_summaries
             


### PR DESCRIPTION
1. **What was found**: `summarize_events` in `cogs/memory/services/event_summarization_service.py` processes message groups sequentially using a `for` loop.
2. **Where it is**: `cogs/memory/services/event_summarization_service.py` line 271.
3. **Why it matters**: Processing independent message groups sequentially causes I/O-bound performance bottlenecks from independent LLM calls (`_process_message_group`), significantly increasing latency for event summarization.
4. **What was done**: Replaced the sequential `for` loop with `asyncio.gather(*tasks, return_exceptions=True)` to process event summaries concurrently. Added logic to handle individual exceptions using `func.report_error` so that a failure in one summary task does not prevent others from completing successfully.

---
*PR created automatically by Jules for task [602542015328160617](https://jules.google.com/task/602542015328160617) started by @zi-yue-1129*