### PR TITLE
[Privacy] Delete episodic memory vectors on user data clear

### DIFF
--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -1048,6 +1048,14 @@ class UserDataCog(commands.Cog):
                 except Exception as cache_err:
                     self.logger.warning(f"Failed to invalidate procedural cache for {user_id}: {cache_err}")
 
+                # Delete episodic memory vectors to maintain data privacy compliance
+                try:
+                    vector_manager = getattr(self.bot, "vector_manager", None)
+                    if vector_manager and getattr(vector_manager, "store", None):
+                        await vector_manager.store.delete_vectors_by_user(user_id)
+                except Exception as e:
+                    self.logger.error(f"Failed to delete episodic vectors for user {user_id}: {e}")
+
 
                 return self._translate(
                     guild_id,


### PR DESCRIPTION
1. **What**: The `/memory clear` command (`UserDataCog._clear_user_data`) only deleted procedural memory (SQLite) and invalidated the local procedural cache. Episodic memory vectors associated with the user were left orphaned in the Qdrant database, violating expected data privacy compliance.
2. **Where**: `cogs/userdata.py` inside the `_clear_user_data` method (~line 1035).
3. **Why**: Data privacy compliance is critical. When users explicitly request to clear their personal data via `/memory clear`, all traces—including their semantic vector embeddings (episodic memory)—must be thoroughly removed from the system. 
4. **What was done**: Added logic to call `vector_manager.store.delete_vectors_by_user(user_id)` inside `UserDataCog._clear_user_data` immediately after the procedural data is successfully deleted. Wrapped the vector deletion process in a protective `try-except` block to ensure the core data clearing flow won't break if the vector system is temporarily unreachable, and relied on existing `VectorStoreInterface` methods without excessive guessing.

---
*PR created automatically by Jules for task [14597419193873751696](https://jules.google.com/task/14597419193873751696) started by @zi-yue-1129*