### PR TITLE
[Perf] Fetch guild and channel knowledge concurrently

### DIFF
--- a/llm/memory/knowledge.py
+++ b/llm/memory/knowledge.py
@@ -45,12 +45,16 @@ class KnowledgeMemoryProvider:
         Returns:
             KnowledgeMemory object containing both levels of knowledge.
         """
-        guild_knowledge = None
+        tasks = []
         if guild_id:
-            guild_knowledge = await self._get_single("guild", guild_id)
-            
-        channel_knowledge = await self._get_single("channel", channel_id)
-        
+            tasks.append(self._get_single("guild", guild_id))
+        tasks.append(self._get_single("channel", channel_id))
+
+        results = await asyncio.gather(*tasks)
+
+        guild_knowledge = results[0] if guild_id else None
+        channel_knowledge = results[-1]
+
         return KnowledgeMemory(
             guild_knowledge=guild_knowledge,
             channel_knowledge=channel_knowledge


### PR DESCRIPTION
**What was found**: In `llm/memory/knowledge.py`, the `KnowledgeMemoryProvider.get()` method fetches `guild_knowledge` and `channel_knowledge` sequentially using consecutive `await` statements.

**Where it is**: `llm/memory/knowledge.py`, specifically lines 48-57 in the `get` method.

**Why it matters**: Sequential `await` calls for independent I/O-bound database lookups create unnecessary serial latency during the hot-path execution of `llm/context_manager.py`. The delay of fetching guild knowledge blocks the fetch of channel knowledge.

**What was done**: Replaced the sequential `await` calls with a dynamic `tasks` list that is executed concurrently via `asyncio.gather(*tasks)`. The output extraction is conditionally managed safely based on whether `guild_id` was provided, ensuring that both fetch operations run in parallel without introducing logical edge-case regressions.

---
*PR created automatically by Jules for task [13567341506891627805](https://jules.google.com/task/13567341506891627805) started by @zi-yue-1129*