### PR TITLE
[Privacy] Delete episodic memory vectors on user data clear

### DIFF
--- a/cogs/userdata.py
+++ b/cogs/userdata.py
@@ -1033,6 +1033,16 @@ class UserDataCog(commands.Cog):
                 )
 
             success = await self.user_manager.delete_user_data(user_id)
+
+            # Delete episodic memory vectors to ensure full privacy compliance
+            try:
+                vector_manager = getattr(self.bot, "vector_manager", None)
+                if vector_manager and hasattr(vector_manager, "store"):
+                    await vector_manager.store.delete_vectors_by_user(str(user_id))
+            except Exception as vector_err:
+                self.logger.error(f"Failed to delete episodic vectors for {user_id}: {vector_err}")
+                await func.report_error(vector_err, f"Clear user episodic vectors failed (user: {user_id})")
+
             if success:
                 # Invalidate ProceduralMemoryProvider cache
                 try:


### PR DESCRIPTION
1. **What was found**: When clearing user data, procedural memory is cleared via SQLite, but episodic memory vectors stored in Qdrant/vector_store are not explicitly deleted, failing to fully comply with data privacy expectations.
2. **Where it is**: `cogs/userdata.py` inside the `_clear_user_data` function.
3. **Why it matters**: Ensures complete user data removal when requested, adhering to the bot's data privacy compliance requirements and user trust.
4. **What was done**: Added a call to `bot.vector_manager.store.delete_vectors_by_user(str(user_id))` within `_clear_user_data`, securely wrapped in a try/except block to handle missing components or API errors gracefully without blocking other clear routines.

---
*PR created automatically by Jules for task [5606624137770242141](https://jules.google.com/task/5606624137770242141) started by @zi-yue-1129*