### PR TITLE
[Privacy] Ensure episodic memory vectors are deleted when clearing user data

### DIFF
--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -652,6 +652,14 @@ class UserDataCog(commands.Cog):
             )
             
             if success:
+                # Delete episodic memory vectors as well for complete data privacy
+                try:
+                    vector_manager = getattr(self.bot, "vector_manager", None)
+                    if vector_manager and hasattr(vector_manager, "store"):
+                        deleted_count = await vector_manager.store.delete_vectors_by_user(user_id)
+                        self.logger.debug(f"Deleted episodic memory vectors for {user_id}, count: {deleted_count}")
+                except Exception as vec_err:
+                    self.logger.warning(f"Failed to delete episodic memory vectors for {user_id}: {vec_err}")
                 # Invalidate ProceduralMemoryProvider cache
                 try:
                     orchestrator = getattr(self.bot, "orchestrator", None)
@@ -1034,6 +1042,14 @@ class UserDataCog(commands.Cog):
 
             success = await self.user_manager.delete_user_data(user_id)
             if success:
+                # Delete episodic memory vectors as well for complete data privacy
+                try:
+                    vector_manager = getattr(self.bot, "vector_manager", None)
+                    if vector_manager and hasattr(vector_manager, "store"):
+                        deleted_count = await vector_manager.store.delete_vectors_by_user(user_id)
+                        self.logger.debug(f"Deleted episodic memory vectors for {user_id}, count: {deleted_count}")
+                except Exception as vec_err:
+                    self.logger.warning(f"Failed to delete episodic memory vectors for {user_id}: {vec_err}")
                 # Invalidate ProceduralMemoryProvider cache
                 try:
                     orchestrator = getattr(self.bot, "orchestrator", None)


### PR DESCRIPTION
1. **What was found**: `UserDataCog._clear_user_data` in `cogs/userdata.py` only deleted user profiles from the local procedural storage (`user_manager`), while completely ignoring semantic memory vectors tied to the user in the episodic vector store.
2. **Where it is**: `cogs/userdata.py`, around line 1042.
3. **Why it matters**: If a user explicitly asks the bot to forget everything about them and clear their data, leaving behind semantic records in the vector database breaks privacy expectations.
4. **What was done**: Added a defensive block immediately after procedural deletion to fetch `bot.vector_manager.store` and call the pre-existing `delete_vectors_by_user(user_id)` method, ensuring full deletion. Errors are caught and logged to prevent interrupting the rest of the purge (e.g. cache invalidation).

---
*PR created automatically by Jules for task [5513214502641058762](https://jules.google.com/task/5513214502641058762) started by @zi-yue-1129*