### PR TITLE
[Security] Enforce access controls for write_personality tool

### DIFF
--- a/llm/tools/system_prompt_tools.py
+++ b/llm/tools/system_prompt_tools.py
@@ -100,8 +100,8 @@ class SystemPromptTools:
                 merged_prompt: The complete merged system prompt text — your current
                     personality with the requested changes incorporated. Must be a
                     full system prompt, not just the changed part.
-                scope: "channel" applies only to the current channel (any user may
-                    do this). "server" applies to the entire server (admin only).
+                scope: "channel" applies only to the current channel (requires channel
+                    management permissions). "server" applies to the entire server (admin only).
 
             Returns:
                 Confirmation message or an error description.
@@ -122,13 +122,20 @@ class SystemPromptTools:
             user_id = str(author.id)
             bot = getattr(runtime, "bot", None)
 
+            from cogs.system_prompt.permissions import PermissionValidator
+            validator = PermissionValidator(bot)
+
             if scope == "server":
-                from cogs.system_prompt.permissions import PermissionValidator
-                validator = PermissionValidator(bot)
                 if not validator.can_modify_server_prompt(author, guild):
                     return (
                         "Error: You need administrator permissions to modify the "
                         "server-level personality."
+                    )
+            else:
+                if not validator.can_modify_channel_prompt(author, channel):
+                    return (
+                        "Error: You do not have permission to modify the "
+                        "personality for this channel."
                     )
 
             return await write_personality(guild_id, channel_id, merged_prompt, scope, bot, user_id)

--- a/tests/test_system_prompt_tools.py
+++ b/tests/test_system_prompt_tools.py
@@ -140,24 +140,38 @@ class TestUpdatePersonalityChannel:
         self.tool = SystemPromptTools(self.runtime).get_tools()[0]
 
     def test_calls_set_channel_prompt_with_correct_args(self):
-        asyncio.get_event_loop().run_until_complete(
-            self.tool.coroutine(merged_prompt="Be funny.", scope="channel")
-        )
+        with patch("cogs.system_prompt.permissions.PermissionValidator") as MockV:
+            MockV.return_value.can_modify_channel_prompt.return_value = True
+            asyncio.run(
+                self.tool.coroutine(merged_prompt="Be funny.", scope="channel")
+            )
         self.mock_manager.set_channel_prompt.assert_called_once_with(
             "111", "222", {"prompt": "Be funny.", "enabled": True}, "333"
         )
 
     def test_returns_success_message(self):
-        result = asyncio.get_event_loop().run_until_complete(
-            self.tool.coroutine(merged_prompt="Be funny.", scope="channel")
-        )
+        with patch("cogs.system_prompt.permissions.PermissionValidator") as MockV:
+            MockV.return_value.can_modify_channel_prompt.return_value = True
+            result = asyncio.run(
+                self.tool.coroutine(merged_prompt="Be funny.", scope="channel")
+            )
         assert "success" in result.lower() or "updated" in result.lower()
 
     def test_invalidates_cache_after_write(self):
-        asyncio.get_event_loop().run_until_complete(
-            self.tool.coroutine(merged_prompt="Be funny.", scope="channel")
-        )
+        with patch("cogs.system_prompt.permissions.PermissionValidator") as MockV:
+            MockV.return_value.can_modify_channel_prompt.return_value = True
+            asyncio.run(
+                self.tool.coroutine(merged_prompt="Be funny.", scope="channel")
+            )
         self.mock_manager.cache.invalidate.assert_called()
+
+    def test_blocks_non_admin_from_channel_scope(self):
+        with patch("cogs.system_prompt.permissions.PermissionValidator") as MockV:
+            MockV.return_value.can_modify_channel_prompt.return_value = False
+            result = asyncio.run(
+                self.tool.coroutine(merged_prompt="...", scope="channel")
+            )
+        assert "permission" in result.lower()
 
 
 class TestUpdatePersonalityServer:
@@ -169,7 +183,7 @@ class TestUpdatePersonalityServer:
     def test_blocks_non_admin_from_server_scope(self):
         with patch("cogs.system_prompt.permissions.PermissionValidator") as MockV:
             MockV.return_value.can_modify_server_prompt.return_value = False
-            result = asyncio.get_event_loop().run_until_complete(
+            result = asyncio.run(
                 self.tool.coroutine(merged_prompt="...", scope="server")
             )
         assert "permission" in result.lower() or "administrator" in result.lower()
@@ -177,7 +191,7 @@ class TestUpdatePersonalityServer:
     def test_allows_admin_to_set_server_scope(self):
         with patch("cogs.system_prompt.permissions.PermissionValidator") as MockV:
             MockV.return_value.can_modify_server_prompt.return_value = True
-            result = asyncio.get_event_loop().run_until_complete(
+            result = asyncio.run(
                 self.tool.coroutine(merged_prompt="Be formal.", scope="server")
             )
         self.mock_manager.set_server_prompt.assert_called_once_with(
@@ -192,7 +206,7 @@ class TestUpdatePersonalityErrors:
         mock_bot.get_cog.return_value = None
         runtime = _make_runtime(bot=mock_bot)
         tool = SystemPromptTools(runtime).get_tools()[0]
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             tool.coroutine(merged_prompt="...", scope="channel")
         )
         assert "error" in result.lower()
@@ -201,7 +215,7 @@ class TestUpdatePersonalityErrors:
         runtime = MagicMock()
         runtime.message = None
         tool = SystemPromptTools(runtime).get_tools()[0]
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             tool.coroutine(merged_prompt="...", scope="channel")
         )
         assert "error" in result.lower()


### PR DESCRIPTION
1. **What was found**: The `update_personality` tool in `llm/tools/system_prompt_tools.py` lacked authorization checks for the `channel` scope, allowing any user to maliciously or inadvertently modify channel-specific system prompts. 
2. **Where it is**: `llm/tools/system_prompt_tools.py` (lines 100-135) and `tests/test_system_prompt_tools.py`.
3. **Why it matters**: A malicious user could instruct the LangChain bot to rewrite its system prompt for a channel, potentially enabling prompt injection or unauthorized modifications of the bot's core instructions without administrative oversight.
4. **What was done**: Added explicit access controls utilizing `PermissionValidator(bot).can_modify_channel_prompt(author, channel)` for the channel scope. Modified the tool's docstring so the LLM correctly understands channel modifications require specific permissions. Updated tests to enforce this behavior and updated outdated `asyncio.get_event_loop().run_until_complete` usages in the test suite to `asyncio.run`.

---
*PR created automatically by Jules for task [4756238080659101734](https://jules.google.com/task/4756238080659101734) started by @zi-yue-1129*