### PR TITLE
[Perf] Use concurrent processing for event summaries

### DIFF
--- a/cogs/memory/services/event_summarization_service.py
+++ b/cogs/memory/services/event_summarization_service.py
@@ -268,10 +268,15 @@ class EventSummarizationService:
             
             # Process each group into event summaries
             event_summaries = []
-            for message_group in grouped_messages:
-                summary_list = await self._process_message_group(message_group, previous_summary)
-                if summary_list:
-                    event_summaries.extend(summary_list)
+            tasks = [self._process_message_group(message_group, previous_summary) for message_group in grouped_messages]
+            if tasks:
+                results = await asyncio.gather(*tasks, return_exceptions=True)
+                for result in results:
+                    if isinstance(result, Exception):
+                        log.error(f"Error processing message group in gather: {result}", exc_info=True)
+                        await func.report_error(result, "EventSummarizationService/summarize_events_gather")
+                    elif result:
+                        event_summaries.extend(result)
             
             return event_summaries
             


### PR DESCRIPTION
1. **What was found**: The `summarize_events` method in `EventSummarizationService` processed message groups sequentially using a `for` loop, causing an I/O bottleneck when making multiple LLM API calls for summarization.
2. **Where it is**: `cogs/memory/services/event_summarization_service.py` (lines 268-274).
3. **Why it matters**: Sequential processing of message groups adds significant latency to event summarization, slowing down the bot's background processing and potentially delaying memory retrieval for users.
4. **What was done**: Replaced the sequential `for` loop with `asyncio.gather(*tasks, return_exceptions=True)` to process all message groups concurrently. Handled individual task failures gracefully using the existing `func.report_error` mechanism to prevent a single failure from aborting the entire batch.

---
*PR created automatically by Jules for task [17392817672981400180](https://jules.google.com/task/17392817672981400180) started by @zi-yue-1129*