### PR TITLE
[Docs] Add generated markdown documentation for python source files

### DIFF
--- a/docs/cogs/memory/db/version_storage.md
+++ b/docs/cogs/memory/db/version_storage.md
@@ -1,0 +1,27 @@
+### Create File: docs/cogs/memory/db/version_storage.md
+# File: `cogs/memory/db/version_storage.py`
+
+## Overview
+Per-guild version tracking storage.
+
+Stores which bot version each guild has already seen, so the
+version-announcement feature fires exactly once per version per guild.
+
+## Classes
+
+### `GuildVersionStorage`
+SQLite-backed store for per-guild seen-version tracking.  Uses an isolated SQLite connection so it works regardless of whether the memory sub-system is enabled.
+
+- **Attributes**:
+  - `db_path` (`Any`): Core attribute of GuildVersionStorage representing its internal state.
+
+- **Methods**:
+  - `__init__(self, db_path) -> None`: Initialize and ensure the required table exists.  Args:     db_path: Path to the SQLite database file, or ":memory:" for tests.
+  - `_open_connection(self) -> sqlite3.Connection`: Open (or reuse) the SQLite connection.  Returns:     An open sqlite3.Connection.
+  - `_ensure_table(self) -> None`: Create the guild_version_seen table if it does not exist.
+  - `get_seen_version(self, guild_id) -> Optional[str]`: Return the last seen bot version for a guild, or None if not recorded.  Args:     guild_id: Discord guild ID as a string.  Returns:     Version string (e.g. "v3.2.0") or None.
+  - `set_seen_version(self, guild_id, version) -> None`: Record that guild_id has seen the given bot version.  Args:     guild_id: Discord guild ID as a string.     version: Bot version string (e.g. "v3.2.0").  Raises:     sqlite3.Error: On database write failure.
+
+## Functions
+
+No functions defined in this file.

--- a/docs/cogs/memory/embedding_providers/vllm_provider.md
+++ b/docs/cogs/memory/embedding_providers/vllm_provider.md
@@ -1,0 +1,14 @@
+### Create File: docs/cogs/memory/embedding_providers/vllm_provider.md
+# File: `cogs/memory/embedding_providers/vllm_provider.py`
+
+## Overview
+Core module for cogs/memory/embedding_providers/vllm_provider.py. Handles relevant business logic and components.
+
+## Classes
+
+No classes defined in this file.
+
+## Functions
+
+### `vllm_provider(settings) -> Embeddings`
+vLLM embedding provider factory.  vLLM exposes an OpenAI-compatible /v1/embeddings endpoint, so this routes through OpenAIEmbeddings with a custom base_url and the api_key vLLM was launched with (VLLM_API_KEY in .env; falls back to the "EMPTY" placeholder vLLM accepts when --api-key is not set).  Expects settings to provide:   - embedding_model_name (the --served-model-name vLLM was launched with)   - vllm_url (e.g. http://127.0.0.1:8182)

--- a/docs/llm/tools/system_prompt_tools.md
+++ b/docs/llm/tools/system_prompt_tools.md
@@ -1,0 +1,27 @@
+### Create File: docs/llm/tools/system_prompt_tools.md
+# File: `llm/tools/system_prompt_tools.py`
+
+## Overview
+LangChain tool for the bot to modify its own system prompt.
+
+The LLM reads its current personality from the system-prompt context it
+already has, generates a merged version, and calls this tool to write it.
+Only the write side lives here — no extra LLM call is needed.
+
+## Classes
+
+### `SystemPromptTools`
+Container for the bot's self-modification tool.
+
+- **Attributes**:
+  - `runtime` (`Any`): Core attribute of SystemPromptTools representing its internal state.
+  - `logger` (`Any`): Core attribute of SystemPromptTools representing its internal state.
+
+- **Methods**:
+  - `__init__(self, runtime) -> None`: Initialize with the orchestrator runtime context.  Args:     runtime: The current OrchestratorRequest context.
+  - `get_tools(self) -> list`: Return the list of self-modification tools.  Returns:     List containing the update_personality StructuredTool.
+
+## Functions
+
+### `write_personality(guild_id, channel_id, merged_prompt, scope, bot, user_id) -> str`
+Write a merged personality string to the system prompt store.  Args:     guild_id: Discord guild ID string.     channel_id: Discord channel ID string.     merged_prompt: The complete merged system prompt text.     scope: "channel" or "server".     bot: The discord.ext.commands.Bot instance.     user_id: ID of the user requesting the change (for audit).  Returns:     A human-readable confirmation or error string.

--- a/docs/llm/utils/attachment_processor.md
+++ b/docs/llm/utils/attachment_processor.md
@@ -1,0 +1,49 @@
+### Create File: docs/llm/utils/attachment_processor.md
+# File: `llm/utils/attachment_processor.py`
+
+## Overview
+Convert Discord Attachments to LangChain content_parts (base64 data URIs).
+
+Supported types:
+- image/* — resized and encoded as JPEG base64 image_url parts
+- application/pdf — rendered page-by-page via pdf2image
+- video/* — key-frame sampled via decord
+
+Unsupported types and processing failures each return a single ``text`` part
+so the calling agent always receives well-formed content.
+
+## Classes
+
+No classes defined in this file.
+
+## Functions
+
+### `_download(url) -> bytes`
+Download a URL and return the raw bytes.  Args:     url: HTTP/HTTPS URL to fetch.  Returns:     Raw response bytes.  Raises:     aiohttp.ClientResponseError: If the server returns a non-2xx status.     aiohttp.ClientError: On network-level failures.
+
+### `_pil_to_content_part(img) -> dict`
+Encode a PIL Image as a LangChain ``image_url`` content part (JPEG base64).  Args:     img: PIL Image object in RGB mode.  Returns:     Dict with ``type`` == ``"image_url"`` and a ``data:image/jpeg;base64,…`` URL.
+
+### `_resize_if_needed(img, max_dim) -> Image.Image`
+Proportionally resize *img* so its longest side does not exceed *max_dim*.  Args:     img: Source PIL Image.     max_dim: Maximum allowed value for ``max(width, height)``.  Returns:     The original image if already within limits, otherwise a resized copy.
+
+### `_decode_image(data, max_dimension) -> Image.Image`
+Synchronously decode and resize an image; intended for thread-pool execution.  Args:     data: Raw image file bytes.     max_dimension: Maximum allowed value for the longest image side.  Returns:     RGB PIL Image, resized if necessary.
+
+### `_process_image(data) -> list[dict]`
+Decode raw image bytes, optionally resize, and encode as a content part.  Args:     data: Raw image file bytes.  Returns:     A single-element list containing an ``image_url`` content part.
+
+### `_render_pdf(data, cfg) -> tuple[list, bool, list[int], int, int]`
+Synchronously render PDF pages to PIL Images; intended for thread-pool execution.  Args:     data: Raw PDF file bytes.     cfg: ``_AttachmentPdfConfig`` instance with rendering parameters.  Returns:     Tuple of ``(pages, truncated, selected_indices, half, total_pages)`` where     *pages* is a list of PIL Images for the selected page range and *half* is     the count of front pages used when truncation occurred.
+
+### `_process_pdf(data, filename) -> list[dict]`
+Render PDF pages to images and encode each as a content part.  Page count drives DPI selection: - <= threshold_full  → dpi_full - <= threshold_medium → dpi_medium - else               → dpi_compressed  If total pages exceed ``max_pages``, the first and last ``max_pages // 2`` pages are sampled and a truncation notice is prepended.  Args:     data: Raw PDF file bytes.     filename: Original filename (used in log context).  Returns:     List of content parts — optionally a leading ``text`` truncation notice     followed by one ``image_url`` part per selected page.
+
+### `_decode_video(data, cfg) -> list[Image.Image]`
+Synchronously decode video key frames; intended for thread-pool execution.  Args:     data: Raw video file bytes.     cfg: ``_AttachmentVideoConfig`` instance with frame-sampling parameters.  Returns:     List of RGB PIL Images, one per sampled frame.
+
+### `_process_video(data, filename) -> list[dict]`
+Sample key frames from a video and encode each as a content part.  Frames are sampled at least ``min_interval_sec`` seconds apart.  If the resulting candidate count exceeds ``max_frames`` the candidates are uniformly subsampled.  Args:     data: Raw video file bytes.     filename: Original filename (used in log context).  Returns:     List of ``image_url`` content parts, one per sampled frame.
+
+### `process_attachment(attachment) -> list[dict]`
+Convert a Discord Attachment to a list of LangChain content_parts.  Dispatches to type-specific processors based on ``attachment.content_type``. Returns an empty list if attachment processing is globally disabled. Returns a ``text`` fallback part for unsupported MIME types or on any processing failure so the caller always receives well-formed content.  Args:     attachment: A ``discord.Attachment`` (or compatible mock) with         ``content_type``, ``filename``, and ``url`` attributes.  Returns:     List of dicts, each a LangChain content_part with ``"type"`` either     ``"image_url"`` or ``"text"``.  Empty list when globally disabled.

--- a/docs/llm/utils/embed_processor.md
+++ b/docs/llm/utils/embed_processor.md
@@ -1,0 +1,14 @@
+### Create File: docs/llm/utils/embed_processor.md
+# File: `llm/utils/embed_processor.py`
+
+## Overview
+Core module for llm/utils/embed_processor.py. Handles relevant business logic and components.
+
+## Classes
+
+No classes defined in this file.
+
+## Functions
+
+### `process_embed(embed) -> list[dict]`
+Convert a Discord Embed to LangChain content_parts.  Text fields (title, description, fields, url) are serialized as a single structured text part. Images and thumbnails are appended as image_url parts when ``attachment_config.embeds.include_images`` is enabled. Empty embeds (no text and no images) return an empty list.  Args:     embed: A Discord ``Embed`` object (or compatible mock) to convert.  Returns:     A list of content-part dicts compatible with the LangChain     ``content_parts`` format. Each dict has at minimum a ``"type"`` key     with value ``"text"`` or ``"image_url"``.

--- a/docs/llm/utils/model_init.md
+++ b/docs/llm/utils/model_init.md
@@ -1,0 +1,14 @@
+### Create File: docs/llm/utils/model_init.md
+# File: `llm/utils/model_init.py`
+
+## Overview
+Shared model instantiation helper with vLLM support via the OpenAI-compatible API.
+
+## Classes
+
+No classes defined in this file.
+
+## Functions
+
+### `create_model_instance(model_name, **kwargs) -> BaseChatModel`
+Create a LangChain chat model, routing 'vllm:' prefixed names through ChatOpenAI.  init_chat_model has no native 'vllm' provider. Since vLLM exposes an OpenAI-compatible endpoint, 'vllm:<model>' is rewritten to 'openai:<model>' with base_url pointed at llm_config.vllm_url and the api_key vLLM was launched with (VLLM_API_KEY in .env; falls back to the "EMPTY" placeholder vLLM accepts when --api-key is not set).  Args:     model_name: e.g. 'vllm:gemma4:26b', 'google_genai:gemini-2.5-flash', 'ollama:gemma4:26b'     **kwargs:   Forwarded to the underlying constructor (max_retries, temperature, …)

--- a/docs/llm/utils/safe_typing.md
+++ b/docs/llm/utils/safe_typing.md
@@ -1,0 +1,25 @@
+### Create File: docs/llm/utils/safe_typing.md
+# File: `llm/utils/safe_typing.py`
+
+## Overview
+Core module for llm/utils/safe_typing.py. Handles relevant business logic and components.
+
+## Classes
+
+### `SafeTyping`
+Typing indicator that handles per-channel deduplication and rate-limiting.  This class ensures that only one typing heart-beat loop is running per channel, even if multiple tasks are processing messages for the same channel. It also enforces a minimum interval between trigger_typing() calls and handles 429 rate limits gracefully.
+
+- **Attributes**:
+  - `_sessions` (`Dict[int, int]`): Core attribute of SafeTyping representing its internal state.
+  - `_tasks` (`Dict[int, asyncio.Task]`): Core attribute of SafeTyping representing its internal state.
+  - `_last_trigger` (`Dict[int, float]`): Core attribute of SafeTyping representing its internal state.
+  - `_channel` (`Any`): Core attribute of SafeTyping representing its internal state.
+  - `_channel_id` (`Any`): Core attribute of SafeTyping representing its internal state.
+
+- **Methods**:
+  - `__init__(self, channel) -> None`: Executes logic for __init__, interacting with the broader component.
+  - `_loop(self, channel_id) -> None`: Background loop to keep the typing indicator alive.
+
+## Functions
+
+No functions defined in this file.


### PR DESCRIPTION
What was found:
There was no complete structural documentation mapping of the python source files.

Where it is:
`docs/` directory matching the source layout.

Why it matters:
The user explicitly requested an automated way to document the python files as an AI Documentation Agent, maintaining the exact project directory layout and following a specific Markdown template structure.

What was done:
Added a documentation generation script that parsed AST for all python files and created corresponding markdown files describing classes, methods and attributes while avoiding overwriting previously existing documentation.

---
*PR created automatically by Jules for task [6254737415778681478](https://jules.google.com/task/6254737415778681478) started by @zi-yue-1129*