### PR TITLE
[UX] Fix hanging thinking state by using edit_original_response

### DIFF
--- a/cogs/channel_manager.py
+++ b/cogs/channel_manager.py
@@ -91,7 +91,7 @@ class ChannelManager(commands.Cog):
             error_message = "You do not have permission to perform this action. Restricted to administrators."
         
         if interaction.response.is_done():
-            await interaction.followup.send(error_message, ephemeral=True)
+            await interaction.edit_original_response(content=error_message)
         else:
             await interaction.response.send_message(error_message, ephemeral=True)
         return False
@@ -122,7 +122,7 @@ class ChannelManager(commands.Cog):
         else:
             response = f"Set **Server-wide** response mode to: {mode.name}"
 
-        await interaction.followup.send(response, ephemeral=True)
+        await interaction.edit_original_response(content=response)
 
     @app_commands.command(name="set_channel_mode", description="Set a special mode for a specific channel (e.g., Story Mode)")
     @app_commands.describe(channel="The channel to set", mode="The mode to set for this channel")
@@ -168,7 +168,7 @@ class ChannelManager(commands.Cog):
                 message = f"Set mode for {channel.mention} to: **{mode.name}**."
 
         self.save_config(guild_id, config)
-        await interaction.followup.send(message, ephemeral=True)
+        await interaction.edit_original_response(content=message)
 
     @app_commands.command(name="add_channel", description="Add channel to whitelist or blacklist")
     @app_commands.choices(list_type=[
@@ -202,7 +202,7 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"Added <#{channel_id}> to {list_type_name}"
             
-            await interaction.followup.send(success_message, ephemeral=True)
+            await interaction.edit_original_response(content=success_message)
         else:
             if self.lang_manager:
                 exists_message = self.lang_manager.translate(
@@ -211,7 +211,7 @@ class ChannelManager(commands.Cog):
             else:
                 exists_message = f"<#{channel_id}> already exists in {list_type_name}"
             
-            await interaction.followup.send(exists_message, ephemeral=True)
+            await interaction.edit_original_response(content=exists_message)
 
     @app_commands.command(name="remove_channel", description="Remove channel from whitelist or blacklist")
     @app_commands.choices(list_type=[
@@ -245,7 +245,7 @@ class ChannelManager(commands.Cog):
             else:
                 success_message = f"Removed <#{channel_id}> from {list_type_name}"
             
-            await interaction.followup.send(success_message, ephemeral=True)
+            await interaction.edit_original_response(content=success_message)
         else:
             if self.lang_manager:
                 not_found_message = self.lang_manager.translate(
@@ -254,7 +254,7 @@ class ChannelManager(commands.Cog):
             else:
                 not_found_message = f"<#{channel_id}> does not exist in {list_type_name}"
             
-            await interaction.followup.send(not_found_message, ephemeral=True)
+            await interaction.edit_original_response(content=not_found_message)
 
     @app_commands.command(name="auto_response", description="Set channel auto-response")
     async def auto_response_command(self, interaction: discord.Interaction, channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread], enabled: bool):
@@ -275,7 +275,7 @@ class ChannelManager(commands.Cog):
         else:
             success_message = f"Set auto-response for <#{channel_id}> to: {enabled}"
         
-        await interaction.followup.send(success_message, ephemeral=True)
+        await interaction.edit_original_response(content=success_message)
 
     def is_allowed_channel(self, channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread], guild_id: str) -> Tuple[bool, bool, Optional[str]]:
         """

--- a/cogs/story/ui/views.py
+++ b/cogs/story/ui/views.py
@@ -295,21 +295,16 @@ class ActiveStoryView(discord.ui.View):
             )
             
             if not user_characters:
-                await interaction.followup.send(
+                await interaction.edit_original_response(content=
                     f"❌ 你在這個伺服器中還沒有創建任何角色。\n"
-                    f"請先使用 `/story` 選單中的 '創建角色' 按鈕來創建一個。",
-                    ephemeral=True
-                )
+                    f"請先使用 `/story` 選單中的 '創建角色' 按鈕來創建一個。")
                 return
             
             # 使用第一個角色（未來可以改為讓使用者選擇）
             character_to_join = user_characters[0]
             
             if character_to_join.character_id in self.story_instance.active_character_ids:
-                await interaction.followup.send(
-                    f"✅ 你的角色 **{character_to_join.name}** 已經在故事中了！",
-                    ephemeral=True
-                )
+                await interaction.edit_original_response(content=f"✅ 你的角色 **{character_to_join.name}** 已經在故事中了！")
                 return
             
             # 將角色加入故事
@@ -341,17 +336,11 @@ class ActiveStoryView(discord.ui.View):
             
             await interaction.channel.send(embed=embed)
             
-            await interaction.followup.send(
-                f"✅ **{character_to_join.name}** 已成功加入故事！",
-                ephemeral=True
-            )
+            await interaction.edit_original_response(content=f"✅ **{character_to_join.name}** 已成功加入故事！")
             
         except Exception as e:
             self.logger.error(f"加入故事錯誤: {e}", exc_info=True)
-            await interaction.followup.send(
-                "❌ 加入故事時發生錯誤，請稍後再試",
-                ephemeral=True
-            )
+            await interaction.edit_original_response(content="❌ 加入故事時發生錯誤，請稍後再試")
     
     @discord.ui.button(label="⏸️ 暫停故事", style=discord.ButtonStyle.secondary)
     async def pause_story_button(self, interaction: discord.Interaction, button: discord.ui.Button):
@@ -597,7 +586,7 @@ class NPCSelectView(discord.ui.View):
 
             if not self.npc_select.values:
                 self.logger.warning("[DEBUG] No values selected in npc_select.")
-                await interaction.followup.send("請至少選擇一個 NPC 或保留預設旁白來開始故事。", ephemeral=True)
+                await interaction.edit_original_response(content="請至少選擇一個 NPC 或保留預設旁白來開始故事。")
                 return
 
             self.logger.info(f"[DEBUG] Raw selected values: {self.npc_select.values}")
@@ -627,8 +616,8 @@ class NPCSelectView(discord.ui.View):
 
         except ValueError:
             self.logger.error("無法將角色 ID 從字串轉換為整數", exc_info=True)
-            await interaction.followup.send("處理角色選擇時發生內部錯誤，請聯繫管理員。", ephemeral=True)
+            await interaction.edit_original_response(content="處理角色選擇時發生內部錯誤，請聯繫管理員。")
         except Exception as e:
             self.logger.error("Error in NPCSelectView confirm_button", exc_info=True)
             if not interaction.response.is_done():
-                 await interaction.followup.send("❌ 開始故事時發生嚴重錯誤，請聯繫管理員。", ephemeral=True)
+                 await interaction.response.send_message(content="❌ 開始故事時發生嚴重錯誤，請聯繫管理員。", ephemeral=True)

--- a/cogs/update_manager.py
+++ b/cogs/update_manager.py
@@ -129,9 +129,9 @@ class UpdateManagerCog(commands.Cog):
                 # 只有擁有者才顯示更新按鈕
                 if self.permission_checker.check_update_permission(interaction.user.id):
                     view = UpdateActionView(self.update_manager, guild_id, self._get_translation)
-                    await interaction.followup.send(embed=embed, view=view)
+                    await interaction.edit_original_response(embed=embed, view=view)
                 else:
-                    await interaction.followup.send(embed=embed)
+                    await interaction.edit_original_response(embed=embed)
             else:
                 status_label = self._get_translation(guild_id, "commands", "update_manager", "commands", "check_update", "up_to_date", "status")
                 status_field_name = self._get_translation(guild_id, "commands", "update_manager", "fields", "status")
@@ -140,7 +140,7 @@ class UpdateManagerCog(commands.Cog):
                     value=status_label,
                     inline=False
                 )
-                await interaction.followup.send(embed=embed)
+                await interaction.edit_original_response(embed=embed)
                 
         except Exception as e:
             self.logger.error(f"檢查更新時發生錯誤: {e}")
@@ -152,7 +152,7 @@ class UpdateManagerCog(commands.Cog):
                 description=error_desc,
                 color=discord.Color.red()
             )
-            await interaction.followup.send(embed=embed)
+            await interaction.edit_original_response(embed=embed)
     
     @app_commands.command(name="update_now", description="立即執行更新（僅限擁有者）")
     async def update_now(self, interaction: discord.Interaction, force: bool = False):
@@ -187,7 +187,7 @@ class UpdateManagerCog(commands.Cog):
                     description=busy_desc,
                     color=discord.Color.orange()
                 )
-                await interaction.followup.send(embed=embed)
+                await interaction.edit_original_response(embed=embed)
                 return
             
             # 檢查是否有可用更新
@@ -201,7 +201,7 @@ class UpdateManagerCog(commands.Cog):
                         description=no_update_desc,
                         color=discord.Color.blue()
                     )
-                    await interaction.followup.send(embed=embed)
+                    await interaction.edit_original_response(embed=embed)
                     return
                 
                 # 創建確認視圖
@@ -235,7 +235,7 @@ class UpdateManagerCog(commands.Cog):
                 warning_field_name = self._get_translation(guild_id, "commands", "update_manager", "fields", "warning")
                 embed.add_field(name=warning_field_name, value=force_warning, inline=False)
             
-            await interaction.followup.send(embed=embed, view=view)
+            await interaction.edit_original_response(embed=embed, view=view)
             
         except Exception as e:
             self.logger.error(f"準備更新時發生錯誤: {e}")
@@ -247,7 +247,7 @@ class UpdateManagerCog(commands.Cog):
                 description=error_desc,
                 color=discord.Color.red()
             )
-            await interaction.followup.send(embed=embed)
+            await interaction.edit_original_response(embed=embed)
     
     @app_commands.command(name="update_status", description="查看更新系統狀態")
     async def update_status(self, interaction: discord.Interaction):


### PR DESCRIPTION
1. **What was found**: Several slash commands (in `cogs/channel_manager.py`, `cogs/update_manager.py`, and `cogs/story/ui/views.py`) were using `interaction.response.defer(thinking=True)` or `ephemeral=True` followed by `interaction.followup.send(...)` for their initial response. 
2. **Where it is**: `cogs/channel_manager.py` (`set_server_mode`, `add_channel`, `remove_channel`, `auto_response`, `check_admin_permissions`), `cogs/update_manager.py` (`check_update`, `update_now`, `update_status`), and `cogs/story/ui/views.py` (`ActiveStoryView`, `NPCSelectView`).
3. **Why it matters**: In `discord.py`, using `defer(thinking=True)` displays a "Bot is thinking..." UI state. If the bot responds with `followup.send()` instead of `edit_original_response()`, the new message is appended, but the original "thinking" state is never dismissed and hangs indefinitely, leading to a confusing user experience. Furthermore, calling `followup.send()` when an interaction has not yet been responded to throws a runtime error.
4. **What was done**: Replaced the initial `interaction.followup.send(...)` calls after a deferral with `interaction.edit_original_response(...)` to correctly replace the loading state with the final result. Also fixed a bug in `cogs/story/ui/views.py` by converting an invalid `edit_original_response` (previously `followup.send`) to `interaction.response.send_message(...)` where `interaction.response.is_done()` explicitly evaluated to False.

---
*PR created automatically by Jules for task [2572006416021721064](https://jules.google.com/task/2572006416021721064) started by @zi-yue-1129*